### PR TITLE
Revert "Use the raster rendering engine by default on OSX"

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -57,11 +57,6 @@ int main(int argc, char **argv)
     QCoreApplication::setOrganizationName(Quassel::buildInfo().organizationName);
     QCoreApplication::setOrganizationDomain(Quassel::buildInfo().organizationDomain);
 
-    // on OSX with Qt4, raster seems to fix performance issues
-#if QT_VERSION < 0x050000 && defined Q_OS_MAC && !defined BUILD_CORE
-    QApplication::setGraphicsSystem("raster");
-#endif
-
     // We need to explicitly initialize the required resources when linking statically
 #ifndef BUILD_QTUI
     Q_INIT_RESOURCE(sql);


### PR DESCRIPTION
This reverts commit 22c5ee283d275d03e86250ed214ac91868b8de26.
The commit unfortunately caused low-quality on Retina displays.

Another idea would be to check if the display is retina and fallback to raster if that's not the case. I could not find a clean and simple way to do that. See also https://blog.qt.digia.com/blog/2013/04/25/retina-display-support-for-mac-os-ios-and-x11/
