### PR TITLE
Add LDAP authentication support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ option(WITH_PHONON   "Enable Phonon support (for audio notifications)"	ON)
 option(WITH_LIBINDICATE "Enable Ayatana notification support"           ON)
 option(WITH_KDE      "Enable KDE4 integration"				OFF)
 option(WITH_CRYPT    "Enable encryption support if present on system"	ON)
+option(WITH_LDAP     "Enable LDAP authentication support if present on system"	ON)
 option(WITH_SYSLOG   "Use syslog for storing log data"			ON)
 
 # We use icon paths from KDE 4.3.x, which are partially invalid on older and possibly
@@ -391,6 +392,19 @@ if(BUILD_CORE)
   else(WITH_CRYPT AND NOT WITH_QT5)
     message(STATUS "Not enabling encryption support")
   endif(WITH_CRYPT AND NOT WITH_QT5)
+
+  # Setup LDAP authentication support
+  if(WITH_LDAP)
+    find_package(Ldap)
+    if(LDAP_FOUND)
+      message(STATUS "Enabling LDAP authentication support")
+      set(HAVE_LDAP true)
+    else(LDAP_FOUND)
+      message(STATUS "Disabling LDAP authentication support")
+    endif(LDAP_FOUND)
+  else(WITH_LDAP)
+    message(STATUS "Not enabling LDAP authentication support")
+  endif(WITH_LDAP)
 
   # Setup syslog support
   if(WITH_SYSLOG)

--- a/cmake/modules/FindLdap.cmake
+++ b/cmake/modules/FindLdap.cmake
@@ -1,0 +1,43 @@
+# Copied from https://raw.github.com/facebook/hiphop-php/master/CMake/FindLdap.cmake
+
+# - Try to find the LDAP client libraries
+# Once done this will define
+#
+#  LDAP_FOUND - system has libldap
+#  LDAP_INCLUDE_DIR - the ldap include directory
+#  LDAP_LIBRARIES - libldap + liblber (if found) library
+#  LBER_LIBRARIES - liblber library
+
+if(LDAP_INCLUDE_DIR AND LDAP_LIBRARIES)
+    # Already in cache, be silent
+    set(Ldap_FIND_QUIETLY TRUE)
+endif(LDAP_INCLUDE_DIR AND LDAP_LIBRARIES)
+
+if(UNIX)
+   FIND_PATH(LDAP_INCLUDE_DIR ldap.h)
+   FIND_LIBRARY(LDAP_LIBRARIES NAMES ldap)
+   FIND_LIBRARY(LBER_LIBRARIES NAMES lber)
+
+else(UNIX)
+   FIND_PATH(LDAP_INCLUDE_DIR winldap.h)
+   FIND_LIBRARY(LDAP_LIBRARIES NAMES wldap32)
+endif(UNIX)
+
+if(LDAP_INCLUDE_DIR AND LDAP_LIBRARIES)
+   set(LDAP_FOUND TRUE)
+   if(LBER_LIBRARIES)
+     set(LDAP_LIBRARIES ${LDAP_LIBRARIES} ${LBER_LIBRARIES})
+   endif(LBER_LIBRARIES)
+endif(LDAP_INCLUDE_DIR AND LDAP_LIBRARIES)
+
+if(LDAP_FOUND)
+   if(NOT Ldap_FIND_QUIETLY)
+      message(STATUS "Found ldap: ${LDAP_LIBRARIES}")
+   endif(NOT Ldap_FIND_QUIETLY)
+else(LDAP_FOUND)
+   if (Ldap_FIND_REQUIRED)
+        message(FATAL_ERROR "Could NOT find ldap")
+   endif (Ldap_FIND_REQUIRED)
+endif(LDAP_FOUND)
+
+MARK_AS_ADVANCED(LDAP_INCLUDE_DIR LDAP_LIBRARIES LBER_LIBRARIES LDAP_DIR)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -83,6 +83,12 @@ if(HAVE_QCA2)
   include_directories(${QCA2_INCLUDE_DIR})
 endif(HAVE_QCA2)
 
