### PR TITLE
Use autonegotiation to choose an SSL protocol.

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -185,7 +185,6 @@ void CoreNetwork::connectToIrc(bool reconnecting)
     enablePingTimeout();
 
 #ifdef HAVE_SSL
-    socket.setProtocol((QSsl::SslProtocol)server.sslVersion);
     if (server.useSsl) {
         CoreIdentity *identity = identityPtr();
         if (identity) {

--- a/src/qtui/settingspages/networkssettingspage.cpp
+++ b/src/qtui/settingspages/networkssettingspage.cpp
@@ -867,7 +867,6 @@ ServerEditDlg::ServerEditDlg(const Network::Server &server, QWidget *parent) : Q
     ui.port->setValue(server.port);
     ui.password->setText(server.password);
     ui.useSSL->setChecked(server.useSsl);
-    ui.sslVersion->setCurrentIndex(server.sslVersion);
     ui.useProxy->setChecked(server.useProxy);
     ui.proxyType->setCurrentIndex(server.proxyType == QNetworkProxy::Socks5Proxy ? 0 : 1);
     ui.proxyHost->setText(server.proxyHost);
@@ -881,7 +880,6 @@ ServerEditDlg::ServerEditDlg(const Network::Server &server, QWidget *parent) : Q
 Network::Server ServerEditDlg::serverData() const
 {
     Network::Server server(ui.host->text().trimmed(), ui.port->value(), ui.password->text(), ui.useSSL->isChecked());
-    server.sslVersion = ui.sslVersion->currentIndex();
     server.useProxy = ui.useProxy->isChecked();
     server.proxyType = ui.proxyType->currentIndex() == 0 ? QNetworkProxy::Socks5Proxy : QNetworkProxy::HttpProxy;
     server.proxyHost = ui.proxyHost->text();

--- a/src/qtui/settingspages/servereditdlg.ui
+++ b/src/qtui/settingspages/servereditdlg.ui
@@ -120,52 +120,6 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>SSL Version:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="sslVersion">
-           <property name="toolTip">
-            <string>Do not change unless you're going to connect to a server not supporting SSLv3!</string>
-           </property>
-           <item>
-            <property name="text">
-             <string>SSLv3 (default)</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>SSLv2</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>TLSv1</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
         <widget class="QGroupBox" name="useProxy">
          <property name="title">
           <string>Use a Proxy</string>
@@ -309,7 +263,6 @@
   <tabstop>port</tabstop>
   <tabstop>password</tabstop>
   <tabstop>useSSL</tabstop>
-  <tabstop>sslVersion</tabstop>
   <tabstop>useProxy</tabstop>
   <tabstop>proxyType</tabstop>
   <tabstop>proxyHost</tabstop>


### PR DESCRIPTION
Previously, the user manually configured which SSL protocol to use
when connecting to IRC.  The default was SSLv3.  A better idea is
to allow Qt to automatically negotiate the best protocol out of
the available secure protocols, which this patch implements.
