### PR TITLE
DataStreamPeer: add missing include <QDataStream>

### DIFF
--- a/src/common/protocols/datastream/datastreampeer.cpp
+++ b/src/common/protocols/datastream/datastreampeer.cpp
@@ -19,7 +19,7 @@
  ***************************************************************************/
 
 #include <QtEndian>
-
+#include <QDataStream>
 #include <QHostAddress>
 #include <QTcpSocket>
 


### PR DESCRIPTION
When DataStreamPeer sources are used "standalone" ie. included to an external project:

```
datastreampeer.cpp: In member function 'virtual void DataStreamPeer::processMessage(const QByteArray&)':
datastreampeer.cpp:58:27: error: variable 'QDataStream stream' has initializer but incomplete type
datastreampeer.cpp:59:23: error: incomplete type 'QDataStream' used in nested name specifier
datastreampeer.cpp:62:28: error: incomplete type 'QDataStream' used in nested name specifier
datastreampeer.cpp: In member function 'void DataStreamPeer::writeMessage(const QVariantList&)':
datastreampeer.cpp:91:26: error: variable 'QDataStream msgStream' has initializer but incomplete type
datastreampeer.cpp:92:26: error: incomplete type 'QDataStream' used in nested name specifier
```
