### PR TITLE
Add option for chat monitor to use backlog

### DIFF
--- a/src/qtui/chatmonitorfilter.cpp
+++ b/src/qtui/chatmonitorfilter.cpp
@@ -40,6 +40,7 @@ ChatMonitorFilter::ChatMonitorFilter(MessageModel *model, QObject *parent)
     QString operationModeSettingsId = "OperationMode";
     QString buffersSettingsId = "Buffers";
     QString showBacklogSettingsId = "ShowBacklog";
+    QString includeReadSettingsId = "IncludeRead";
 
     _showHighlights = viewSettings.value(showHighlightsSettingsId, false).toBool();
     _operationMode = viewSettings.value(operationModeSettingsId, 0).toInt();
@@ -47,11 +48,13 @@ ChatMonitorFilter::ChatMonitorFilter(MessageModel *model, QObject *parent)
     foreach(QVariant v, viewSettings.value(buffersSettingsId, QVariant()).toList())
     _bufferIds << v.value<BufferId>();
     _showBacklog = viewSettings.value(showBacklogSettingsId, true).toBool();
+    _includeRead = viewSettings.value(includeReadSettingsId, true).toBool();
 
     viewSettings.notify(showHighlightsSettingsId, this, SLOT(showHighlightsSettingChanged(const QVariant &)));
     viewSettings.notify(operationModeSettingsId, this, SLOT(operationModeSettingChanged(const QVariant &)));
     viewSettings.notify(buffersSettingsId, this, SLOT(buffersSettingChanged(const QVariant &)));
     viewSettings.notify(showBacklogSettingsId, this, SLOT(showBacklogSettingChanged(const QVariant &)));
+    viewSettings.notify(includeReadSettingsId, this, SLOT(includeReadSettingChanged(const QVariant &)));
 }
 
 
@@ -63,8 +66,8 @@ bool ChatMonitorFilter::filterAcceptsRow(int sourceRow, const QModelIndex &sourc
     BufferId bufferId = source_index.data(MessageModel::BufferIdRole).value<BufferId>();
 
     Message::Flags flags = (Message::Flags)source_index.data(MessageModel::FlagsRole).toInt();
-    if ((flags & Message::Backlog) && (!_showBacklog ||
-	    (Client::networkModel()->lastSeenMsgId(bufferId) >= sourceModel()->data(source_index, MessageModel::MsgIdRole).value<MsgId>())))
+    if ((flags & Message::Backlog) && (!_showBacklog || (!_includeRead &&
+	    (Client::networkModel()->lastSeenMsgId(bufferId) >= sourceModel()->data(source_index, MessageModel::MsgIdRole).value<MsgId>()))))
 	    return false;
 
     if (!_showOwnMessages && flags & Message::Self)
@@ -196,4 +199,8 @@ void ChatMonitorFilter::buffersSettingChanged(const QVariant &newValue)
 
 void ChatMonitorFilter::showBacklogSettingChanged(const QVariant &newValue) {
 	_showBacklog = newValue.toBool();
+}
+
+void ChatMonitorFilter::includeReadSettingChanged(const QVariant &newValue) {
+	_includeRead = newValue.toBool();
 }

--- a/src/qtui/chatmonitorfilter.h
+++ b/src/qtui/chatmonitorfilter.h
@@ -59,6 +59,7 @@ private slots:
     void operationModeSettingChanged(const QVariant &newValue);
     void buffersSettingChanged(const QVariant &newValue);
     void showBacklogSettingChanged(const QVariant &newValue);
+    void includeReadSettingChanged(const QVariant &newValue);
 
 private:
     int _showFields;
@@ -67,6 +68,7 @@ private:
     bool _showHighlights;
     int _operationMode;
     bool _showBacklog;
+    bool _includeRead;
 };
 
 

