### PR TITLE
Allow for clients to negotiate whether compression is used.

### DIFF
--- a/src/client/clientauthhandler.h
+++ b/src/client/clientauthhandler.h
@@ -21,6 +21,7 @@
 #ifndef CLIENTAUTHHANDLER_H
 #define CLIENTAUTHHANDLER_H
 
+#include "compressor.h"
 #include "authhandler.h"
 #include "coreaccount.h"
 

--- a/src/common/peerfactory.cpp
+++ b/src/common/peerfactory.cpp
@@ -33,23 +33,23 @@ PeerFactory::ProtoList PeerFactory::supportedProtocols()
 }
 
 
-RemotePeer *PeerFactory::createPeer(const ProtoDescriptor &protocol, AuthHandler *authHandler, QTcpSocket *socket, QObject *parent)
+RemotePeer *PeerFactory::createPeer(const ProtoDescriptor &protocol, AuthHandler *authHandler, QTcpSocket *socket, Compressor::CompressionLevel level, QObject *parent)
 {
-    return createPeer(ProtoList() << protocol, authHandler, socket, parent);
+    return createPeer(ProtoList() << protocol, authHandler, socket, level, parent);
 }
 
 
-RemotePeer *PeerFactory::createPeer(const ProtoList &protocols, AuthHandler *authHandler, QTcpSocket *socket, QObject *parent)
+RemotePeer *PeerFactory::createPeer(const ProtoList &protocols, AuthHandler *authHandler, QTcpSocket *socket, Compressor::CompressionLevel level, QObject *parent)
 {
     foreach(const ProtoDescriptor &protodesc, protocols) {
         Protocol::Type proto = protodesc.first;
         quint16 features = protodesc.second;
         switch(proto) {
             case Protocol::LegacyProtocol:
-                return new LegacyPeer(authHandler, socket, parent);
+                return new LegacyPeer(authHandler, socket, level, parent);
             case Protocol::DataStreamProtocol:
                 if (DataStreamPeer::acceptsFeatures(features))
-                    return new DataStreamPeer(authHandler, socket, features, parent);
+                    return new DataStreamPeer(authHandler, socket, features, level, parent);
                 break;
             default:
                 break;

--- a/src/common/peerfactory.h
+++ b/src/common/peerfactory.h
@@ -23,6 +23,7 @@
 
 #include <QPair>
 
+#include "compressor.h"
 #include "protocol.h"
 
 class QObject;
@@ -41,8 +42,8 @@ public:
 
     static ProtoList supportedProtocols();
 
-    static RemotePeer *createPeer(const ProtoDescriptor &protocol, AuthHandler *authHandler, QTcpSocket *socket, QObject *parent = 0);
-    static RemotePeer *createPeer(const ProtoList &protocols, AuthHandler *authHandler, QTcpSocket *socket, QObject *parent = 0);
+    static RemotePeer *createPeer(const ProtoDescriptor &protocol, AuthHandler *authHandler, QTcpSocket *socket, Compressor::CompressionLevel level, QObject *parent = 0);
+    static RemotePeer *createPeer(const ProtoList &protocols, AuthHandler *authHandler, QTcpSocket *socket, Compressor::CompressionLevel level, QObject *parent = 0);
 
 };
 

--- a/src/common/protocols/datastream/datastreampeer.cpp
+++ b/src/common/protocols/datastream/datastreampeer.cpp
@@ -28,8 +28,8 @@
 
 using namespace Protocol;
 
-DataStreamPeer::DataStreamPeer(::AuthHandler *authHandler, QTcpSocket *socket, quint16 features, QObject *parent)
-    : RemotePeer(authHandler, socket, Compressor::BestCompression, parent)
+DataStreamPeer::DataStreamPeer(::AuthHandler *authHandler, QTcpSocket *socket, quint16 features, Compressor::CompressionLevel level, QObject *parent)
+    : RemotePeer(authHandler, socket, level, parent)
 {
     Q_UNUSED(features);
 }

--- a/src/common/protocols/datastream/datastreampeer.h
+++ b/src/common/protocols/datastream/datastreampeer.h
@@ -39,7 +39,7 @@ public:
         HeartBeatReply
     };
 
-    DataStreamPeer(AuthHandler *authHandler, QTcpSocket *socket, quint16 features, QObject *parent = 0);
+    DataStreamPeer(AuthHandler *authHandler, QTcpSocket *socket, quint16 features, Compressor::CompressionLevel level, QObject *parent = 0);
 
     Protocol::Type protocol() const { return Protocol::DataStreamProtocol; }
     QString protocolName() const { return "the DataStream protocol"; }

--- a/src/common/protocols/legacy/legacypeer.cpp
+++ b/src/common/protocols/legacy/legacypeer.cpp
@@ -31,8 +31,8 @@ const uint clientNeedsProtocol = protocolVersion;
 
 using namespace Protocol;
 
-LegacyPeer::LegacyPeer(::AuthHandler *authHandler, QTcpSocket *socket, QObject *parent)
-    : RemotePeer(authHandler, socket, Compressor::NoCompression, parent),
+LegacyPeer::LegacyPeer(::AuthHandler *authHandler, QTcpSocket *socket, Compressor::CompressionLevel level, QObject *parent)
+    : RemotePeer(authHandler, socket, level, parent),
     _useCompression(false)
 {
 

--- a/src/common/protocols/legacy/legacypeer.h
+++ b/src/common/protocols/legacy/legacypeer.h
@@ -37,7 +37,7 @@ public:
         HeartBeatReply
     };
 
-    LegacyPeer(AuthHandler *authHandler, QTcpSocket *socket, QObject *parent = 0);
+    LegacyPeer(AuthHandler *authHandler, QTcpSocket *socket, Compressor::CompressionLevel level, QObject *parent = 0);
 
     Protocol::Type protocol() const { return Protocol::LegacyProtocol; }
     QString protocolName() const { return "the legacy protocol"; }


### PR DESCRIPTION
Previously, streaming compression would always be used for the
datastream protocol and never for the legacy protocol, regardless
of whether the client set the compression bit during the handshake.
This patch enables negotiation of compression support and also
allows for streaming compression when using the legacy protocol
with the new handshake.

As is, this patch prevents clients with streaming compression
support but without this patch from connecting to cores with this
patch.  This problem occurs because the above-mentioned clients
never set the compression bit during the handshake, which didn't
cause a problem before because both sides unconditionally enabled
compression.  However, when connecting to a core with this patch,
such a client will request no compression and the core will
disable compression.  However, the client will still enable the
compression anyway, causing the connection to fail.
