### PR TITLE
Don't disable standard_conforming_strings on 4.8.5

### DIFF
--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -98,8 +98,10 @@ QVariantMap PostgreSqlStorage::setupDefaults() const
 
 void PostgreSqlStorage::initDbSession(QSqlDatabase &db)
 {
+#if QT_VERSION < 0x040805
     // this blows... but unfortunately Qt's PG driver forces us to this...
     db.exec("set standard_conforming_strings = off");
+#endif
     db.exec("set escape_string_warning = off");
 }
 


### PR DESCRIPTION
The Qt postgresql driver used to insert superfluous slashes, which
resulted in slashes being duplicated in quassel [1]. Since Qt 4.8.5
this behaviour has been corrected upstream [2,3], which means that
disabling standard_conforming_strings results in even worse behaviour.

Messages ending in a backslash are not logged to the database and when
sending such messages they are thus not shown in the client. Next to
this, migration fails when nicks ending in a backslash and the same
nick without backslash is present, as these would be considered equal.

[1] http://bugs.quassel-irc.org/issues/692
[2] https://qt.gitorious.org/qt/qtbase/commit/e3c5351d06ce8a12f035cd0627356bc64d8c334a
[3] https://bugreports.qt-project.org/browse/QTBUG-30076

Fixes #1244
