### PR TITLE
Add core commandline option to require SSL for client connections.

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -115,6 +115,9 @@ int main(int argc, char **argv)
     cliParser->addOption("change-userpass <username>", 0, "Starts an interactive session to change the password of the user identified by username");
     cliParser->addSwitch("oidentd", 0, "Enable oidentd integration");
     cliParser->addOption("oidentd-conffile <file>", 0, "Set path to oidentd configuration file");
+#ifdef HAVE_SSL
+    cliParser->addSwitch("require-ssl", 0, "Require SSL for client connections");
+#endif
 #endif
 
 #ifdef HAVE_KDE

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -101,6 +101,11 @@ void CoreAuthHandler::handle(const RegisterClient &msg)
     // TODO: only in compat mode
     bool useSsl = false;
 #ifdef HAVE_SSL
+    if (Quassel::isOptionSet("require-ssl") && !msg.sslSupported) {
+        _peer->dispatch(ClientDenied(tr("<b>SSL is required!</b><br>You need to use SSL in order to connect to this core.")));
+        _peer->close();
+        return;
+    }
     if (Core::sslSupported() && msg.sslSupported)
         useSsl = true;
 #endif


### PR DESCRIPTION
If the --require-ssl commandline option is passed when starting the core, it will reject any client that does not use SSL.
