### PR TITLE
Improve the odds of winning the oidentd race when using SSL for IRC

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -82,7 +82,7 @@ CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
     connect(this, SIGNAL(newEvent(Event *)), coreSession()->eventManager(), SLOT(postEvent(Event *)));
 
     if (Quassel::isOptionSet("oidentd")) {
-        connect(this, SIGNAL(socketInitialized(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(addSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Qt::BlockingQueuedConnection);
+        connect(this, SIGNAL(socketConnected(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(addSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Qt::BlockingQueuedConnection);
         connect(this, SIGNAL(socketDisconnected(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(removeSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)));
     }
 }
@@ -444,6 +444,15 @@ void CoreNetwork::socketError(QAbstractSocket::SocketError error)
 
 void CoreNetwork::socketInitialized()
 {
+    CoreIdentity *identity = identityPtr();
+    if (!identity) {
+        qCritical() << "Identity invalid!";
+        disconnectFromIrc();
+        return;
+    }
+    
+    emit socketConnected(identity, localAddress(), localPort(), peerAddress(), peerPort());
+    
     Server server = usedServer();
 #ifdef HAVE_SSL
     if (server.useSsl && !socket.isEncrypted())
@@ -452,12 +461,6 @@ void CoreNetwork::socketInitialized()
 #if QT_VERSION >= 0x040600
     socket.setSocketOption(QAbstractSocket::KeepAliveOption, true);
 #endif
-    CoreIdentity *identity = identityPtr();
-    if (!identity) {
-        qCritical() << "Identity invalid!";
-        disconnectFromIrc();
-        return;
-    }
 
     emit socketInitialized(identity, localAddress(), localPort(), peerAddress(), peerPort());
 

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -157,6 +157,7 @@ signals:
     void sslErrors(const QVariant &errorData);
 
     void newEvent(Event *event);
+    void socketConnected(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
     void socketInitialized(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
     void socketDisconnected(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
 


### PR DESCRIPTION
Previously, the .oidentd.conf file was not written until
socketInitialized(), which meant that when using SSL for the IRC
connection, the file would not be written until the SSL negotiation
was complete.  This delay meant that, in practice, oidentd
integration almost never worked when using SSL IRC connections.
This patch adds a new socketConnected() signal that fires as soon
as the connection is open, regardless of encryption status, and
connects the call to the oidentd configuration generator to this
signal.  This gives oidentd integration the same likelihood of
working with SSL connections as with non-SSL connections.
