### PR TITLE
Web Search Updates

### DIFF
--- a/src/qtui/chatscene.cpp
+++ b/src/qtui/chatscene.cpp
@@ -832,7 +832,8 @@ void ChatScene::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
             searchSelectionText = searchSelectionText.left(_webSearchSelectionTextMaxVisible).append(QString::fromUtf8("…"));
         searchSelectionText = tr("Search '%1'").arg(searchSelectionText);
 
-        menu.addAction(QIcon::fromTheme("edit-find"), searchSelectionText, this, SLOT(webSearchOnSelection()));
+        QAction *webSearchAction = new Action(SmallIcon("edit-find"), searchSelectionText, &menu, this, SLOT(webSearchOnSelection()));
+        menu.insertAction(sep, webSearchAction);
     }
 
     if (QtUi::mainWindow()->menuBar()->isHidden())


### PR DESCRIPTION
Noticed this quirk after you froze code for the last version.

-----

> Move websearch from botton of context menu to underneath copy selection.

It seems the 'Copy Selection' button got moved between when the patch
was made and when it finally got applied. Got missed during the merge.

![](http://i.imgur.com/ncia5wx.png) vs ![](http://i.imgur.com/152dCv1.png)

[Was menu.addAction(SmallIcon("edit-copy") in the PR](https://github.com/quassel/quassel/pull/13/files#diff-509e92fe0be2c90a578793222ac75e2cL803)

[menu.insertAction(sep, act); by the time it got merged](quassel@d30eb50#diff-509e92fe0be2c90a578793222ac75e2cL815)
