### PR TITLE
Add button to toggle Joins/Parts/Quits with a single click.

### DIFF
--- a/src/uisupport/contextmenuactionprovider.cpp
+++ b/src/uisupport/contextmenuactionprovider.cpp
@@ -44,6 +44,7 @@ ContextMenuActionProvider::ContextMenuActionProvider(QObject *parent) : NetworkM
     registerAction(BufferRemove, tr("Delete Chat(s)..."));
     registerAction(BufferSwitchTo, tr("Go to Chat"));
 
+    registerAction(HideJoinPartQuit, tr("Joins/Parts/Quits"));
     registerAction(HideJoin, tr("Joins"), true);
     registerAction(HidePart, tr("Parts"), true);
     registerAction(HideQuit, tr("Quits"), true);
@@ -92,6 +93,8 @@ ContextMenuActionProvider::ContextMenuActionProvider(QObject *parent) : NetworkM
     registerAction(ShowIgnoreList, tr("Show Ignore List"));
 
     QMenu *hideEventsMenu = new QMenu();
+    hideEventsMenu->addAction(action(HideJoinPartQuit));
+    hideEventsMenu->addSeparator();
     hideEventsMenu->addAction(action(HideJoin));
     hideEventsMenu->addAction(action(HidePart));
     hideEventsMenu->addAction(action(HideQuit));

--- a/src/uisupport/networkmodelcontroller.cpp
+++ b/src/uisupport/networkmodelcontroller.cpp
@@ -307,6 +307,19 @@ void NetworkModelController::handleHideAction(ActionType type, QAction *action)
 {
     Q_UNUSED(action)
 
+    if (type == HideJoinPartQuit) {
+        bool anyChecked = NetworkModelController::action(HideJoin)->isChecked();
+        anyChecked |= NetworkModelController::action(HidePart)->isChecked();
+        anyChecked |= NetworkModelController::action(HideQuit)->isChecked();
+
+        // If any are checked, uncheck them all.
+        // If none are checked, check them all.
+        bool newCheckedState = !anyChecked;
+        NetworkModelController::action(HideJoin)->setChecked(newCheckedState);
+        NetworkModelController::action(HidePart)->setChecked(newCheckedState);
+        NetworkModelController::action(HideQuit)->setChecked(newCheckedState);
+    }
+
     int filter = 0;
     if (NetworkModelController::action(HideJoin)->isChecked())
         filter |= Message::Join | Message::NetsplitJoin;
@@ -324,6 +337,7 @@ void NetworkModelController::handleHideAction(ActionType type, QAction *action)
         filter |= Message::Topic;
 
     switch (type) {
+    case HideJoinPartQuit:
     case HideJoin:
     case HidePart:
     case HideQuit:

--- a/src/uisupport/networkmodelcontroller.h
+++ b/src/uisupport/networkmodelcontroller.h
@@ -64,6 +64,7 @@ public:
         HideMode = 0x0500,
         HideDayChange = 0x0600,
         HideTopic = 0x0700,
+        HideJoinPartQuit = 0xd00,
         HideUseDefaults = 0xe00,
         HideApplyToAll = 0xf00,
 


### PR DESCRIPTION
Added to the top of the context menu along with a separator underneath.

![](http://i.imgur.com/RNn54gW.png)

From a users perspective, separating the 3 events is quite silly. Parts/Quits should probably be merged together probably as well.

Couldn't find any issues for this on the tracker.