### PR TITLE
Sanitize topic message

### DIFF
--- a/src/qtui/topicwidget.cpp
+++ b/src/qtui/topicwidget.cpp
@@ -156,12 +156,12 @@ void TopicWidget::setTopic(const QModelIndex &index)
         }
     }
 
-    _topic = newtopic;
+    _topic = sanitizeTopic(newtopic);
     _readonly = readonly;
 
     ui.topicEditButton->setVisible(!_readonly);
-    ui.topicLabel->setText(newtopic);
-    ui.topicLineEdit->setPlainText(newtopic);
+    ui.topicLabel->setText(_topic);
+    ui.topicLineEdit->setPlainText(_topic);
     switchPlain();
 }
 
@@ -263,4 +263,17 @@ bool TopicWidget::eventFilter(QObject *obj, QEvent *event)
     }
 
     return false;
+}
+
+QString TopicWidget::sanitizeTopic(const QString& topic)
+{
+    // Normally, you don't have new lines in topic messages
+    // But the use of "plain text" functionnality from Qt replaces
+    // some unicode characters with a new line, which then triggers
+    // a stack overflow later
+    QString result(topic);
+    result.replace(QChar::ParagraphSeparator, " ");
+    result.replace(QChar::LineSeparator, " ");
+
+    return result;
 }

--- a/src/qtui/topicwidget.h
+++ b/src/qtui/topicwidget.h
@@ -57,6 +57,8 @@ private slots:
     void setUseCustomFont(const QVariant &);
 
 private:
+    QString sanitizeTopic(const QString& topic);
+
     Ui::TopicWidget ui;
 
     QString _topic;


### PR DESCRIPTION
The code handling the topic message isn't expecting any new lines
since it is usually not possible to have any from the IRC specs.
But we can have some Unicode new lines instead!
Qt is happily converting them to simple new lines which then crashes
the client with a stack overflow.
