### PR TITLE
 Never use the expressions "allows to", "helps to", "requires to" etc

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -675,7 +675,7 @@ msgstr "Vyhledávaný text:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Přepnout mezi jednoduchým a pokročilým módem.￼Pokročilý mód umožňuje předat vyhledávaný řetězec IRC Serveru."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/da.po
+++ b/po/da.po
@@ -675,7 +675,7 @@ msgstr "Søge mønster:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Skift mellem simpel og advanceret tilstand.\nAdvanceret tilstand gør det muligt at sende søge strenge til IRC-serveren."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/de.po
+++ b/po/de.po
@@ -676,8 +676,8 @@ msgstr "Suchmuster:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
-msgstr "Zwischen einfachem und erweitertem Modus umschalten.\nDer erweiterte Modus ermöglicht es, Suchbegriffe an den IRC-Server weiterzureichen."
+"Advanced mode allows one to pass search strings to the IRC Server."
+msgstr "Zwischen einfachem und erweitertem Modus umschalten.\nDer erweiterte Modus ermöglicht es einem, Suchbegriffe an den IRC-Server weiterzureichen."
 
 #: ../src/qtui/ui/channellistdlg.ui:62
 msgctxt "ChannelListDlg|"

--- a/po/el.po
+++ b/po/el.po
@@ -677,7 +677,7 @@ msgstr "Αναζήτηση Προτύπου:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Εναλλαγή μεταξύ απλών και προχωρημένων ρυθμίσεων.\nΟι προχωρημένες ρυθμίσεις επιτρέπουν την εισαγωγή λέξεων προς αναζήτηση στον διακομιστή IRC."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -673,8 +673,8 @@ msgstr "Search Pattern:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
-msgstr "Toggle between simple and advanced mode.\nAdvanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
+msgstr "Toggle between simple and advanced mode.\nAdvanced mode allows one to pass search strings to the IRC Server."
 
 #: ../src/qtui/ui/channellistdlg.ui:62
 msgctxt "ChannelListDlg|"

