### PR TITLE
Save Main ToolBar state when not built against KDE. Fixes #1116

### DIFF
--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -1016,7 +1016,7 @@ void MainWin::setupToolBars()
     QtUi::toolBarActionProvider()->addActions(_mainToolBar, ToolBarActionProvider::MainToolBar);
     _toolbarMenu->addAction(_mainToolBar->toggleViewAction());
 
-#ifndef HAVE_KDE
+#ifdef Q_WS_MAC
     QtUiSettings uiSettings;
 
     bool visible = uiSettings.value("ShowMainToolBar", QVariant(true)).toBool();
@@ -1025,7 +1025,7 @@ void MainWin::setupToolBars()
 #endif
 }
 
-#ifndef HAVE_KDE
+#ifdef Q_WS_MAC
 void MainWin::saveMainToolBarStatus(bool enabled)
 {
     QtUiSettings uiSettings;

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -154,7 +154,7 @@ private slots:
 
     void saveMenuBarStatus(bool enabled);
     void saveStatusBarStatus(bool enabled);
-#ifndef HAVE_KDE
+#ifdef Q_WS_MAC
     void saveMainToolBarStatus(bool enabled);
 #endif
 


### PR DESCRIPTION
Tested on OSX.
