### PR TITLE
Fix duplication/dropping of messages in certain instances.

### DIFF
--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -350,7 +350,7 @@ void CoreSession::processMessages()
 
         // recheck if there exists a buffer to store a redirected message in
         for (int i = 0; i < redirectedMessages.count(); i++) {
-            const RawMessage &rawMsg = _messageQueue.at(i);
+            const RawMessage &rawMsg = redirectedMessages.at(i);
             if (bufferInfoCache.contains(rawMsg.networkId) && bufferInfoCache[rawMsg.networkId].contains(rawMsg.target)) {
                 bufferInfo = bufferInfoCache[rawMsg.networkId][rawMsg.target];
             }


### PR DESCRIPTION
When multiple messages are processed at once, if one of the messages is flagged
for redirection, the wrong array is accessed, potentially causing the redirected
message to be dropped and another message to be duplicated.
