### PR TITLE
signalproxy.h: add missing forward declaration of QIODevice

### DIFF
--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -27,6 +27,7 @@
 #include "protocol.h"
 
 struct QMetaObject;
+class QIODevice;
 
 class Peer;
 class SyncableObject;


### PR DESCRIPTION
When SignalProxy sources are used "standalone" ie. included to an external project:

```
In file included from moc_signalproxy.cpp:9:0:
signalproxy.h:139:34: error: 'QIODevice' has not been declared
```
