### PR TITLE
types.h: add missing include

### DIFF
--- a/src/common/types.h
+++ b/src/common/types.h
@@ -26,6 +26,7 @@
 #include <QVariant>
 #include <QTextStream>
 #include <QHostAddress>
+#include <QDataStream>
 
 class SignedId
 {


### PR DESCRIPTION
```
error: use of overloaded operator '<<' is ambiguous (with operand types 'QDataStream' and 'qint32' (aka 'int'))
inline QDataStream &operator<<(QDataStream &out, const SignedId &signedId) { out << signedId.toInt(); return out; }
                                                                             ~~~ ^  ~~~~~~~~~~~~~~~~
../../Qt/5.0.2/5.0.2/clang_64/include/QtCore/qchar.h:395:28: note: candidate function
Q_CORE_EXPORT QDataStream &operator<<(QDataStream &, QChar);
                           ^
../../Qt/5.0.2/5.0.2/clang_64/include/QtCore/qvariant.h:527:28: note: candidate function
Q_CORE_EXPORT QDataStream& operator<< (QDataStream& s, const QVariant& p);
                           ^
[...]
```
