### PR TITLE
Add option to force ident response to the user's quassel username

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -115,6 +115,7 @@ int main(int argc, char **argv)
     cliParser->addOption("change-userpass <username>", 0, "Starts an interactive session to change the password of the user identified by username");
     cliParser->addSwitch("oidentd", 0, "Enable oidentd integration");
     cliParser->addOption("oidentd-conffile <file>", 0, "Set path to oidentd configuration file");
+    cliParser->addSwitch("oidentd-forceuser", 0, "Forces ident response to be the quassel username");
 #ifdef HAVE_SSL
     cliParser->addSwitch("require-ssl", 0, "Require SSL for client connections");
 #endif

--- a/src/core/SQL/PostgreSQL/16/select_username.sql
+++ b/src/core/SQL/PostgreSQL/16/select_username.sql
@@ -1,0 +1,3 @@
+SELECT username
+FROM quasseluser
+WHERE userid = :userid

--- a/src/core/SQL/SQLite/17/select_username.sql
+++ b/src/core/SQL/SQLite/17/select_username.sql
@@ -1,0 +1,3 @@
+SELECT username
+FROM quasseluser
+WHERE userid = :userid

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -98,6 +98,15 @@ public:
         return instance()->_storage->getUserSetting(userId, settingName, defaultValue);
     }
 