+if(HAVE_LDAP)
+  set(SOURCES ${SOURCES} ldapstorage.cpp sqliteldapstorage.cpp postgresqlldapstorage.cpp)
+  set(MOC_HDRS ${MOC_HDRS} ldapstorage.h sqliteldapstorage.h postgresqlldapstorage.h)
+  include_directories(${LDAP_INCLUDE_DIR})
+endif(HAVE_LDAP)
+
 include_directories(${CMAKE_SOURCE_DIR}/src/common ${QUASSEL_QT_INCLUDES})
 
 if(NOT WITH_QT5)
@@ -98,3 +104,7 @@ set_target_properties(mod_core PROPERTIES COMPILE_FLAGS "${QUASSEL_QT_COMPILEFLA
 if(HAVE_QCA2)
   target_link_libraries(mod_core ${QCA2_LIBRARIES})
 endif(HAVE_QCA2)
+
+if(HAVE_LDAP)
+  target_link_libraries(mod_core ${LDAP_LIBRARIES})
+endif(HAVE_LDAP)

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -25,9 +25,11 @@
 #include "coresettings.h"
 #include "internalconnection.h"
 #include "postgresqlstorage.h"
+#include "postgresqlldapstorage.h"
 #include "quassel.h"
 #include "signalproxy.h"
 #include "sqlitestorage.h"
+#include "sqliteldapstorage.h"
 #include "network.h"
 #include "logger.h"
 
@@ -312,7 +314,9 @@ void Core::registerStorageBackends()
 {
     // Register storage backends here!
     registerStorageBackend(new SqliteStorage(this));
+    registerStorageBackend(new SqliteLdapStorage(this));
     registerStorageBackend(new PostgreSqlStorage(this));
+    registerStorageBackend(new PostgreSqlLdapStorage(this));
 }
 
 

--- a/src/core/ldapstorage.cpp
+++ b/src/core/ldapstorage.cpp
@@ -1,0 +1,525 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2013 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include "ldapstorage.h"
+
+#include <logger.h>
+
+static const QString LdapSettingServer = QString::fromLatin1("LDAP Server");
+static const QString LdapSettingBindDN = QString::fromLatin1("LDAP bind DN");
+static const QString LdapSettingBindPassword = QString::fromLatin1("LDAP bind password");
+static const QString LdapSettingBaseDN = QString::fromLatin1("LDAP base DN");
+static const QString LdapSettingUIDAttribute = QString::fromLatin1("LDAP UID attribute");
+static const QString LdapSettingRequiredAttributes = QString::fromLatin1("LDAP required attributes");
+
+LdapStorage::LdapStorage(Storage *s, QObject *parent)
+    : Storage(parent)
+    , m_storage(s)
+    , m_ldapConnection(0)
+{
+}
+
+LdapStorage::~LdapStorage()
+{
+    if (m_ldapConnection != 0) {
+        ldap_unbind_ext(m_ldapConnection, 0, 0);
+    }
+
+    delete m_storage;
+}
+
+bool LdapStorage::isAvailable() const
+{
+    return m_storage->isAvailable();
+}
+
+QString LdapStorage::displayName() const
+{
+    return m_storage->displayName() + QString::fromLatin1("LDAP");
+}
+
+QString LdapStorage::description() const
+{
+    return m_storage->description() + QString::fromLatin1(" - LDAP authentication");
+}
+
+QStringList LdapStorage::setupKeys() const
+{
+    static const QStringList ldapSetupKeys = QStringList()
+                                          << LdapSettingServer
+                                          << LdapSettingBindDN
+                                          << LdapSettingBindPassword
+                                          << LdapSettingBaseDN
+                                          << LdapSettingUIDAttribute
+                                          << LdapSettingRequiredAttributes;
+    return m_storage->setupKeys() + ldapSetupKeys;
+}
+
+QVariantMap LdapStorage::setupDefaults() const
+{
+    static QVariantMap ldapDefaults;
+
+    if (ldapDefaults.empty()) {
+        ldapDefaults.insert(LdapSettingServer, QString::fromLatin1("ldap://hostname:port"));
+        ldapDefaults.insert(LdapSettingBindDN, QString());
+        ldapDefaults.insert(LdapSettingBindPassword, QString());
+        ldapDefaults.insert(LdapSettingBaseDN, QString::fromLatin1("ou=People,o=MyOrganization"));
+        ldapDefaults.insert(LdapSettingUIDAttribute, QString::fromLatin1("uid"));
+        ldapDefaults.insert(LdapSettingRequiredAttributes, QString::fromLatin1("attri1=val1;attr2=val2"));
+    }
+
+    QVariantMap defaults = m_storage->setupDefaults();
+    defaults.unite(ldapDefaults);
+
+    return defaults;
+}
+
+bool LdapStorage::setup(const QVariantMap &settings)
+{
+    setLdapProperties(settings);
+    return m_storage->setup(settings);
+}
+
+Storage::State LdapStorage::init(const QVariantMap &settings)
+{
+    setLdapProperties(settings);
+
+    quInfo() << displayName() << "storage is ready. Settings:";
+    quInfo() << "Server:" << m_ldapServer;
+    quInfo() << "Bind DN:" << m_bindDN;
+    quInfo() << "Base DN:" << m_baseDN;
+    quInfo() << "UID attribute:" << m_ldapAttribute;
+
+    for (int i = 0; i < m_requiredAttributes.size(); ++i)
+        quInfo() << "Required attributes:" << m_requiredAttributes.at(i).first << "=" << m_requiredAttributes.at(i).second;
+
+    return m_storage->init(settings);
+}
+
+void LdapStorage::sync()
+{
+    m_storage->sync();
+}
+
+UserId LdapStorage::addUser(const QString &user, const QString&)
+{
+    return m_storage->addUser(user, QString());
+}
+
+bool LdapStorage::updateUser(UserId user, const QString&)
+{
+    return m_storage->updateUser(user, QString());
+}
+
+void LdapStorage::renameUser(UserId user, const QString &newName)
+{
+    m_storage->renameUser(user, newName);
+}
+
+UserId LdapStorage::validateUser(const QString &username, const QString &password)
+{
+    UserId id = m_storage->validateUser(username, QString());
+
+    if (not ldapAuth(username, password)) {
+        return UserId();
+    }
+
+    if (not id.isValid()) {
+        addUser(username, QString());
+    }
+
+    return m_storage->validateUser(username, QString());
+}
+
+UserId LdapStorage::getUserId(const QString &username)
+{
+    return m_storage->getUserId(username);
+}
+
+UserId LdapStorage::internalUser()
+{
+    return m_storage->internalUser();
+}
+
+void LdapStorage::delUser(UserId user)
+{
+    m_storage->delUser(user);
+}
+
+void LdapStorage::setUserSetting(UserId user, const QString &settingName, const QVariant &data)
+{
+    m_storage->setUserSetting(user, settingName, data);
+}
+
+QVariant LdapStorage::getUserSetting(UserId user, const QString &settingName, const QVariant &data)
+{
+    return m_storage->getUserSetting(user, settingName, data);
+}
+
+IdentityId LdapStorage::createIdentity(UserId user, CoreIdentity &identity)
+{
+    return m_storage->createIdentity(user, identity);
+}
+
+bool LdapStorage::updateIdentity(UserId user, const CoreIdentity &identity)
+{
+    return m_storage->updateIdentity(user, identity);
+}
+
+void LdapStorage::removeIdentity(UserId user, IdentityId identityId)
+{
+    m_storage->removeIdentity(user, identityId);
+}
+
+QList<CoreIdentity> LdapStorage::identities(UserId user)
+{
+    return m_storage->identities(user);
+}
+
+NetworkId LdapStorage::createNetwork(UserId user, const NetworkInfo &info)
+{
+    return m_storage->createNetwork(user, info);
+}
+
+bool LdapStorage::updateNetwork(UserId user, const NetworkInfo &info)
+{
+    return m_storage->updateNetwork(user, info);
+}
+
+bool LdapStorage::removeNetwork(UserId user, const NetworkId &id)
+{
+    return m_storage->removeNetwork(user, id);
+}
+
+QList<NetworkInfo> LdapStorage::networks(UserId user)
+{
+    return m_storage->networks(user);
+}
+
+QList<NetworkId> LdapStorage::connectedNetworks(UserId user)
+{
+    return m_storage->connectedNetworks(user);
+}
+
+void LdapStorage::setNetworkConnected(UserId user, const NetworkId &networkId, bool isConnected)
+{
+    return m_storage->setNetworkConnected(user, networkId, isConnected);
+}
+
+QHash<QString, QString> LdapStorage::persistentChannels(UserId user, const NetworkId &networkId)
+{
+    return m_storage->persistentChannels(user, networkId);
+}
+
+void LdapStorage::setChannelPersistent(UserId user, const NetworkId &networkId, const QString &channel, bool isJoined)
+{
+    m_storage->setChannelPersistent(user, networkId, channel, isJoined);
+}
+
+void LdapStorage::setPersistentChannelKey(UserId user, const NetworkId &networkId, const QString &channel, const QString &key)
+{
+    m_storage->setPersistentChannelKey(user, networkId, channel, key);
+}
+
+QString LdapStorage::awayMessage(UserId user, NetworkId networkId)
+{
+    return m_storage->awayMessage(user, networkId);
+}
+
+void LdapStorage::setAwayMessage(UserId user, NetworkId networkId, const QString &awayMsg)
+{
+    m_storage->setAwayMessage(user, networkId, awayMsg);
+}
+
+QString LdapStorage::userModes(UserId user, NetworkId networkId)
+{
+    return m_storage->userModes(user, networkId);
+}
+
+void LdapStorage::setUserModes(UserId user, NetworkId networkId, const QString &userModes)
+{
+    m_storage->setUserModes(user, networkId, userModes);
+}
+
+BufferInfo LdapStorage::bufferInfo(UserId user, const NetworkId &networkId, BufferInfo::Type type, const QString &buffer, bool create)
+{
+    return m_storage->bufferInfo(user, networkId, type, buffer, create);
+}
+
+BufferInfo LdapStorage::getBufferInfo(UserId user, const BufferId &bufferId)
+{
+    return m_storage->getBufferInfo(user, bufferId);
+}
+
+QList<BufferInfo> LdapStorage::requestBuffers(UserId user)
+{
+    return m_storage->requestBuffers(user);
+}
+
+QList<BufferId> LdapStorage::requestBufferIdsForNetwork(UserId user, NetworkId networkId)
+{
+    return m_storage->requestBufferIdsForNetwork(user, networkId);
+}
+
+bool LdapStorage::removeBuffer(const UserId &user, const BufferId &bufferId)
+{
+    return m_storage->removeBuffer(user, bufferId);
+}
+
+bool LdapStorage::renameBuffer(const UserId &user, const BufferId &buffer, const QString &newName)
+{
+    return m_storage->renameBuffer(user, buffer, newName);
+}
+
+bool LdapStorage::mergeBuffersPermanently(const UserId &user, const BufferId &bufferId1, const BufferId &bufferId2)
+{
+    return m_storage->mergeBuffersPermanently(user, bufferId1, bufferId2);
+}
+
+void LdapStorage::setBufferLastSeenMsg(UserId user, const BufferId &bufferId, const MsgId &msgId)
+{
+    m_storage->setBufferLastSeenMsg(user, bufferId, msgId);
+}
+
+QHash<BufferId, MsgId> LdapStorage::bufferLastSeenMsgIds(UserId user)
+{
+    return m_storage->bufferLastSeenMsgIds(user);
+}
+
+void LdapStorage::setBufferMarkerLineMsg(UserId user, const BufferId &bufferId, const MsgId &msgId)
+{
+    m_storage->setBufferMarkerLineMsg(user, bufferId, msgId);
+}
+
+QHash<BufferId, MsgId> LdapStorage::bufferMarkerLineMsgIds(UserId user)
+{
+    return m_storage->bufferMarkerLineMsgIds(user);
+}
+
+bool LdapStorage::logMessage(Message &msg)
+{
+    return m_storage->logMessage(msg);
+}
+
+bool LdapStorage::logMessages(MessageList &msgs)
+{
+    return m_storage->logMessages(msgs);
+}
+
+QList<Message> LdapStorage::requestMsgs(UserId user, BufferId bufferId, MsgId first, MsgId last, int limit)
+{
+    return m_storage->requestMsgs(user, bufferId, first, last, limit);
+}
+
+QList<Message> LdapStorage::requestAllMsgs(UserId user, MsgId first, MsgId last, int limit)
+{
+    return m_storage->requestAllMsgs(user, first, last, limit);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void LdapStorage::setLdapProperties(const QVariantMap &properties)
+{
+    m_ldapServer = properties.value(LdapSettingServer).toByteArray();
+    m_bindDN = properties.value(LdapSettingBindDN).toByteArray();
+    m_bindPasword = properties.value(LdapSettingBindPassword).toByteArray();
+    m_baseDN = properties.value(LdapSettingBaseDN).toByteArray();
+    m_ldapAttribute = properties.value(LdapSettingUIDAttribute).toByteArray();
+
+    foreach (const QByteArray &str, properties.value(LdapSettingRequiredAttributes).toByteArray().split(';')) {
+        const QByteArray trimmed = str.trimmed();
+
+        if (trimmed.isEmpty()) {
+            continue;
+        }
+
+        const QList<QByteArray> tokens = trimmed.split('=');
+
+        if (tokens.size() != 2) {
+            continue;
+        }
+
+        m_requiredAttributes.append(qMakePair(tokens.at(0).trimmed(), tokens.at(1).trimmed()));
+    }
+}
+
+bool LdapStorage::ldapConnect()
+{
+    if (m_ldapConnection != 0) {
+        ldapDisconnect();
+    }
+
+    int res, v = LDAP_VERSION3;
+
+    res = ldap_initialize(&m_ldapConnection, m_ldapServer.constData());
+
+    if (res != LDAP_SUCCESS) {
+        qWarning() << "Could not connect to LDAP server:" << ldap_err2string(res);
+        return false;
+    }
+
+    res = ldap_set_option(m_ldapConnection, LDAP_OPT_PROTOCOL_VERSION, (void*)&v);
+
+    if (res != LDAP_SUCCESS) {
+        qWarning() << "Could not set LDAP protocol version to v3:" << ldap_err2string(res);
+        ldap_unbind_ext(m_ldapConnection, 0, 0);
+        m_ldapConnection = 0;
+        return false;
+    }
+
+    return true;
+}
+
+void LdapStorage::ldapDisconnect()
+{
+    if (m_ldapConnection == 0) {
+        return;
+    }
+
+    ldap_unbind_ext(m_ldapConnection, 0, 0);
+    m_ldapConnection = 0;
+}
+
+bool LdapStorage::ldapAuth(const QString &username, const QString &password)
+{
+    if (password.isEmpty()) {
+        return false;
+    }
+
+    int res;
+
+    if (m_ldapConnection == 0) {
+        if (not ldapConnect()) {
+            return false;
+        }
+    }
+
+    struct berval cred;
+
+    cred.bv_val = const_cast<char*>(m_bindPasword.size() > 0 ? m_bindPasword.constData() : NULL);
+    cred.bv_len = m_bindPasword.size();
+
+    res = ldap_sasl_bind_s(m_ldapConnection,
+                           m_bindDN.size() > 0 ? m_bindDN.constData() : 0,
+                           LDAP_SASL_SIMPLE,
+                           &cred,
+                           0,
+                           0,
+                           0);
+
+    if (res != LDAP_SUCCESS) {
+        qWarning() << "Refusing connection from" << username << "(LDAP bind failed:" << ldap_err2string(res) << ")";
+        ldapDisconnect();
+        return false;
+    }
+
+    LDAPMessage *msg = NULL, *entry = NULL;
+
+    const QByteArray ldapQuery = m_ldapAttribute + '=' + username.toLocal8Bit();
+
+    res = ldap_search_ext_s(m_ldapConnection,
+                            m_baseDN.constData(),
+                            LDAP_SCOPE_SUBTREE,
+                            ldapQuery.constData(),
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            &msg);
+
+    if (res != LDAP_SUCCESS) {
+        qWarning() << "Refusing connection from" << username << "(LDAP search failed:" << ldap_err2string(res) << ")";
+        return false;
+    }
+
+    if (ldap_count_entries(m_ldapConnection, msg) > 1) {
+        qWarning() << "Refusing connection from" << username << "(LDAP search returned more than one result)";
+        ldap_msgfree(msg);
+        return false;
+    }
+
+    entry = ldap_first_entry(m_ldapConnection, msg);
+
+    if (entry == 0) {
+        qWarning() << "Refusing connection from" << username << "(LDAP search returned no results)";
+        ldap_msgfree(msg);
+        return false;
+    }
+
+    const QByteArray password_c = password.toLocal8Bit();
+
+    cred.bv_val = const_cast<char*>(password_c.constData());
+    cred.bv_len = password.size();
+
+    char *userDN = ldap_get_dn(m_ldapConnection, entry);
+
+    res = ldap_sasl_bind_s(m_ldapConnection,
+                           userDN,
+                           LDAP_SASL_SIMPLE,
+                           &cred,
+                           0,
+                           0,
+                           0);
+
+    if (res != LDAP_SUCCESS) {
+        qWarning() << "Refusing connection from" << username << "(LDAP authentication failed)";
+        ldap_memfree(userDN);
+        ldap_msgfree(msg);
+        return false;
+    }
+
+    if (m_requiredAttributes.isEmpty()) {
+        ldap_memfree(userDN);
+        ldap_msgfree(msg);
+        return true;
+    }
+
+    bool authenticated = false;
+
+    // Needed to use foreach
+    typedef QPair<QByteArray, QByteArray> QByteArrayPair;
+
+    foreach (const QByteArrayPair &pair, m_requiredAttributes) {
+        const QByteArray &attribute = pair.first;
+        const QByteArray &value = pair.second;
+
+        struct berval attr_value;
+        attr_value.bv_val = const_cast<char*>(value.constData());
+        attr_value.bv_len = value.size();
+
+        authenticated = (ldap_compare_ext_s(m_ldapConnection,
+                                            userDN,
+                                            attribute.constData(),
+                                            &attr_value,
+                                            0,
+                                            0) == LDAP_COMPARE_TRUE);
+
+        if (authenticated) {
+            break;
+        }
+    }
+
+    ldap_memfree(userDN);
+    ldap_msgfree(msg);
+
+    return authenticated;
+}

--- a/src/core/ldapstorage.h
+++ b/src/core/ldapstorage.h
@@ -1,0 +1,104 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2013 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#ifndef LDAPSTORAGE_H
+#define LDAPSTORAGE_H
+
+#include "storage.h"
+
+#include <ldap.h>
+
+class LdapStorage : public Storage
+{
+    Q_OBJECT
+public:
+    LdapStorage(Storage *s, QObject *parent = 0);
+    virtual ~LdapStorage();
+
+public slots:
+    virtual bool isAvailable() const;
+    virtual QString displayName() const;
+    virtual QString description() const;
+    virtual QStringList setupKeys() const;
+    virtual QVariantMap setupDefaults() const;
+    virtual bool setup(const QVariantMap &settings = QVariantMap());
+    virtual State init(const QVariantMap &settings = QVariantMap());
+    virtual void sync();
+    virtual UserId addUser(const QString &user, const QString &password);
+    virtual bool updateUser(UserId user, const QString &password);
+    virtual void renameUser(UserId user, const QString &newName);
+    virtual UserId validateUser(const QString &user, const QString &password);
+    virtual UserId getUserId(const QString &username);
+    virtual UserId internalUser();
+    virtual void delUser(UserId user);
+    virtual void setUserSetting(UserId userId, const QString &settingName, const QVariant &data);
+    virtual QVariant getUserSetting(UserId userId, const QString &settingName, const QVariant &data = QVariant());
+    virtual IdentityId createIdentity(UserId user, CoreIdentity &identity);
+    virtual bool updateIdentity(UserId user, const CoreIdentity &identity);
+    virtual void removeIdentity(UserId user, IdentityId identityId);
+    virtual QList<CoreIdentity> identities(UserId user);
+    virtual NetworkId createNetwork(UserId user, const NetworkInfo &info);
+    virtual bool updateNetwork(UserId user, const NetworkInfo &info);
+    virtual bool removeNetwork(UserId user, const NetworkId &networkId);
+    virtual QList<NetworkInfo> networks(UserId user);
+    virtual QList<NetworkId> connectedNetworks(UserId user);
+    virtual void setNetworkConnected(UserId user, const NetworkId &networkId, bool isConnected);
+    virtual QHash<QString, QString> persistentChannels(UserId user, const NetworkId &networkId);
+    virtual void setChannelPersistent(UserId user, const NetworkId &networkId, const QString &channel, bool isJoined);
+    virtual void setPersistentChannelKey(UserId user, const NetworkId &networkId, const QString &channel, const QString &key);
+    virtual QString awayMessage(UserId user, NetworkId networkId);
+    virtual void setAwayMessage(UserId user, NetworkId networkId, const QString &awayMsg);
+    virtual QString userModes(UserId user, NetworkId networkId);
+    virtual void setUserModes(UserId user, NetworkId networkId, const QString &userModes);
+    virtual BufferInfo bufferInfo(UserId user, const NetworkId &networkId, BufferInfo::Type type, const QString &buffer = "", bool create = true);
+    virtual BufferInfo getBufferInfo(UserId user, const BufferId &bufferId);
+    virtual QList<BufferInfo> requestBuffers(UserId user);
+    virtual QList<BufferId> requestBufferIdsForNetwork(UserId user, NetworkId networkId);
+    virtual bool removeBuffer(const UserId &user, const BufferId &bufferId);
+    virtual bool renameBuffer(const UserId &user, const BufferId &bufferId, const QString &newName);
+    virtual bool mergeBuffersPermanently(const UserId &user, const BufferId &bufferId1, const BufferId &bufferId2);
+    virtual void setBufferLastSeenMsg(UserId user, const BufferId &bufferId, const MsgId &msgId);
+    virtual QHash<BufferId, MsgId> bufferLastSeenMsgIds(UserId user);
+    virtual void setBufferMarkerLineMsg(UserId user, const BufferId &bufferId, const MsgId &msgId);
+    virtual QHash<BufferId, MsgId> bufferMarkerLineMsgIds(UserId user);
+    virtual bool logMessage(Message &msg);
+    virtual bool logMessages(MessageList &msgs);
+    virtual QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1);
+    virtual QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1);
+
+private:
+    void setLdapProperties(const QVariantMap &properties);
+    bool ldapConnect();
+    void ldapDisconnect();
+    bool ldapAuth(const QString &username, const QString &password);
+
+private:
+    Storage *m_storage;
+    QByteArray m_ldapServer;
+    QByteArray m_bindDN;
+    QByteArray m_bindPasword;
+    QByteArray m_baseDN;
+    QByteArray m_ldapAttribute;
+    QList<QPair<QByteArray, QByteArray> > m_requiredAttributes;
+    LDAP *m_ldapConnection;
+};
+
+
+#endif // LDAPSTORAGE_H

