### PR TITLE
Right Click Selected Text > Google Search

### DIFF
--- a/src/qtui/chatscene.cpp
+++ b/src/qtui/chatscene.cpp
@@ -20,12 +20,14 @@
 
 #include <QApplication>
 #include <QClipboard>
+#include <QDesktopServices>
 #include <QDrag>
 #include <QGraphicsSceneMouseEvent>
 #include <QMenu>
 #include <QMenuBar>
 #include <QMimeData>
 #include <QPersistentModelIndex>
+#include <QUrl>
 
 #ifdef HAVE_KDE
 #  include <KMenuBar>
@@ -799,10 +801,19 @@ void ChatScene::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
     chatView()->addActionsToMenu(&menu, pos);
     menu.addSeparator();
 
-    if (isPosOverSelection(pos))
+    if (isPosOverSelection(pos)) {
         menu.addAction(SmallIcon("edit-copy"), tr("Copy Selection"),
             this, SLOT(selectionToClipboard()),
             QKeySequence::Copy);
+
+        QString searchSelectionText = selection();
+        if (searchSelectionText.length() > _webSearchSelectionTextMaxVisible)
+            searchSelectionText = searchSelectionText.left(_webSearchSelectionTextMaxVisible).append(QString::fromUtf8("\u2026"));
+        searchSelectionText = tr("Search '%1'").arg(searchSelectionText);
+
+        menu.addAction(SmallIcon("zoom-in"), searchSelectionText,
+            this, SLOT(webSearchOnSelection()));
+    }
 
     // item-specific options (select link etc)
     ChatItem *item = chatItemAt(pos);
@@ -1041,6 +1052,21 @@ void ChatScene::clearSelection()
     clearGlobalSelection();
     if (selectingItem())
         selectingItem()->clearSelection();
+}
+
+
+/******** *************************************************************************************/
+
+void ChatScene::webSearchOnSelection()
+{
+    if (!hasSelection())
+        return;
+
+    ChatViewSettings settings;
+    QString webSearchBaseUrl = settings.webSearchUrlFormatString();
+    QString webSearchUrl = webSearchBaseUrl.replace(QString("%s"), selection());
+    QUrl url = QUrl::fromUserInput(webSearchUrl);
+    QDesktopServices::openUrl(url);
 }
 
 

--- a/src/qtui/chatscene.h
+++ b/src/qtui/chatscene.h
@@ -143,6 +143,8 @@ public slots:
     void selectionToClipboard(QClipboard::Mode = QClipboard::Clipboard);
     void stringToClipboard(const QString &str, QClipboard::Mode = QClipboard::Clipboard);
 
+    void webSearchOnSelection();
+
     void requestBacklog();
 
 #ifdef HAVE_WEBKIT
@@ -220,6 +222,8 @@ private:
     bool _leftButtonPressed;
 
     bool _showWebPreview;
+
+    static const int _webSearchSelectionTextMaxVisible = 24;
 
 #ifdef HAVE_WEBKIT
     struct WebPreview {

--- a/src/qtui/chatviewsettings.h
+++ b/src/qtui/chatviewsettings.h
@@ -47,6 +47,9 @@ public:
 
     inline QString timestampFormatString() { return localValue("TimestampFormat", "[hh:mm:ss]").toString(); }
     inline void setTimestampFormatString(const QString &format) { setLocalValue("TimestampFormat", format); }
+
+    inline QString webSearchUrlFormatString() { return localValue("WebSearchUrlFormat", "https://www.google.com/search?q=%s").toString(); }
+    inline void setWebSearchUrlFormatString(const QString &format) { setLocalValue("WebSearchUrlFormat", format); }
 };
 
 

--- a/src/qtui/settingspages/chatviewsettingspage.ui
+++ b/src/qtui/settingspages/chatviewsettingspage.ui
@@ -154,6 +154,30 @@
     </widget>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Web Search Url:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="webSearchUrlFormat">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The URL to open with the selected text as the parameter. Place &lt;span style=&quot; font-weight:600;&quot;&gt;%s&lt;/span&gt; where selected text should go.&lt;/p&gt;&lt;p&gt;Eg:&lt;/p&gt;&lt;p&gt;https://www.google.com/search?q=&lt;span style=&quot; font-weight:600;&quot;&gt;%s&lt;br/&gt;&lt;/span&gt;https://duckduckgo.com/?q=&lt;span style=&quot; font-weight:600;&quot;&gt;%s&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="settingsKey" stdset="0">
+        <string>WebSearchUrlFormat</string>
+       </property>
+       <property name="defaultValue" stdset="0">
+        <string>https://www.google.com/search?q=%s</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QGroupBox" name="useCustomColors">
      <property name="title">
       <string>Custom Colors</string>


### PR DESCRIPTION
Adds a context menu option when selecting text and adds a field in the Chat View Settings which has the url used for the searching. It uses `%s` as the replacement token instead of Qt's weirdness.

You should scrutinize my C++ as I'm not used to it.

If you know how to add an icon, it would be a welcome addition.
# Screenshots

![](http://i.imgur.com/Ewx9AAc.jpg)
![](http://i.imgur.com/lrjlrGL.jpg)
