### PR TITLE
Implement issue #1219: Update the marker line when quassel loses focus

### DIFF
--- a/src/qtui/bufferwidget.cpp
+++ b/src/qtui/bufferwidget.cpp
@@ -40,7 +40,8 @@
 BufferWidget::BufferWidget(QWidget *parent)
     : AbstractBufferContainer(parent),
     _chatViewSearchController(new ChatViewSearchController(this)),
-    _autoMarkerLine(true)
+    _autoMarkerLine(true),
+    _autoMarkerLineOnLostFocus(true)
 {
     ui.setupUi(this);
     layout()->setContentsMargins(0, 0, 0, 0);
@@ -99,6 +100,7 @@ BufferWidget::BufferWidget(QWidget *parent)
 
     ChatViewSettings s;
     s.initAndNotify("AutoMarkerLine", this, SLOT(setAutoMarkerLine(QVariant)), true);
+    s.initAndNotify("AutoMarkerLineOnLostFocus", this, SLOT(setAutoMarkerLineOnLostFocus(QVariant)), true);
 }
 
 
@@ -112,6 +114,11 @@ BufferWidget::~BufferWidget()
 void BufferWidget::setAutoMarkerLine(const QVariant &v)
 {
     _autoMarkerLine = v.toBool();
+}
+
+void BufferWidget::setAutoMarkerLineOnLostFocus(const QVariant &v)
+{
+    _autoMarkerLineOnLostFocus = v.toBool();
 }
 
 
@@ -270,14 +277,14 @@ void BufferWidget::setMarkerLine(ChatView *view, bool allowGoingBack)
     if (lastLine) {
         QModelIndex idx = lastLine->index();
         MsgId msgId = idx.data(MessageModel::MsgIdRole).value<MsgId>();
+        BufferId bufId = view->scene()->singleBufferId();
 
         if (!allowGoingBack) {
-            BufferId bufId = view->scene()->singleBufferId();
             MsgId oldMsgId = Client::markerLine(bufId);
             if (oldMsgId.isValid() && msgId <= oldMsgId)
                 return;
         }
-        view->setMarkerLine(msgId);
+        Client::setMarkerLine(bufId, msgId);
     }
 }
 

--- a/src/qtui/bufferwidget.h
+++ b/src/qtui/bufferwidget.h
@@ -42,6 +42,7 @@ public:
 
     inline ChatViewSearchBar *searchBar() const { return ui.searchBar; }
     void addActionsToMenu(QMenu *, const QPointF &pos);
+    virtual inline bool autoMarkerLineOnLostFocus() const { return _autoMarkerLineOnLostFocus; }
 
 public slots:
     virtual void setMarkerLine(ChatView *view = 0, bool allowGoingBack = true);
@@ -63,6 +64,7 @@ private slots:
     void zoomOriginal();
 
     void setAutoMarkerLine(const QVariant &);
+    void setAutoMarkerLineOnLostFocus(const QVariant &);
 
 private:
     Ui::BufferWidget ui;
@@ -71,6 +73,7 @@ private:
     ChatViewSearchController *_chatViewSearchController;
 
     bool _autoMarkerLine;
+    bool _autoMarkerLineOnLostFocus;
 };
 
 

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -1365,11 +1365,17 @@ void MainWin::toggleFullscreen()
 /********************************************************************************************************/
 
 bool MainWin::event(QEvent *event)
-{
-    if (event->type() == QEvent::WindowActivate) {
-        BufferId buffer = Client::bufferModel()->currentBuffer();
-        if (buffer.isValid())
-            Client::instance()->markBufferAsRead(buffer);
+{  
+    switch(event->type()) {
+    case QEvent::WindowActivate:
+        BufferId bufferId = Client::bufferModel()->currentBuffer();
+        if (bufferId.isValid())
+            Client::instance()->markBufferAsRead(bufferId);
+        break;
+    case QEvent::WindowDeactivate:
+        if (bufferWidget()->autoMarkerLineOnLostFocus())
+            bufferWidget()->setMarkerLine();
+        break;
     }
     return QMainWindow::event(event);
 }

--- a/src/qtui/settingspages/chatviewsettingspage.ui
+++ b/src/qtui/settingspages/chatviewsettingspage.ui
@@ -154,6 +154,25 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="autoMarkerLineOnLostFocus">
+     <property name="toolTip">
+      <string>Set the marker line to the bottom of the current chat window when Quassel loses focus.</string>
+     </property>
+     <property name="text">
+      <string>Set marker line automatically when Quassel loses focus</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="settingsKey" stdset="0">
+      <string>AutoMarkerLineOnLostFocus</string>
+     </property>
+     <property name="defaultValue" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="useCustomColors">
      <property name="title">
       <string>Custom Colors</string>


### PR DESCRIPTION
Solves [issue #1219](http://bugs.quassel-irc.org/issues/1219) on bugs.quassel-irc.org.

We now listen for QEvent::WindowDeactivate in the main window. This should pickup on window closing/minimizing/losing focus. We also change view->setMarkerLine() to Client::setMarkerLine which will send an event to the syncher, and eventually arrives at ChatView::markerLineSet, which moves the marker line for us.
