### PR TITLE
add option to enable linewrap mode

### DIFF
--- a/src/qtui/inputwidget.cpp
+++ b/src/qtui/inputwidget.cpp
@@ -122,6 +122,9 @@ InputWidget::InputWidget(QWidget *parent)
     s.notify("EnableScrollBars", this, SLOT(setScrollBarsEnabled(QVariant)));
     setScrollBarsEnabled(s.value("EnableScrollBars", true));
 
+    s.notify("EnableLineWrap", this, SLOT(setLineWrapEnabled(QVariant)));
+    setLineWrapEnabled(s.value("EnableLineWrap", false));
+
     s.notify("EnableMultiLine", this, SLOT(setMultiLineEnabled(QVariant)));
     setMultiLineEnabled(s.value("EnableMultiLine", true));
 
@@ -206,6 +209,12 @@ void InputWidget::setMaxLines(const QVariant &v)
 void InputWidget::setScrollBarsEnabled(const QVariant &v)
 {
     ui.inputEdit->setScrollBarsEnabled(v.toBool());
+}
+
+
+void InputWidget::setLineWrapEnabled(const QVariant &v)
+{
+    ui.inputEdit->setLineWrapEnabled(v.toBool());
 }
 
 

--- a/src/qtui/inputwidget.h
+++ b/src/qtui/inputwidget.h
@@ -61,6 +61,7 @@ private slots:
     void setShowStyleButtons(const QVariant &);
     void setEnablePerChatHistory(const QVariant &);
     void setMaxLines(const QVariant &);
+    void setLineWrapEnabled(const QVariant &);
     void setMultiLineEnabled(const QVariant &);
     void setScrollBarsEnabled(const QVariant &);
     void onTextEntered(const QString &text);

--- a/src/qtui/settingspages/inputwidgetsettingspage.ui
+++ b/src/qtui/settingspages/inputwidgetsettingspage.ui
@@ -122,6 +122,22 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="enableLineWrapMode">
+     <property name="toolTip">
+      <string>Enables line wrapping for input.</string>
+     </property>
+     <property name="text">
+      <string>Line wrapping</string>
+     </property>
+     <property name="settingsKey" stdset="0">
+      <string notr="true">EnableLineWrap</string>
+     </property>
+     <property name="defaultValue" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Multi-Line Editing</string>

--- a/src/qtui/topicwidget.cpp
+++ b/src/qtui/topicwidget.cpp
@@ -30,7 +30,7 @@ TopicWidget::TopicWidget(QWidget *parent)
 {
     ui.setupUi(this);
     ui.topicEditButton->setIcon(SmallIcon("edit-rename"));
-    ui.topicLineEdit->setWordWrapEnabled(true);
+    ui.topicLineEdit->setLineWrapEnabled(true);
     ui.topicLineEdit->installEventFilter(this);
 
     connect(ui.topicLabel, SIGNAL(clickableActivated(Clickable)), SLOT(clickableActivated(Clickable)));

--- a/src/uisupport/multilineedit.cpp
+++ b/src/uisupport/multilineedit.cpp
@@ -53,7 +53,7 @@ MultiLineEdit::MultiLineEdit(QWidget *parent)
 #endif
 
     setMode(SingleLine);
-    setWordWrapEnabled(false);
+    setLineWrapEnabled(false);
     reset();
 
     connect(this, SIGNAL(textChanged()), this, SLOT(on_textChanged()));
@@ -95,6 +95,13 @@ void MultiLineEdit::setMode(Mode mode)
         return;
 
     _mode = mode;
+}
+
+
+void MultiLineEdit::setLineWrapEnabled(bool enable)
+{
+    setLineWrapMode(enable ? WidgetWidth : NoWrap);
+    updateSizeHint();
 }
 
 
@@ -204,13 +211,6 @@ void MultiLineEdit::setSpellCheckEnabled(bool enable)
 #else
     Q_UNUSED(enable)
 #endif
-}
-
-
-void MultiLineEdit::setWordWrapEnabled(bool enable)
-{
-    setLineWrapMode(enable ? WidgetWidth : NoWrap);
-    updateSizeHint();
 }
 
 

--- a/src/uisupport/multilineedit.h
+++ b/src/uisupport/multilineedit.h
@@ -81,9 +81,7 @@ public slots:
     void setScrollBarsEnabled(bool enable = true);
     void setSpellCheckEnabled(bool enable = true);
     void setPasteProtectionEnabled(bool enable = true, QWidget *msgBoxParent = 0);
-
-    // Note: Enabling wrap will make isSingleLine() not work correctly, so only use this if minHeight() > 1!
-    void setWordWrapEnabled(bool enable = true);
+    void setLineWrapEnabled(bool enable = false);
 
     inline void setHistory(QStringList history) { _history = history; }
     inline void setTempHistory(QHash<int, QString> tempHistory) { _tempHistory = tempHistory; }


### PR DESCRIPTION
re-enable line wrapping for the input line (previously dubbed 'WORD-wrapping' - incorrectly)

as per Tucos's comment on IRC ('iirc it didn't actually break anything, but the big boss was hesitant to just add it back in without proper testing'), this has been built on linux x86/x86_64 platforms with Qt 4.8.4/5 and 5.1.0 and used without issue for a day, so hopefully isn't going to be too problematic
