### PR TITLE
Disable webpreview to avoid user interactaction

### DIFF
--- a/src/qtui/webpreviewitem.cpp
+++ b/src/qtui/webpreviewitem.cpp
@@ -36,6 +36,7 @@ WebPreviewItem::WebPreviewItem(const QUrl &url)
     QWebView *webView = new QWebView;
     webView->settings()->setAttribute(QWebSettings::JavascriptEnabled, false);
     webView->load(url);
+    webView->setDisabled(true);
     webView->resize(1000, 750);
     QGraphicsProxyWidget *proxyItem = new QGraphicsProxyWidget(this);
     proxyItem->setWidget(webView);


### PR DESCRIPTION
If the user interacts with the webview, for instance click a button or type text in it, it crashes the client.

Disable the webview so we still get the previews but can't interact with them.
