### PR TITLE
LegacyPeer: kill the dependency to Quassel::buildInfo()

### DIFF
--- a/src/common/protocol.h
+++ b/src/common/protocol.h
@@ -80,12 +80,12 @@ struct ClientDenied : public HandshakeMessage
 
 struct ClientRegistered : public HandshakeMessage
 {
-    inline ClientRegistered(quint32 coreFeatures, bool coreConfigured, const QVariantList &backendInfo, bool sslSupported, const QDateTime &coreStartTime)
+    inline ClientRegistered(quint32 coreFeatures, bool coreConfigured, const QVariantList &backendInfo, bool sslSupported, const QString &coreInfo)
     : coreFeatures(coreFeatures)
     , coreConfigured(coreConfigured)
     , backendInfo(backendInfo)
     , sslSupported(sslSupported)
-    , coreStartTime(coreStartTime)
+    , coreInfo(coreInfo)
     {}
 
     quint32 coreFeatures;
@@ -94,7 +94,7 @@ struct ClientRegistered : public HandshakeMessage
 
     // this is only used by the LegacyProtocol in compat mode
     bool sslSupported;
-    QDateTime coreStartTime;
+    QString coreInfo;
 };
 
 

--- a/src/common/protocols/datastream/datastreampeer.cpp
+++ b/src/common/protocols/datastream/datastreampeer.cpp
@@ -124,7 +124,7 @@ void DataStreamPeer::handleHandshakeMessage(const QVariantList &mapData)
     }
 
     else if (msgType == "ClientInitAck") {
-        handle(ClientRegistered(m["CoreFeatures"].toUInt(), m["Configured"].toBool(), m["StorageBackends"].toList(), false, QDateTime())); // SupportsSsl and coreStartTime obsolete
+        handle(ClientRegistered(m["CoreFeatures"].toUInt(), m["Configured"].toBool(), m["StorageBackends"].toList(), false, QString())); // SupportsSsl and coreInfo obsolete
     }
 
     else if (msgType == "CoreSetupData") {

--- a/src/common/protocols/legacy/legacypeer.cpp
+++ b/src/common/protocols/legacy/legacypeer.cpp
@@ -19,10 +19,10 @@
  ***************************************************************************/
 
 #include <QHostAddress>
+#include <QDataStream>
 #include <QTcpSocket>
 
 #include "legacypeer.h"
-#include "quassel.h"
 
 /* version.inc is no longer used for this */
 const uint protocolVersion = 10;
@@ -170,7 +170,7 @@ void LegacyPeer::handleHandshakeMessage(const QVariant &msg)
             socket()->setProperty("UseCompression", true);
 #endif
 
-        handle(ClientRegistered(m["CoreFeatures"].toUInt(), m["Configured"].toBool(), m["StorageBackends"].toList(), m["SupportSsl"].toBool(), QDateTime()));
+        handle(ClientRegistered(m["CoreFeatures"].toUInt(), m["Configured"].toBool(), m["StorageBackends"].toList(), m["SupportSsl"].toBool(), QString()));
     }
 
     else if (msgType == "CoreSetupData") {
@@ -249,15 +249,7 @@ void LegacyPeer::dispatch(const ClientRegistered &msg) {
     m["SupportsCompression"] = socket()->property("UseCompression").toBool(); // this property gets already set in the ClientInit handler
 
     // This is only used for old v10 clients (pre-0.5)
-    int uptime = msg.coreStartTime.secsTo(QDateTime::currentDateTime().toUTC());
-    int updays = uptime / 86400; uptime %= 86400;
-    int uphours = uptime / 3600; uptime %= 3600;
-    int upmins = uptime / 60;
-    m["CoreInfo"] = tr("<b>Quassel Core Version %1</b><br>"
-                       "Built: %2<br>"
-                       "Up %3d%4h%5m (since %6)").arg(Quassel::buildInfo().fancyVersionString)
-                       .arg(Quassel::buildInfo().buildDate)
-                       .arg(updays).arg(uphours, 2, 10, QChar('0')).arg(upmins, 2, 10, QChar('0')).arg(msg.coreStartTime.toString(Qt::TextDate));
+    m["CoreInfo"] = msg.coreInfo;
 
     m["LoginEnabled"] = m["Configured"] = msg.coreConfigured;
 

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -169,8 +169,18 @@ void CoreAuthHandler::handle(const RegisterClient &msg)
     if (!configured)
         backends = Core::backendInfo();
 
-    // useSsl and startTime are only used for the legacy protocol
-    _peer->dispatch(ClientRegistered(Quassel::features(), configured, backends, useSsl, Core::instance()->startTime()));
+    int uptime = Core::instance()->startTime().secsTo(QDateTime::currentDateTime().toUTC());
+    int updays = uptime / 86400; uptime %= 86400;
+    int uphours = uptime / 3600; uptime %= 3600;
+    int upmins = uptime / 60;
+    QString coreInfo = tr("<b>Quassel Core Version %1</b><br>"
+                          "Built: %2<br>"
+                          "Up %3d%4h%5m (since %6)").arg(Quassel::buildInfo().fancyVersionString)
+                          .arg(Quassel::buildInfo().buildDate)
+                          .arg(updays).arg(uphours, 2, 10, QChar('0')).arg(upmins, 2, 10, QChar('0')).arg(Core::instance()->startTime().toString(Qt::TextDate));
+
+    // useSsl and coreInfo are only used for the legacy protocol
+    _peer->dispatch(ClientRegistered(Quassel::features(), configured, backends, useSsl, coreInfo));
 
     if (_legacy && useSsl)
         startSsl();


### PR DESCRIPTION
This makes LegacyPeer usable outside Quassel (IRC for Sailfish)
