### PR TITLE
Fix problems with single character line endings

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -411,7 +411,10 @@ void CoreNetwork::socketHasData()
 {
     while (socket.canReadLine()) {
         QByteArray s = socket.readLine();
-        s.chop(2);
+        if (s.endsWith("\r\n"))
+            s.chop(2);
+        else if (s.endsWith("\n"))
+            s.chop(1);
         NetworkDataEvent *event = new NetworkDataEvent(EventManager::NetworkIncoming, this, s);
 #if QT_VERSION >= 0x040700
         event->setTimestamp(QDateTime::currentDateTimeUtc());


### PR DESCRIPTION
Some IRC servers just send LF line endings instead of CR-LF. Though not RFC compliant this should be handled by quassel. Quassel now checks if the line sent by the server ends with CR-LF or just LF and chops accordingly.
Fixes #1267
