### PR TITLE
Fix URL regex

### DIFF
--- a/src/uisupport/clickable.cpp
+++ b/src/uisupport/clickable.cpp
@@ -55,7 +55,7 @@ ClickableList ClickableList::fromString(const QString &str)
     // For matching URLs
     static QString scheme("(?:(?:mailto:|(?:[+.-]?\\w)+://)|www(?=\\.\\S+\\.))");
     static QString authority("(?:(?:[,.;@:]?[-\\w]+)+\\.?|\\[[0-9a-f:.]+\\])(?::\\d+)?");
-    static QString urlChars("(?:[,.;:]*[\\w~@/?&=+$()!%#*{}\\[\\]\\|'^-])");
+    static QString urlChars("(?:[,.;:]*[\\w~@/?&=+$()!%#*-])");
     static QString urlEnd("(?:>|[,.;:\"]*\\s|\\b|$)");
 
     static QRegExp regExp[] = {


### PR DESCRIPTION
Removes unwise characters from URL regex. These characters should be percent escaped according to RFC 2396.

Fixes [#1243](http://bugs.quassel-irc.org/issues/1243)
