### PR TITLE
Remove stray whitespace in INSTALL and README.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -13,8 +13,8 @@ Note that quasselcore is no longer being built by default, since it tends to
 confuse users more than it helped. It will be back as soon as we have simple mode
 implemented.
 
-We now use CMake as our build system. CMake supports and encourages out-of-source 
-builds, which do not clutter the source directory. You can (and should) thus use 
+We now use CMake as our build system. CMake supports and encourages out-of-source
+builds, which do not clutter the source directory. You can (and should) thus use
 an arbitrary directory for building.
 
 There is no "make distclean"; "make clean" should usually be enough since CMake

--- a/README
+++ b/README
@@ -12,7 +12,7 @@ However, you can add more users, or change passwords of existing ones,
 using manageusers.py to be found in the scripts/ directory.
 
 IRC is the preferred means of getting in touch with the developers.
-The Quassel IRC Team can be contacted on Freenode/#quassel (or 
+The Quassel IRC Team can be contacted on Freenode/#quassel (or
 #quassel.de).  We always welcome new users in our channels!
 
 Our homepage is <http://quassel-irc.org>


### PR DESCRIPTION
This resolves [issue 1230: Trailing whitespace in README/INSTALL](http://bugs.quassel-irc.org/issues/1230).
