### PR TITLE
Move preset networks handling out of Network

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SOURCES
     networkevent.cpp
     peer.cpp
     peerfactory.cpp
+    presetnetworks.cpp
     quassel.cpp
     remotepeer.cpp
     settings.cpp

--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -18,16 +18,13 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#include <QSettings>
 #include <QTextCodec>
 
 #include "network.h"
-#include "quassel.h"
 
 QTextCodec *Network::_defaultCodecForServer = 0;
 QTextCodec *Network::_defaultCodecForEncoding = 0;
 QTextCodec *Network::_defaultCodecForDecoding = 0;
-QString Network::_networksIniPath = QString();
 
 // ====================
 //  Public:
@@ -477,73 +474,6 @@ QByteArray Network::encodeServerString(const QString &string) const
         return _defaultCodecForServer->fromUnicode(string);
     }
     return string.toLatin1();
-}
-
-
-/*** Handle networks.ini ***/
-
-QStringList Network::presetNetworks(bool onlyDefault)
-{
-    // lazily find the file, make sure to not call one of the other preset functions first (they'll fail else)
-    if (_networksIniPath.isNull()) {
-        _networksIniPath = Quassel::findDataFilePath("networks.ini");
-        if (_networksIniPath.isNull()) {
-            _networksIniPath = ""; // now we won't check again, as it's not null anymore
-            return QStringList();
-        }
-    }
-    if (!_networksIniPath.isEmpty()) {
-        QSettings s(_networksIniPath, QSettings::IniFormat);
-        QStringList networks = s.childGroups();
-        if (!networks.isEmpty()) {
-            // we sort the list case-insensitive
-            QMap<QString, QString> sorted;
-            foreach(QString net, networks) {
-                if (onlyDefault && !s.value(QString("%1/Default").arg(net)).toBool())
-                    continue;
-                sorted[net.toLower()] = net;
-            }
-            return sorted.values();
-        }
-    }
-    return QStringList();
-}
-
-
-QStringList Network::presetDefaultChannels(const QString &networkName)
-{
-    if (_networksIniPath.isEmpty()) // be sure to have called presetNetworks() first, else this always fails
-        return QStringList();
-    QSettings s(_networksIniPath, QSettings::IniFormat);
-    return s.value(QString("%1/DefaultChannels").arg(networkName)).toStringList();
-}
-
-
-NetworkInfo Network::networkInfoFromPreset(const QString &networkName)
-{
-    NetworkInfo info;
-    if (!_networksIniPath.isEmpty()) {
-        info.networkName = networkName;
-        QSettings s(_networksIniPath, QSettings::IniFormat);
-        s.beginGroup(info.networkName);
-        foreach(QString server, s.value("Servers").toStringList()) {
-            bool ssl = false;
-            QStringList splitserver = server.split(':', QString::SkipEmptyParts);
-            if (splitserver.count() != 2) {
-                qWarning() << "Invalid server entry in networks.conf:" << server;
-                continue;
-            }
-            if (splitserver[1].at(0) == '+')
-                ssl = true;
-            uint port = splitserver[1].toUInt();
-            if (!port) {
-                qWarning() << "Invalid port entry in networks.conf:" << server;
-                continue;
-            }
-            info.serverList << Network::Server(splitserver[0].trimmed(), port, QString(), ssl);
-        }
-    }
-    return info;
 }
 
 

--- a/src/common/network.h
+++ b/src/common/network.h
@@ -213,10 +213,6 @@ public :
     inline bool autoAwayActive() const { return _autoAwayActive; }
     inline void setAutoAwayActive(bool active) { _autoAwayActive = active; }
 
-    static QStringList presetNetworks(bool onlyDefault = false);
-    static QStringList presetDefaultChannels(const QString &networkName);
-    static NetworkInfo networkInfoFromPreset(const QString &networkName);
-
 public slots:
     void setNetworkName(const QString &networkName);
     void setCurrentServer(const QString &currentServer);
@@ -371,8 +367,6 @@ private:
     static QTextCodec *_defaultCodecForDecoding;
 
     bool _autoAwayActive; // when this is active handle305 and handle306 don't trigger any output
-
-    static QString _networksIniPath;
 
     friend class IrcUser;
     friend class IrcChannel;

