### PR TITLE
Add some numerics to the 'Just display' list.

### DIFF
--- a/src/core/eventstringifier.cpp
+++ b/src/core/eventstringifier.cpp
@@ -104,6 +104,10 @@ void EventStringifier::processIrcEventNumeric(IrcEventNumeric *e)
     case 253:
     case 254:
     case 255:
+    case 256:
+    case 257:
+    case 258:
+    case 259:
     case 265:
     case 266:
     case 372:
@@ -112,6 +116,7 @@ void EventStringifier::processIrcEventNumeric(IrcEventNumeric *e)
         break;
 
     // Server error messages without param, just display them
+    case 263:
     case 409:
     case 411:
     case 412:


### PR DESCRIPTION
These are all defined in RFC 2812, but were not displayed as server
messages by quassel:
256 (RPL_ADMINME), 257 (RPL_ADMINLOC1), 258 (RPL_ADMINLOC2),
259 (RPL_ADMINEMAIL) and 263 (RPL_TRYAGAIN, this one is technically an
error, thus shown as such).
