### PR TITLE
Use null QVariant instead of "ALL" for select limit on psql

### DIFF
--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1516,7 +1516,7 @@ QList<Message> PostgreSqlStorage::requestMsgs(UserId user, BufferId bufferId, Ms
     if (limit != -1)
         params << limit;
     else
-        params << "ALL";
+        params << QVariant(QVariant::Int);
 
     QSqlQuery query = executePreparedQuery(queryName, params, db);
 


### PR DESCRIPTION
Using "ALL" as it was before was making PostgreSQL error out when
attempting to return backlog for Quasseldroid when Quasseldroid is
in "Unread messages per chat" mode.  According to
http://www.postgresql.org/docs/9.3/static/queries-limit.html,
LIMIT NULL is the same thing as having no LIMIT at all.  According
to http://qt-project.org/doc/qt-4.8/qsqlquery.html, NULL values
are bound in Qt SQL prepared statements by using a null QVariant.
