### PR TITLE
Fix notifications when minimized.

### DIFF
--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -657,7 +657,7 @@ void MainWin::removeBufferView(int bufferViewConfigId)
 
 void MainWin::bufferViewToggled(bool enabled)
 {
-    if (!enabled && !isVisible()) {
+    if (!enabled && !isMinimized()) {
         // hiding the mainwindow triggers a toggle of the bufferview (which pretty much sucks big time)
         // since this isn't our fault and we can't do anything about it, we suppress the resulting calls
         return;


### PR DESCRIPTION
QWidget::isVisible() just checks if the widget has been explicitly
hidden, not if it is minimized, covered, or whatnot.

Fixes #1240
