### PR TITLE
Enable the ping timeout as soon as the connection to IRC is open.

### DIFF
--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -226,6 +226,7 @@ private:
     QTimer _pingTimer;
     uint _lastPingTime;
     uint _pingCount;
+    bool _sendPings;
 
     QStringList _autoWhoQueue;
     QHash<QString, int> _autoWhoPending;


### PR DESCRIPTION
This fixes the problem where Quassel would get stuck while connecting if the socket is closed by the server but the core is, for whatever reason, not notified of this.  This patch works by enabling the ping timeout as soon as the connection is open, but not actually sending any PINGs until the IRC authentication is complete.  This will cause the core to reconnect if at any point it doesn't receive data from the server for more than the usual ping timeout interval.