--- a/po/en_US.po
+++ b/po/en_US.po
@@ -671,7 +671,7 @@ msgstr ""
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr ""
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/eo.po
+++ b/po/eo.po
@@ -673,7 +673,7 @@ msgstr "Serĉa ŝablono:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Ŝalti inter la simpla kaj spertula reĝimoj.⏎ La spertula reĝimo permesas vin transdoni serĉoĉenojn al la IRC servilo."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/es.po
+++ b/po/es.po
@@ -678,7 +678,7 @@ msgstr "Patrón de búsqueda:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Conmutar entre el modo simple y el modo avanzado.\nEl modo avanzado permite pasar cadenas de texto de búsqueda al servidor IRC."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/fi.po
+++ b/po/fi.po
@@ -676,7 +676,7 @@ msgstr "Hakulauseke:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Vaihda yksinkertaisen ja edistyneen tilan välillä.\nEdistynyt tila sallii hakulausekkeiden antamisen IRC-palvelimelle."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/fr.po
+++ b/po/fr.po
@@ -675,7 +675,7 @@ msgstr "Chaîne à rechercher :"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Basculer entre mode simple et mode avancé\nLe mode avancé permet de transmettre des chaînes à rechercher au serveur IRC."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/gl.po
+++ b/po/gl.po
@@ -675,7 +675,7 @@ msgstr "Patrón de busca:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Cambiar entre o modo simple e o avanzado.\nO modo avanzado permite enviar cadeas de busca ao servidor IRC."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/hu.po
+++ b/po/hu.po
@@ -673,7 +673,7 @@ msgstr "Keresési minta:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Válasszon egyszerű és haladó mód között.\nA haladó mód engedi szöveg keresését az IRC szerveren."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/it.po
+++ b/po/it.po
@@ -674,7 +674,7 @@ msgstr "Modello di ricerca:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Passa dalla modalità semplice a quella avanzata.\nLa modalità avanzata permette di passare stringhe di ricerca al server IRC."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/ja.po
+++ b/po/ja.po
@@ -673,7 +673,7 @@ msgstr "検索パターン:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr ""
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/ko.po
+++ b/po/ko.po
@@ -673,7 +673,7 @@ msgstr "검색 양식:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "간단 모드 그리고 고급 모드를 전환합니다.\n고급 모드는 검색 문자열을 IRC 서버로 전달할 수 있습니다."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/lt.po
+++ b/po/lt.po
@@ -672,7 +672,7 @@ msgstr "Paieškos šablonas:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr ""
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/nb.po
+++ b/po/nb.po
@@ -676,7 +676,7 @@ msgstr "Søketekst:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Veksle mellom enkel og avansert modus. Avansert modus tillater å sende søkestrenger til IRC tjeneren."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/nl.po
+++ b/po/nl.po
@@ -675,7 +675,7 @@ msgstr "Zoekpatroon:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Wissel tussen eenvoudige en geavanceerde modus.\nIn de geavanceerde modus kunt u zoekopdrachten naar de IRC-server sturen."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/oc.po
+++ b/po/oc.po
@@ -673,7 +673,7 @@ msgstr ""
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr ""
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/pl.po
+++ b/po/pl.po
@@ -672,7 +672,7 @@ msgstr ""
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr ""
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/pt.po
+++ b/po/pt.po
@@ -673,7 +673,7 @@ msgstr "Padrão de Procura:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Alterna entre o modo simples e avançado.\nO modo avançado permite passar strings de busca ao servidor IRC."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -674,7 +674,7 @@ msgstr "Pesquisar padrão:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Alterna entre o modo simples e avançado.\nO modo avançado permite passar strings de busca ao servidor IRC."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/quassel.pot
+++ b/po/quassel.pot
@@ -681,7 +681,7 @@ msgstr ""
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr ""
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/ro.po
+++ b/po/ro.po
@@ -672,7 +672,7 @@ msgstr "Model de căutat:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr ""
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/ru.po
+++ b/po/ru.po
@@ -673,7 +673,7 @@ msgstr "Шаблон поиска:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Переключение между простым и расширенным режимами.\nРасширенный режим позволяет передавать поисковые строки серверу IRC."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/sl.po
+++ b/po/sl.po
@@ -673,7 +673,7 @@ msgstr "Iskalni vzorec:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Preklopi med preprostim in naprednim načinom.\nNapredni način omogoča pošiljanje iskalnih nizov na strežnik za IRC."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/sq.po
+++ b/po/sq.po
@@ -673,7 +673,7 @@ msgstr ""
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr ""
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/sr.po
+++ b/po/sr.po
@@ -672,7 +672,7 @@ msgstr ""
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr ""
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/sv.po
+++ b/po/sv.po
@@ -674,7 +674,7 @@ msgstr "Sökmönster:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr ""
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/tr.po
+++ b/po/tr.po
@@ -675,7 +675,7 @@ msgstr "Arama Deseni:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Basit ve gelişmiş mod arasında seçim yap.\nGelişmiş modda arama dizgileri IRC Sunucuya gönderilebilir."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/uk.po
+++ b/po/uk.po
@@ -674,7 +674,7 @@ msgstr "Шаблон пошуку:"
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "Перемикач між простим та розширеним режимом.\nУ розширеному режимі IRC-серверу можна передавати рядки для пошуку."
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -673,7 +673,7 @@ msgstr "搜索模式："
 msgctxt "ChannelListDlg|"
 msgid ""
 "Toggle between simple and advanced mode.\n"
-"Advanced mode allows to pass search strings to the IRC Server."
+"Advanced mode allows one to pass search strings to the IRC Server."
 msgstr "在简单和高级模式之间切换。\n高级模式允许发送搜索字符串到IRC服务器。"
 
 #: ../src/qtui/ui/channellistdlg.ui:62

--- a/src/qtui/ui/channellistdlg.ui
+++ b/src/qtui/ui/channellistdlg.ui
@@ -46,7 +46,7 @@
       <widget class="ClickableLabel" name="advancedModeLabel">
        <property name="toolTip">
         <string>Toggle between simple and advanced mode.
-Advanced mode allows to pass search strings to the IRC Server.</string>
+Advanced mode allows one to pass search strings to the IRC Server.</string>
        </property>
        <property name="text">
         <string/>


### PR DESCRIPTION
Each of these expressions requires a direct object.

fixes some  lintian warnings in debianoid systems
