### PR TITLE
Do not emit messages if storing them in the DB failed

### DIFF
--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -321,8 +321,8 @@ void CoreSession::processMessages()
             bufferInfo = Core::bufferInfo(user(), rawMsg.networkId, BufferInfo::StatusBuffer, "");
         }
         Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender, rawMsg.flags);
-        Core::storeMessage(msg);
-        emit displayMsg(msg);
+        if(Core::storeMessage(msg))
+            emit displayMsg(msg);
     }
     else {
         QHash<NetworkId, QHash<QString, BufferInfo> > bufferInfoCache;
@@ -364,10 +364,11 @@ void CoreSession::processMessages()
             messages << msg;
         }
 
-        Core::storeMessages(messages);
-        // FIXME: extend protocol to a displayMessages(MessageList)
-        for (int i = 0; i < messages.count(); i++) {
-            emit displayMsg(messages[i]);
+        if(Core::storeMessages(messages)) {
+            // FIXME: extend protocol to a displayMessages(MessageList)
+            for (int i = 0; i < messages.count(); i++) {
+                emit displayMsg(messages[i]);
+            }
         }
     }
     _processMessages = false;


### PR DESCRIPTION
If a message is not stored in the database, then some of its IDs
(networkId at least) will be invalid.  If this message is sent to
clients, it will cause a nameless empty buffer to appear in the
desktop client and will cause Quasseldroid to crash (of course.)
Better behavior would be to simply not emit the message, since it
can't be displayed properly anyway.
