### PR TITLE
Fix nick on 001 RPL_WELCOME over a bouncer

### DIFF
--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -480,14 +480,10 @@ void CoreSessionEventProcessor::processKeyEvent(KeyEvent *e)
 
 
 /* RPL_WELCOME */
-void CoreSessionEventProcessor::processIrcEvent001(IrcEvent *e)
+void CoreSessionEventProcessor::processIrcEvent001(IrcEventNumeric *e)
 {
-    if (!checkParamCount(e, 1))
-        return;
-
-    QString myhostmask = e->params().at(0).section(' ', -1, -1);
     e->network()->setCurrentServer(e->prefix());
-    e->network()->setMyNick(nickFromMask(myhostmask));
+    e->network()->setMyNick(e->target());
 }
 
 

--- a/src/core/coresessioneventprocessor.h
+++ b/src/core/coresessioneventprocessor.h
@@ -63,7 +63,7 @@ public:
     Q_INVOKABLE void processKeyEvent(KeyEvent *event);
 #endif
 
-    Q_INVOKABLE void processIrcEvent001(IrcEvent *event);          // RPL_WELCOME
+    Q_INVOKABLE void processIrcEvent001(IrcEventNumeric *event);   // RPL_WELCOME
     Q_INVOKABLE void processIrcEvent005(IrcEvent *event);          // RPL_ISUPPORT
     Q_INVOKABLE void processIrcEvent221(IrcEvent *event);          // RPL_UMODEIS
     Q_INVOKABLE void processIrcEvent250(IrcEvent *event);          // RPL_STATSCONN


### PR DESCRIPTION
Fixes http://bugs.quassel-irc.org/issues/1020 by using the event target as nick
