### PR TITLE
Use the old way of finding translations for OSX.

### DIFF
--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -495,7 +495,7 @@ void Quassel::loadTranslation(const QLocale &locale)
     quasselTranslator->setObjectName("QuasselTr");
     qApp->installTranslator(quasselTranslator);
 
-#if QT_VERSION >= 0x040800
+#if QT_VERSION >= 0x040800 && !defined Q_OS_MAC
     bool success = qtTranslator->load(locale, QString("qt_"), translationDirPath());
     if (!success)
         qtTranslator->load(locale, QString("qt_"), QLibraryInfo::location(QLibraryInfo::TranslationsPath));


### PR DESCRIPTION
Many OSX users reported their clients being in Japanese, rather than
English, since 0.9.0, which turned out to be due to
QSystemLocale::query for QSystemLocal::UILanguages (internally done by
Qt if a QLocale is passed to QTranslator::load) returning 'en', rather
than the proper local form (e.g. 'en-US').
As 'en' has no translation, the second language got picked up, which
happened to be 'ja', which does have a translation.

Fixes #1233 (but reintroduces #1194 on OSX)
