### PR TITLE
Add a "local" display-only command

### DIFF
--- a/src/core/coreuserinputhandler.cpp
+++ b/src/core/coreuserinputhandler.cpp
@@ -549,6 +549,16 @@ void CoreUserInputHandler::handlePing(const BufferInfo &bufferInfo, const QStrin
 }
 
 
+void CoreUserInputHandler::handlePrint(const BufferInfo &bufferInfo, const QString &msg)
+{
+    if (bufferInfo.bufferName().isEmpty() || !bufferInfo.acceptsRegularMessages())
+        return;  // server buffer
+
+    QByteArray encMsg = channelEncode(bufferInfo.bufferName(), msg);
+    emit displayMsg(Message::Info, bufferInfo.type(), bufferInfo.bufferName(), msg, network()->myNick(), Message::Self);
+}
+
+
 // TODO: implement queries
 void CoreUserInputHandler::handleQuery(const BufferInfo &bufferInfo, const QString &msg)
 {

--- a/src/core/coreuserinputhandler.h
+++ b/src/core/coreuserinputhandler.h
@@ -62,6 +62,7 @@ public slots:
     void handleHalfop(const BufferInfo& bufferInfo, const QString &nicks);
     void handlePart(const BufferInfo &bufferInfo, const QString &text);
     void handlePing(const BufferInfo &bufferInfo, const QString &text);
+    void handlePrint(const BufferInfo &bufferInfo, const QString &text);
     void handleQuery(const BufferInfo &bufferInfo, const QString &text);
     void handleQuit(const BufferInfo &bufferInfo, const QString &text);
     void handleQuote(const BufferInfo &bufferInfo, const QString &text);


### PR DESCRIPTION
It's part of feature #1281:
It's a command named "local" which will only display something on current buffer with type Info, without sending anything to the server.