### PR TITLE
Enable the ping timeout as soon as the connection to IRC is open.

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -40,6 +40,7 @@ CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
 
     _lastPingTime(0),
     _pingCount(0),
+    _sendPings(false),
     _requestedUserModes('-')
 {
     _autoReconnectTimer.setSingleShot(true);
@@ -446,6 +447,8 @@ void CoreNetwork::socketInitialized()
 
     emit socketInitialized(identity, localAddress(), localPort(), peerAddress(), peerPort());
 
+    enablePingTimeout();
+
     // TokenBucket to avoid sending too much at once
     _messageDelay = 2200;  // this seems to be a safe value (2.2 seconds delay)
     _burstSize = 5;
@@ -551,7 +554,7 @@ void CoreNetwork::networkInitialized()
 
     sendPerform();
 
-    enablePingTimeout();
+    _sendPings = true;
 
     if (networkConfig()->autoWhoEnabled()) {
         _autoWhoCycleTimer.start();
@@ -795,7 +798,9 @@ void CoreNetwork::sendPing()
     else {
         _lastPingTime = now;
         _pingCount++;
-        userInputHandler()->handlePing(BufferInfo(), QString());
+        // Don't send pings until the network is initialized
+        if(_sendPings)
+            userInputHandler()->handlePing(BufferInfo(), QString());
     }
 }
 
@@ -815,6 +820,7 @@ void CoreNetwork::enablePingTimeout(bool enable)
 void CoreNetwork::disablePingTimeout()
 {
     _pingTimer.stop();
+    _sendPings = false;
     resetPingTimeout();
 }
 

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -226,6 +226,7 @@ private:
     QTimer _pingTimer;
     uint _lastPingTime;
     uint _pingCount;
+    bool _sendPings;
 
     QStringList _autoWhoQueue;
     QHash<QString, int> _autoWhoPending;


### PR DESCRIPTION
This fixes the problem where Quassel would get stuck while connecting if the socket is closed by the server but the core is, for whatever reason, not notified of this.  This patch works by enabling the ping timeout as soon as the connection is open, but not actually sending any PINGs until the IRC authentication is complete.  This will cause the core to reconnect if at any point it doesn't receive data from the server for more than the usual ping timeout interval.