--- a/src/common/presetnetworks.cpp
+++ b/src/common/presetnetworks.cpp
@@ -1,0 +1,93 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2014 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include <QSettings>
+
+#include "presetnetworks.h"
+#include "quassel.h"
+
+QString PresetNetworks::_networksIniPath = QString();
+
+// ====================
+//  Public:
+// ====================
+QStringList PresetNetworks::names(bool onlyDefault)
+{
+    // lazily find the file, make sure to not call one of the other preset functions first (they'll fail else)
+    if (_networksIniPath.isNull()) {
+        _networksIniPath = Quassel::findDataFilePath("networks.ini");
+        if (_networksIniPath.isNull()) {
+            _networksIniPath = ""; // now we won't check again, as it's not null anymore
+            return QStringList();
+        }
+    }
+    if (!_networksIniPath.isEmpty()) {
+        QSettings s(_networksIniPath, QSettings::IniFormat);
+        QStringList networks = s.childGroups();
+        if (!networks.isEmpty()) {
+            // we sort the list case-insensitive
+            QMap<QString, QString> sorted;
+            foreach(QString net, networks) {
+                if (onlyDefault && !s.value(QString("%1/Default").arg(net)).toBool())
+                    continue;
+                sorted[net.toLower()] = net;
+            }
+            return sorted.values();
+        }
+    }
+    return QStringList();
+}
+
+
+QStringList PresetNetworks::defaultChannels(const QString &networkName)
+{
+    if (_networksIniPath.isEmpty()) // be sure to have called presetNetworks() first, else this always fails
+        return QStringList();
+    QSettings s(_networksIniPath, QSettings::IniFormat);
+    return s.value(QString("%1/DefaultChannels").arg(networkName)).toStringList();
+}
+
+
+NetworkInfo PresetNetworks::networkInfo(const QString &networkName)
+{
+    NetworkInfo info;
+    if (!_networksIniPath.isEmpty()) {
+        info.networkName = networkName;
+        QSettings s(_networksIniPath, QSettings::IniFormat);
+        s.beginGroup(info.networkName);
+        foreach(QString server, s.value("Servers").toStringList()) {
+            bool ssl = false;
+            QStringList splitserver = server.split(':', QString::SkipEmptyParts);
+            if (splitserver.count() != 2) {
+                qWarning() << "Invalid server entry in networks.conf:" << server;
+                continue;
+            }
+            if (splitserver[1].at(0) == '+')
+                ssl = true;
+            uint port = splitserver[1].toUInt();
+            if (!port) {
+                qWarning() << "Invalid port entry in networks.conf:" << server;
+                continue;
+            }
+            info.serverList << Network::Server(splitserver[0].trimmed(), port, QString(), ssl);
+        }
+    }
+    return info;
+}

--- a/src/common/presetnetworks.h
+++ b/src/common/presetnetworks.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2014 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#ifndef PRESETNETWORKS_H
+#define PRESETNETWORKS_H
+
+#include <QString>
+#include <QStringList>
+
+#include "network.h"
+
+class PresetNetworks
+{
+public:
+    static QStringList names(bool onlyDefault = false);
+    static QStringList defaultChannels(const QString &networkName);
+    static NetworkInfo networkInfo(const QString &networkName);
+
+private:
+    static QString _networksIniPath;
+};
+
+#endif

--- a/src/qtui/ircconnectionwizard.cpp
+++ b/src/qtui/ircconnectionwizard.cpp
@@ -23,6 +23,7 @@
 #include "client.h"
 #include "identityeditwidget.h"
 #include "simplenetworkeditor.h"
+#include "presetnetworks.h"
 
 #include <QVBoxLayout>
 
@@ -143,12 +144,12 @@ NetworkPage::NetworkPage(QWidget *parent)
     : QWizardPage(parent),
     _networkEditor(new SimpleNetworkEditor(this))
 {
-    QStringList defaultNets = Network::presetNetworks(true);
+    QStringList defaultNets = PresetNetworks::names(true);
     if (!defaultNets.isEmpty()) {
-        NetworkInfo info = Network::networkInfoFromPreset(defaultNets[0]);
+        NetworkInfo info = PresetNetworks::networkInfo(defaultNets[0]);
         if (!info.networkName.isEmpty()) {
             _networkInfo = info;
-            _channelList = Network::presetDefaultChannels(defaultNets[0]);
+            _channelList = PresetNetworks::defaultChannels(defaultNets[0]);
         }
     }
 

--- a/src/qtui/settingspages/networkssettingspage.cpp
+++ b/src/qtui/settingspages/networkssettingspage.cpp
@@ -28,6 +28,7 @@
 #include "iconloader.h"
 #include "identity.h"
 #include "network.h"
+#include "presetnetworks.h"
 #include "settingspagedlg.h"
 #include "util.h"
 
@@ -786,7 +787,7 @@ NetworkAddDlg::NetworkAddDlg(const QStringList &exist, QWidget *parent) : QDialo
     ui.useSSL->setIcon(SmallIcon("document-encrypt"));
 
     // read preset networks
-    QStringList networks = Network::presetNetworks();
+    QStringList networks = PresetNetworks::names();
     foreach(QString s, existing)
     networks.removeAll(s);
     if (networks.count())
@@ -810,7 +811,7 @@ NetworkInfo NetworkAddDlg::networkInfo() const
         return info;
     }
     else
-        return Network::networkInfoFromPreset(ui.presetList->currentText());
+        return PresetNetworks::networkInfo(ui.presetList->currentText());
 }
 
 


### PR DESCRIPTION
This moves highly application specific functionality out of Network
and makes it possible to re-use Quassel's code base for implementing
the Quassel protocol in external applications.
