### PR TITLE
Add option for chat monitor to use backlog

### DIFF
--- a/src/qtui/chatmonitorfilter.cpp
+++ b/src/qtui/chatmonitorfilter.cpp
@@ -39,16 +39,19 @@ ChatMonitorFilter::ChatMonitorFilter(MessageModel *model, QObject *parent)
     QString showHighlightsSettingsId = "ShowHighlights";
     QString operationModeSettingsId = "OperationMode";
     QString buffersSettingsId = "Buffers";
+    QString showBacklogSettingsId = "ShowBacklog";
 
     _showHighlights = viewSettings.value(showHighlightsSettingsId, false).toBool();
     _operationMode = viewSettings.value(operationModeSettingsId, 0).toInt();
     // read configured list of buffers to monitor/ignore
     foreach(QVariant v, viewSettings.value(buffersSettingsId, QVariant()).toList())
     _bufferIds << v.value<BufferId>();
+    _showBacklog = viewSettings.value(showBacklogSettingsId, true).toBool();
 
     viewSettings.notify(showHighlightsSettingsId, this, SLOT(showHighlightsSettingChanged(const QVariant &)));
     viewSettings.notify(operationModeSettingsId, this, SLOT(operationModeSettingChanged(const QVariant &)));
     viewSettings.notify(buffersSettingsId, this, SLOT(buffersSettingChanged(const QVariant &)));
+    viewSettings.notify(showBacklogSettingsId, this, SLOT(showBacklogSettingChanged(const QVariant &)));
 }
 
 
@@ -57,16 +60,18 @@ bool ChatMonitorFilter::filterAcceptsRow(int sourceRow, const QModelIndex &sourc
     Q_UNUSED(sourceParent)
 
     QModelIndex source_index = sourceModel()->index(sourceRow, 0);
+    BufferId bufferId = source_index.data(MessageModel::BufferIdRole).value<BufferId>();
 
     Message::Flags flags = (Message::Flags)source_index.data(MessageModel::FlagsRole).toInt();
-    if (flags & Message::Backlog || (!_showOwnMessages && flags & Message::Self))
+    if (!_showBacklog && flags & Message::Backlog)
+        return false;
+
+    if (!_showOwnMessages && flags & Message::Self)
         return false;
 
     Message::Type type = (Message::Type)source_index.data(MessageModel::TypeRole).toInt();
     if (!(type & (Message::Plain | Message::Notice | Message::Action)))
         return false;
-
-    BufferId bufferId = source_index.data(MessageModel::BufferIdRole).value<BufferId>();
 
     // ChatMonitorSettingsPage
     if (_operationMode == ChatViewSettings::OptOut
@@ -186,4 +191,8 @@ void ChatMonitorFilter::buffersSettingChanged(const QVariant &newValue)
         _bufferIds << v.value<BufferId>();
     }
     invalidateFilter();
+}
+
+void ChatMonitorFilter::showBacklogSettingChanged(const QVariant &newValue) {
+    _showBacklog = newValue.toBool();
 }

--- a/src/qtui/chatmonitorfilter.h
+++ b/src/qtui/chatmonitorfilter.h
@@ -58,6 +58,7 @@ private slots:
     void showHighlightsSettingChanged(const QVariant &newValue);
     void operationModeSettingChanged(const QVariant &newValue);
     void buffersSettingChanged(const QVariant &newValue);
+    void showBacklogSettingChanged(const QVariant &newValue);
 
 private:
     int _showFields;
@@ -65,6 +66,7 @@ private:
     QList<BufferId> _bufferIds;
     bool _showHighlights;
     int _operationMode;
+    bool _showBacklog;
 };
 
 

--- a/src/qtui/settingspages/chatmonitorsettingspage.cpp
+++ b/src/qtui/settingspages/chatmonitorsettingspage.cpp
@@ -63,6 +63,7 @@ ChatMonitorSettingsPage::ChatMonitorSettingsPage(QWidget *parent)
     connect(ui.operationMode, SIGNAL(currentIndexChanged(int)), SLOT(switchOperationMode(int)));
     connect(ui.showHighlights, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
     connect(ui.showOwnMessages, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
+    connect(ui.showBacklog, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
 }
 
 
@@ -79,6 +80,7 @@ void ChatMonitorSettingsPage::defaults()
     settings["ShowOwnMsgs"] = false;
     settings["Buffers"] = QVariant();
     settings["Default"] = true;
+    settings["ShowBacklog"] = true;
     load();
     widgetHasChanged();
 }
@@ -95,6 +97,7 @@ void ChatMonitorSettingsPage::load()
     ui.operationMode->setCurrentIndex(settings["OperationMode"].toInt() - 1);
     ui.showHighlights->setChecked(settings["ShowHighlights"].toBool());
     ui.showOwnMessages->setChecked(settings["ShowOwnMsgs"].toBool());
+    ui.showBacklog->setChecked(settings["ShowBacklog"].toBool());
 
     // get all available buffer Ids
     QList<BufferId> allBufferIds = Client::networkModel()->allBufferIds();
@@ -127,6 +130,7 @@ void ChatMonitorSettingsPage::loadSettings()
     settings["ShowHighlights"] = chatViewSettings.value("ShowHighlights", false);
     settings["ShowOwnMsgs"] = chatViewSettings.value("ShowOwnMsgs", false);
     settings["Buffers"] = chatViewSettings.value("Buffers", QVariantList());
+    settings["ShowBacklog"] = chatViewSettings.value("ShowBacklog", true);
 }
 
 
@@ -137,6 +141,7 @@ void ChatMonitorSettingsPage::save()
     chatViewSettings.setValue("OperationMode", ui.operationMode->currentIndex() + 1);
     chatViewSettings.setValue("ShowHighlights", ui.showHighlights->isChecked());
     chatViewSettings.setValue("ShowOwnMsgs", ui.showOwnMessages->isChecked());
+    chatViewSettings.setValue("ShowBacklog", ui.showBacklog->isChecked());
 
     // save list of active buffers
     QVariantList saveableBufferIdList;
@@ -164,6 +169,8 @@ bool ChatMonitorSettingsPage::testHasChanged()
     if (settings["ShowHighlights"].toBool() != ui.showHighlights->isChecked())
         return true;
     if (settings["ShowOwnMsgs"].toBool() != ui.showOwnMessages->isChecked())
+        return true;
+    if (settings["ShowBacklog"].toBool() != ui.showBacklog->isChecked())
         return true;
 
     if (_configActive->bufferList().count() != settings["Buffers"].toList().count())

--- a/src/qtui/settingspages/chatmonitorsettingspage.ui
+++ b/src/qtui/settingspages/chatmonitorsettingspage.ui
@@ -158,6 +158,16 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QCheckBox" name="showBacklog">
+     <property name="toolTip">
+      <string>Display messages from backlog on reconnect</string>
+     </property>
+     <property name="text">
+      <string>Show messages from backlog</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>


### PR DESCRIPTION
Will show valid messages from the backlog in the chat monitor if the "Show messages from backlog" option is set in the Chat Monitor configuration page.
