### PR TITLE
Improve reliability of SSL connections.

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -44,7 +44,6 @@ CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
     _requestedUserModes('-')
 {
     _autoReconnectTimer.setSingleShot(true);
-    _socketCloseTimer.setSingleShot(true);
     connect(&_socketCloseTimer, SIGNAL(timeout()), this, SLOT(socketCloseTimeout()));
 
     setPingInterval(networkConfig()->pingInterval());
@@ -182,6 +181,8 @@ void CoreNetwork::connectToIrc(bool reconnecting)
     else {
         socket.setProxy(QNetworkProxy::NoProxy);
     }
+    
+    enablePingTimeout();
 
 #ifdef HAVE_SSL
     socket.setProtocol((QSsl::SslProtocol)server.sslVersion);
@@ -446,8 +447,6 @@ void CoreNetwork::socketInitialized()
     }
 
     emit socketInitialized(identity, localAddress(), localPort(), peerAddress(), peerPort());
-
-    enablePingTimeout();
 
     // TokenBucket to avoid sending too much at once
     _messageDelay = 2200;  // this seems to be a safe value (2.2 seconds delay)

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -174,7 +174,7 @@ private slots:
     void socketHasData();
     void socketError(QAbstractSocket::SocketError);
     void socketInitialized();
-    inline void socketCloseTimeout() { socket.disconnectFromHost(); }
+    inline void socketCloseTimeout() { socket.abort(); }
     void socketDisconnected();
     void socketStateChanged(QAbstractSocket::SocketState);
     void networkInitialized();


### PR DESCRIPTION
First, this fixes a bug similar to Bug #1249 except for SSL
connections.  If the TCP connection fails but isn't
actually closed before the SSL handshake is complete,
Quassel will become stuck and never attempt to reconnect.
The solution is to start the ping timeout even earlier,
before the connection is established at all.

Second, this fixes the issue where multiple presses of the
"Disconnect" button and long waits were required to close
certain broken SSL connections (where SSL negotiation was
not yet complete, as above).  The solution is to call
socket.abort() instead of socket.disconnectFromHost(),
which will ensure that the socket is closed immediately.
Additionally, in case that fails for some reason, the
socketCloseTimer is no longer a single-shot timer, so
if the first abort doesn't work, it will keep trying.

(Probably?) fixes bug #1005
