### PR TITLE
Set initial focus to host input widget.

### DIFF
--- a/src/qtui/settingspages/networkssettingspage.cpp
+++ b/src/qtui/settingspages/networkssettingspage.cpp
@@ -865,6 +865,7 @@ ServerEditDlg::ServerEditDlg(const Network::Server &server, QWidget *parent) : Q
     ui.setupUi(this);
     ui.useSSL->setIcon(SmallIcon("document-encrypt"));
     ui.host->setText(server.host);
+    ui.host->setFocus();
     ui.port->setValue(server.port);
     ui.password->setText(server.password);
     ui.useSSL->setChecked(server.useSsl);


### PR DESCRIPTION
When adding a new server, setting the initial focus to the host input widget speeds up the process by a lot.