### PR TITLE
Add codec blacklist for UTF-8 detection

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -29,6 +29,10 @@
 
 class QMetaMethod;
 
+// MIBenum values from http://www.iana.org/assignments/character-sets/character-sets.xml#table-character-sets-1
+static QList<int> utf8DetectionBlacklist = QList<int>()
+    << 39 /* ISO-2022-JP */;
+
 QString nickFromMask(QString mask)
 {
     return mask.section('!', 0, 0);
@@ -90,6 +94,9 @@ QString stripAcceleratorMarkers(const QString &label_)
 
 QString decodeString(const QByteArray &input, QTextCodec *codec)
 {
+    if (codec && utf8DetectionBlacklist.contains(codec->mibEnum()))
+        return codec->toUnicode(input);
+
     // First, we check if it's utf8. It is very improbable to encounter a string that looks like
     // valid utf8, but in fact is not. This means that if the input string passes as valid utf8, it
     // is safe to assume that it is.


### PR DESCRIPTION
ISO-2022-JP is valid UTF-8, which means this codec needs to bypass the
auto-detection.
