### PR TITLE
Add Serenity-IRC to list of available networks

### DIFF
--- a/data/networks.ini
+++ b/data/networks.ini
@@ -44,6 +44,9 @@ Servers=irc.oftc.net:6667
 [QuakeNet]
 Servers=irc.quakenet.org:6667,de.quakenet.org:6667,se.quakenet.org:6667,uk.quakenet.org:6667,us.quakenet.org:6667
 
+[Serenity-IRC]
+Servers=irc.serenity-irc.net:6667,eu.serenity-irc.net:6667,us.serenity-irc.net:6667
+
 [Undernet]
 Servers=eu.undernet.org:6667,us.undernet.org:6667,elsene.be.eu.undernet.org:6667,elsene.be.eu.undernet.org:7000,helsinki.fi.eu.Undernet.org:6666,zagreb.hr.eu.undernet.org:6666,zagreb.hr.eu.undernet.org:9999,ede.nl.eu.undernet.org:6660,oslo.no.eu.undernet.org:6666,london.uk.eu.undernet.org:6660,london.uk.eu.undernet.org:7000,mesa.az.us.undernet.org:6660,mesa.az.us.undernet.org:6665,mesa.az.us.undernet.org:7000,newyork.ny.us.undernet.org:6660,newyork.ny.us.undernet.org:7000
 


### PR DESCRIPTION
Serenity-IRC has been around since 2003 and is a small and friendly
network for general chat and bantering.
