### PR TITLE
add irssi's 'wii' as a default alias

### DIFF
--- a/src/common/aliasmanager.cpp
+++ b/src/common/aliasmanager.cpp
@@ -102,6 +102,7 @@ AliasManager::AliasList AliasManager::defaults()
             << Alias("chanserv",  "/msg chanserv $0")
             << Alias("hs", "/msg hostserv $0")
             << Alias("hostserv", "/msg hostserv $0")
+            << Alias("wii", "/whois $0 $0")
             << Alias("back", "/quote away");
 
 #ifdef Q_OS_LINUX


### PR DESCRIPTION
irssi has an alias 'wii' that does a whois with the nick twice, which queries the origin server directly, and gives extra info like idle time.