--- a/src/core/postgresqlldapstorage.cpp
+++ b/src/core/postgresqlldapstorage.cpp
@@ -1,0 +1,32 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2013 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include "postgresqlldapstorage.h"
+
+#include "postgresqlstorage.h"
+
+PostgreSqlLdapStorage::PostgreSqlLdapStorage(QObject *parent)
+    : LdapStorage(new PostgreSqlStorage, parent)
+{
+}
+
+PostgreSqlLdapStorage::~PostgreSqlLdapStorage()
+{
+}

--- a/src/core/postgresqlldapstorage.h
+++ b/src/core/postgresqlldapstorage.h
@@ -1,0 +1,35 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2013 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#ifndef POSTGRESQLLDAPSTORAGE_H
+#define POSTGRESQLLDAPSTORAGE_H
+
+#include "ldapstorage.h"
+
+class PostgreSqlLdapStorage : public LdapStorage
+{
+    Q_OBJECT
+
+public:
+    PostgreSqlLdapStorage(QObject *parent = 0);
+    virtual ~PostgreSqlLdapStorage();
+};
+
+#endif // POSTGRESQLLDAPSTORAGE_H

--- a/src/core/sqliteldapstorage.cpp
+++ b/src/core/sqliteldapstorage.cpp
@@ -1,0 +1,32 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2013 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include "sqliteldapstorage.h"
+
+#include "sqlitestorage.h"
+
+SqliteLdapStorage::SqliteLdapStorage(QObject *parent)
+    : LdapStorage(new SqliteStorage, parent)
+{
+}
+
+SqliteLdapStorage::~SqliteLdapStorage()
+{
+}

--- a/src/core/sqliteldapstorage.h
+++ b/src/core/sqliteldapstorage.h
@@ -1,0 +1,35 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2013 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#ifndef SQLITELDAPSTORAGE_H
+#define SQLITELDAPSTORAGE_H
+
+#include "ldapstorage.h"
+
+class SqliteLdapStorage : public LdapStorage
+{
+    Q_OBJECT
+
+public:
+    SqliteLdapStorage(QObject *parent = 0);
+    virtual ~SqliteLdapStorage();
+};
+
+#endif // SQLITELDAPSTORAGE_H


### PR DESCRIPTION
A new class LdapStorage acts as a proxy for an actual storage, intercepting
authentication requests to serve them via LDAP.