### PR TITLE
Only create the regular expression for content/sender matches once.

### DIFF
--- a/src/common/ignorelistmanager.cpp
+++ b/src/common/ignorelistmanager.cpp
@@ -23,7 +23,6 @@
 #include <QtCore>
 #include <QDebug>
 #include <QStringList>
-#include <QRegExp>
 
 INIT_SYNCABLE_OBJECT(IgnoreListManager)
 IgnoreListManager &IgnoreListManager::operator=(const IgnoreListManager &other)
@@ -145,19 +144,13 @@ IgnoreListManager::StrictnessType IgnoreListManager::_match(const QString &msgCo
             else
                 str = msgSender;
 
-            QRegExp ruleRx = QRegExp(item.ignoreRule);
-            ruleRx.setCaseSensitivity(Qt::CaseInsensitive);
-            if (!item.isRegEx) {
-                ruleRx.setPatternSyntax(QRegExp::Wildcard);
-            }
-
 //      qDebug() << "IgnoreListManager::match: ";
 //      qDebug() << "string: " << str;
 //      qDebug() << "pattern: " << ruleRx.pattern();
 //      qDebug() << "scopeRule: " << item.scopeRule;
 //      qDebug() << "now testing";
-            if ((!item.isRegEx && ruleRx.exactMatch(str)) ||
-                (item.isRegEx && ruleRx.indexIn(str) != -1)) {
+            if ((!item.isRegEx && item.regEx.exactMatch(str)) ||
+                (item.isRegEx && item.regEx.indexIn(str) != -1)) {
 //        qDebug() << "MATCHED!";
                 return item.strictness;
             }

--- a/src/common/ignorelistmanager.h
+++ b/src/common/ignorelistmanager.h
@@ -22,6 +22,7 @@
 #define IGNORELISTMANAGER_H
 
 #include <QString>
+#include <QRegExp>
 
 #include "message.h"
 #include "syncableobject.h"
@@ -60,10 +61,16 @@ public:
         ScopeType scope;
         QString scopeRule;
         bool isActive;
+        QRegExp regEx;
         IgnoreListItem() {}
         IgnoreListItem(IgnoreType type_, const QString &ignoreRule_, bool isRegEx_, StrictnessType strictness_,
             ScopeType scope_, const QString &scopeRule_, bool isActive_)
-            : type(type_), ignoreRule(ignoreRule_), isRegEx(isRegEx_), strictness(strictness_), scope(scope_), scopeRule(scopeRule_), isActive(isActive_)  {}
+            : type(type_), ignoreRule(ignoreRule_), isRegEx(isRegEx_), strictness(strictness_), scope(scope_), scopeRule(scopeRule_), isActive(isActive_), regEx(ignoreRule_) {
+            regEx.setCaseSensitivity(Qt::CaseInsensitive);
+            if (!isRegEx_) {
+                regEx.setPatternSyntax(QRegExp::Wildcard);
+            }
+        }
         bool operator!=(const IgnoreListItem &other)
         {
             return (type != other.type ||


### PR DESCRIPTION
I have moved the regex creation into the IgnoreListItem and that seems to have sped up the process of initally filling new buffers. However, there is still a noticable delay.

http://bugs.quassel-irc.org/issues/1227