+    //! Retrieve a username for a core user
+    /**
+     * \param user     The core user
+     * \return the username of the given user
+     */
+    static inline QString getUserName(UserId user)
+    {
+        return instance()->_storage->getUserName(user);
+    }
 
     /* Identity handling */
     static inline IdentityId createIdentity(UserId user, CoreIdentity &identity)

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -81,8 +81,8 @@ CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
     connect(this, SIGNAL(newEvent(Event *)), coreSession()->eventManager(), SLOT(postEvent(Event *)));
 
     if (Quassel::isOptionSet("oidentd")) {
-        connect(this, SIGNAL(socketInitialized(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(addSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Qt::BlockingQueuedConnection);
-        connect(this, SIGNAL(socketDisconnected(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(removeSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)));
+        connect(this, SIGNAL(socketInitialized(const CoreIdentity*, QString, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(addSocket(const CoreIdentity*, QString, QHostAddress, quint16, QHostAddress, quint16)), Qt::BlockingQueuedConnection);
+        connect(this, SIGNAL(socketDisconnected(const CoreIdentity*, QString, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(removeSocket(const CoreIdentity*, QString, QHostAddress, quint16, QHostAddress, quint16)));
     }
 }
 
@@ -157,6 +157,9 @@ void CoreNetwork::connectToIrc(bool reconnecting)
 
     // cleaning up old quit reason
     _quitReason.clear();
+
+    // update username
+    _userName = _coreSession->userName();
 
     // use a random server?
     if (useRandomServer()) {
@@ -445,7 +448,7 @@ void CoreNetwork::socketInitialized()
         return;
     }
 
-    emit socketInitialized(identity, localAddress(), localPort(), peerAddress(), peerPort());
+    emit socketInitialized(identity, _userName, localAddress(), localPort(), peerAddress(), peerPort());
 
     enablePingTimeout();
 
@@ -496,7 +499,7 @@ void CoreNetwork::socketDisconnected()
 
     setConnected(false);
     emit disconnected(networkId());
-    emit socketDisconnected(identityPtr(), localAddress(), localPort(), peerAddress(), peerPort());
+    emit socketDisconnected(identityPtr(), _userName, localAddress(), localPort(), peerAddress(), peerPort());
     if (_quitRequested) {
         _quitRequested = false;
         setConnectionState(Network::Disconnected);

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -157,8 +157,8 @@ signals:
     void sslErrors(const QVariant &errorData);
 
     void newEvent(Event *event);
-    void socketInitialized(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
-    void socketDisconnected(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
+    void socketInitialized(const CoreIdentity *identity, QString userName, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
+    void socketDisconnected(const CoreIdentity *identity, QString userName, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
 
 protected:
     inline virtual IrcChannel *ircChannelFactory(const QString &channelname) { return new CoreIrcChannel(channelname, this); }
@@ -198,6 +198,8 @@ private slots:
 
 private:
     CoreSession *_coreSession;
+
+    QString _userName;
 
 #ifdef HAVE_SSL
     QSslSocket socket;

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -24,6 +24,7 @@
 #include <QString>
 #include <QVariant>
 
+#include "core.h"
 #include "corecoreinfo.h"
 #include "corealiasmanager.h"
 #include "coreignorelistmanager.h"
@@ -64,6 +65,7 @@ public:
 
     QList<BufferInfo> buffers() const;
     inline UserId user() const { return _user; }
+    inline QString userName() const { return Core::instance()->getUserName(_user); }
     CoreNetwork *network(NetworkId) const;
     CoreIdentity *identity(IdentityId) const;
     inline CoreNetworkConfig *networkConfig() const { return _networkConfig; }

--- a/src/core/oidentdconfiggenerator.cpp
+++ b/src/core/oidentdconfiggenerator.cpp
@@ -66,10 +66,14 @@ bool OidentdConfigGenerator::init()
 }
 
 
-bool OidentdConfigGenerator::addSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort)
+bool OidentdConfigGenerator::addSocket(const CoreIdentity *identity, const QString userName, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort)
 {
     Q_UNUSED(localAddress) Q_UNUSED(peerAddress) Q_UNUSED(peerPort)
-    QString ident = identity->ident();
+    QString ident;
+    if (Quassel::isOptionSet("oidentd-forceuser"))
+        ident = userName;
+    else
+        ident = identity->ident();
 
     _quasselConfig.append(_quasselStanzaTemplate.arg(localPort).arg(ident).arg(_configTag).toAscii());
 
@@ -80,9 +84,9 @@ bool OidentdConfigGenerator::addSocket(const CoreIdentity *identity, const QHost
 
 
 //! not yet implemented
-bool OidentdConfigGenerator::removeSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort)
+bool OidentdConfigGenerator::removeSocket(const CoreIdentity *identity, const QString userName, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort)
 {
-    Q_UNUSED(identity) Q_UNUSED(localAddress) Q_UNUSED(localPort) Q_UNUSED(peerAddress) Q_UNUSED(peerPort)
+    Q_UNUSED(identity) Q_UNUSED(userName) Q_UNUSED(localAddress) Q_UNUSED(localPort) Q_UNUSED(peerAddress) Q_UNUSED(peerPort)
     return true;
 }
 

--- a/src/core/oidentdconfiggenerator.h
+++ b/src/core/oidentdconfiggenerator.h
@@ -62,8 +62,8 @@ public:
     ~OidentdConfigGenerator();
 
 public slots:
-    bool addSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
-    bool removeSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
+    bool addSocket(const CoreIdentity *identity, const QString userName, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
+    bool removeSocket(const CoreIdentity *identity, const QString userName, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
 
 private:
     bool init();

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -268,6 +268,20 @@ UserId PostgreSqlStorage::getUserId(const QString &user)
     }
 }
 
+QString PostgreSqlStorage::getUserName(const UserId userId)
+{
+    QSqlQuery query(logDb());
+    query.prepare(queryString("select_username"));
+    query.bindValue(":userid", userId.toInt());
+    safeExec(query);
+
+    if(query.first()) {
+        return query.value(0).toString();
+    }
+    else {
+        return QString();
+    }
+}
 
 UserId PostgreSqlStorage::internalUser()
 {

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -53,6 +53,7 @@ public slots:
     virtual void renameUser(UserId user, const QString &newName);
     virtual UserId validateUser(const QString &user, const QString &password);
     virtual UserId getUserId(const QString &username);
+    virtual QString getUserName(const UserId userId);
     virtual UserId internalUser();
     virtual void delUser(UserId user);
     virtual void setUserSetting(UserId userId, const QString &settingName, const QVariant &data);

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -57,6 +57,7 @@
     <file>./SQL/PostgreSQL/16/select_senderid.sql</file>
     <file>./SQL/PostgreSQL/16/select_servers_for_network.sql</file>
     <file>./SQL/PostgreSQL/16/select_user_setting.sql</file>
+    <file>./SQL/PostgreSQL/16/select_username.sql</file>
     <file>./SQL/PostgreSQL/16/select_userid.sql</file>
     <file>./SQL/PostgreSQL/16/setup_000_quasseluser.sql</file>
     <file>./SQL/PostgreSQL/16/setup_010_sender.sql</file>
@@ -167,6 +168,7 @@
     <file>./SQL/SQLite/17/select_persistent_channels.sql</file>
     <file>./SQL/SQLite/17/select_servers_for_network.sql</file>
     <file>./SQL/SQLite/17/select_user_setting.sql</file>
+    <file>./SQL/SQLite/17/select_username.sql</file>
     <file>./SQL/SQLite/17/select_userid.sql</file>
     <file>./SQL/SQLite/17/setup_000_quasseluser.sql</file>
     <file>./SQL/SQLite/17/setup_010_sender.sql</file>

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -231,6 +231,26 @@ UserId SqliteStorage::getUserId(const QString &username)
     return userId;
 }
 
+QString SqliteStorage::getUserName(const UserId userId)
+{
+    QString userName;
+
+    {
+        QSqlQuery query(logDb());
+        query.prepare(queryString("select_username"));
+        query.bindValue(":userid", userId.toInt());
+
+        lockForRead();
+        safeExec(query);
+
+        if(query.first()) {
+            userName = query.value(0).toString();
+        }
+    }
+    unlock();
+
+    return userName;
+}
 
 UserId SqliteStorage::internalUser()
 {

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -54,6 +54,7 @@ public slots:
     virtual void renameUser(UserId user, const QString &newName);
     virtual UserId validateUser(const QString &user, const QString &password);
     virtual UserId getUserId(const QString &username);
+    virtual QString getUserName(const UserId userId);
     virtual UserId internalUser();
     virtual void delUser(UserId user);
     virtual void setUserSetting(UserId userId, const QString &settingName, const QVariant &data);

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -124,6 +124,12 @@ public slots:
      */
     virtual UserId getUserId(const QString &username) = 0;
 
+    //! Get the corresponding username to a given UserId
+    /** \param userId The UserId to get the UserName for
+     *  \return The username corresponding to the UserId
+     */
+    virtual QString getUserName(const UserId userId) = 0;
+
     //! Determine the UserId of the internal user
     /** \return A valid UserId if the password matches the username; 0 else
      */


### PR DESCRIPTION
Added a command-line option --oidentd-forceuser to force all ident responses to be the quassel username of the connecting user, ignoring the ident set in the user's active identity.

This does not effect the username sent on login, only the ident sent.

The purpose of this option is to comply with network requirements for an ident unique to the actual user connecting be sent, such as QuakeNet's 'Trust' system, and I know others have the same requirement for their core. I've been running a version of this patch for quite some time on my core (and now this patch) as well as on a test core without any issues.

(This is an updated version of PR #38)