### PR TITLE
Fix MainToolBar visibility not saving in OSX

### DIFF
--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -1025,13 +1025,15 @@ void MainWin::setupToolBars()
 #endif
 }
 
-#ifdef Q_OS_MAC
 void MainWin::saveMainToolBarStatus(bool enabled)
 {
+#ifdef Q_OS_MAC
     QtUiSettings uiSettings;
     uiSettings.setValue("ShowMainToolBar", enabled);
-}
+#else
+    Q_UNUSED(enabled);
 #endif
+}
 
 
 void MainWin::connectedToCore()

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -154,9 +154,7 @@ private slots:
 
     void saveMenuBarStatus(bool enabled);
     void saveStatusBarStatus(bool enabled);
-#ifdef Q_OS_MAC
     void saveMainToolBarStatus(bool enabled);
-#endif
 
     void loadLayout();
     void saveLayout();


### PR DESCRIPTION
The current code, although completely valid, doesn't work due to moc not seeing built in defines. See;
https://bugreports.qt-project.org/browse/QTBUG-34593
