### PR TITLE
Use a Unicode string instead of the escaped version.

### DIFF
--- a/src/qtui/chatscene.cpp
+++ b/src/qtui/chatscene.cpp
@@ -818,7 +818,7 @@ void ChatScene::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 
         QString searchSelectionText = selection();
         if (searchSelectionText.length() > _webSearchSelectionTextMaxVisible)
-            searchSelectionText = searchSelectionText.left(_webSearchSelectionTextMaxVisible).append(QString::fromUtf8("\u2026"));
+            searchSelectionText = searchSelectionText.left(_webSearchSelectionTextMaxVisible).append(QString::fromUtf8("…"));
         searchSelectionText = tr("Search '%1'").arg(searchSelectionText);
 
         menu.addAction(SmallIcon("edit-find"), searchSelectionText, this, SLOT(webSearchOnSelection()));


### PR DESCRIPTION
Compiling with MSVC Doesn't like unicode literals here.

Fixes:

![](http://i.imgur.com/hl0yXd8.png)
