### PR TITLE
Respond to CTCP PING even if it had no parameter.

### DIFF
--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -1016,7 +1016,7 @@ void CoreSessionEventProcessor::handleCtcpClientinfo(CtcpEvent *e)
 
 void CoreSessionEventProcessor::handleCtcpPing(CtcpEvent *e)
 {
-    e->setReply(e->param());
+    e->setReply(e->param().isNull() ? "" : e->param());
 }
 
 


### PR DESCRIPTION
Normally the response param is whatever came in, but e.g. qwebirc does
not send any params if the user does not explicitly specify any. This
would result in "Received unknown CTCP-PING". This patch makes quassel
respond with any empty string.