--- a/src/qtui/settingspages/chatmonitorsettingspage.cpp
+++ b/src/qtui/settingspages/chatmonitorsettingspage.cpp
@@ -64,6 +64,7 @@ ChatMonitorSettingsPage::ChatMonitorSettingsPage(QWidget *parent)
     connect(ui.showHighlights, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
     connect(ui.showOwnMessages, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
     connect(ui.showBacklog, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
+    connect(ui.includeRead, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
 }
 
 
@@ -81,6 +82,7 @@ void ChatMonitorSettingsPage::defaults()
     settings["Buffers"] = QVariant();
     settings["Default"] = true;
     settings["ShowBacklog"] = true;
+    settings["IncludeRead"] = false;
     load();
     widgetHasChanged();
 }
@@ -98,6 +100,7 @@ void ChatMonitorSettingsPage::load()
     ui.showHighlights->setChecked(settings["ShowHighlights"].toBool());
     ui.showOwnMessages->setChecked(settings["ShowOwnMsgs"].toBool());
     ui.showBacklog->setChecked(settings["ShowBacklog"].toBool());
+    ui.includeRead->setChecked(settings["IncludeRead"].toBool());
 
     // get all available buffer Ids
     QList<BufferId> allBufferIds = Client::networkModel()->allBufferIds();
@@ -131,6 +134,7 @@ void ChatMonitorSettingsPage::loadSettings()
     settings["ShowOwnMsgs"] = chatViewSettings.value("ShowOwnMsgs", false);
     settings["Buffers"] = chatViewSettings.value("Buffers", QVariantList());
     settings["ShowBacklog"] = chatViewSettings.value("ShowBacklog", true);
+    settings["IncludeRead"] = chatViewSettings.value("IncludeRead", true);
 }
 
 
@@ -142,6 +146,7 @@ void ChatMonitorSettingsPage::save()
     chatViewSettings.setValue("ShowHighlights", ui.showHighlights->isChecked());
     chatViewSettings.setValue("ShowOwnMsgs", ui.showOwnMessages->isChecked());
     chatViewSettings.setValue("ShowBacklog", ui.showBacklog->isChecked());
+    chatViewSettings.setValue("IncludeRead", ui.includeRead->isChecked());
 
     // save list of active buffers
     QVariantList saveableBufferIdList;
@@ -169,6 +174,10 @@ bool ChatMonitorSettingsPage::testHasChanged()
     if (settings["ShowHighlights"].toBool() != ui.showHighlights->isChecked())
         return true;
     if (settings["ShowOwnMsgs"].toBool() != ui.showOwnMessages->isChecked())
+        return true;
+    if (settings["ShowBacklog"].toBool() != ui.showBacklog->isChecked())
+        return true;
+    if (settings["IncludeRead"].toBool() != ui.includeRead->isChecked())
         return true;
 
     if (_configActive->bufferList().count() != settings["Buffers"].toList().count())

--- a/src/qtui/settingspages/chatmonitorsettingspage.ui
+++ b/src/qtui/settingspages/chatmonitorsettingspage.ui
@@ -168,6 +168,36 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>16</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="includeRead">
+       <property name="toolTip">
+        <string>Include read messages from backlog on reconnect</string>
+       </property>
+       <property name="text">
+        <string>Include read messages</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -185,7 +215,16 @@ p, li { white-space: pre-wrap; }
   <tabstop>activeBuffers</tabstop>
   <tabstop>showHighlights</tabstop>
   <tabstop>showOwnMessages</tabstop>
+  <tabstop>showBacklog</tabstop>
+  <tabstop>includeRead</tabstop>
  </tabstops>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>showBacklog</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>includeRead</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
Will show valid messages from the backlog in the chat monitor if the "Show messages from backlog" option is set in the Chat Monitor configuration page.

The second commit adds an option to include read messages in the chat monitor when it uses the backlog.

As per the comments on https://github.com/quassel/quassel/pull/44 I've applied the patch linked from http://bugs.quassel-irc.org/issues/734 directly, then fixed the merge conflicts caused due to style changes.
