### PR TITLE
Implement password changing from client.

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -48,6 +48,7 @@
 #include "quassel.h"
 #include "signalproxy.h"
 #include "util.h"
+#include "clientauthhandler.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -151,6 +152,8 @@ void Client::init()
     p->attachSignal(this, SIGNAL(requestRemoveNetwork(NetworkId)), SIGNAL(removeNetwork(NetworkId)));
     p->attachSlot(SIGNAL(networkCreated(NetworkId)), this, SLOT(coreNetworkCreated(NetworkId)));
     p->attachSlot(SIGNAL(networkRemoved(NetworkId)), this, SLOT(coreNetworkRemoved(NetworkId)));
+
+    p->attachSignal(this, SIGNAL(clientChangePassword(QString)));
 
     //connect(mainUi(), SIGNAL(connectToCore(const QVariantMap &)), this, SLOT(connectToCore(const QVariantMap &)));
     connect(mainUi(), SIGNAL(disconnectFromCore()), this, SLOT(disconnectFromCore()));
@@ -643,6 +646,13 @@ void Client::markBufferAsRead(BufferId id)
 {
     if (bufferSyncer() && id.isValid())
         bufferSyncer()->requestMarkBufferAsRead(id);
+}
+
+void Client::changePassword(QString newPassword) {
+    CoreAccount account = currentCoreAccount();
+    account.setPassword(newPassword);
+    coreAccountModel()->createOrUpdateAccount(account);
+    emit clientChangePassword(newPassword);
 }
 
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -153,8 +153,6 @@ void Client::init()
     p->attachSlot(SIGNAL(networkCreated(NetworkId)), this, SLOT(coreNetworkCreated(NetworkId)));
     p->attachSlot(SIGNAL(networkRemoved(NetworkId)), this, SLOT(coreNetworkRemoved(NetworkId)));
 
-    p->attachSignal(this, SIGNAL(clientChangePassword(QString)));
-
     //connect(mainUi(), SIGNAL(connectToCore(const QVariantMap &)), this, SLOT(connectToCore(const QVariantMap &)));
     connect(mainUi(), SIGNAL(disconnectFromCore()), this, SLOT(disconnectFromCore()));
     connect(this, SIGNAL(connected()), mainUi(), SLOT(connectedToCore()));
@@ -386,32 +384,39 @@ void Client::setSyncedToCore()
     connect(bufferSyncer(), SIGNAL(buffersPermanentlyMerged(BufferId, BufferId)), _messageModel, SLOT(buffersPermanentlyMerged(BufferId, BufferId)));
     connect(bufferSyncer(), SIGNAL(bufferMarkedAsRead(BufferId)), SIGNAL(bufferMarkedAsRead(BufferId)));
     connect(networkModel(), SIGNAL(requestSetLastSeenMsg(BufferId, MsgId)), bufferSyncer(), SLOT(requestSetLastSeenMsg(BufferId, const MsgId &)));
-    signalProxy()->synchronize(bufferSyncer());
+
+    SignalProxy *p = signalProxy();
+
+    if ((Client::coreFeatures() & Quassel::PasswordChange)) {
+        p->attachSignal(this, SIGNAL(clientChangePassword(QString)));
+    }
+
+    p->synchronize(bufferSyncer());
 
     // create a new BufferViewManager
     Q_ASSERT(!_bufferViewManager);
-    _bufferViewManager = new ClientBufferViewManager(signalProxy(), this);
+    _bufferViewManager = new ClientBufferViewManager(p, this);
     connect(_bufferViewManager, SIGNAL(initDone()), _bufferViewOverlay, SLOT(restore()));
 
     // create AliasManager
     Q_ASSERT(!_aliasManager);
     _aliasManager = new ClientAliasManager(this);
     connect(aliasManager(), SIGNAL(initDone()), SLOT(sendBufferedUserInput()));
-    signalProxy()->synchronize(aliasManager());
+    p->synchronize(aliasManager());
 
     // create NetworkConfig
     Q_ASSERT(!_networkConfig);
     _networkConfig = new NetworkConfig("GlobalNetworkConfig", this);
-    signalProxy()->synchronize(networkConfig());
+    p->synchronize(networkConfig());
 
     // create IgnoreListManager
     Q_ASSERT(!_ignoreListManager);
     _ignoreListManager = new ClientIgnoreListManager(this);
-    signalProxy()->synchronize(ignoreListManager());
+    p->synchronize(ignoreListManager());
 
     Q_ASSERT(!_transferManager);
     _transferManager = new ClientTransferManager(this);
-    signalProxy()->synchronize(transferManager());
+    p->synchronize(transferManager());
 
     // trigger backlog request once all active bufferviews are initialized
     connect(bufferViewOverlay(), SIGNAL(initDone()), this, SLOT(requestInitialBacklog()));

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -191,6 +191,8 @@ signals:
      */
     void bufferMarkedAsRead(BufferId id);
 
+    void clientChangePassword(QString password);
+
 public slots:
     void disconnectFromCore();
 
@@ -199,6 +201,8 @@ public slots:
     void buffersPermanentlyMerged(BufferId bufferId1, BufferId bufferId2);
 
     void markBufferAsRead(BufferId id);
+
+    void changePassword(QString newPassword);
 
 private slots:
     void setSyncedToCore();

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -71,8 +71,9 @@ public:
         SaslAuthentication = 0x0002,
         SaslExternal = 0x0004,
         HideInactiveNetworks = 0x0008,
+        PasswordChange = 0x0010,
 
-        NumFeatures = 0x0008
+        NumFeatures = 0x0010
     };
     Q_DECLARE_FLAGS(Features, Feature);
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -662,6 +662,7 @@ SessionThread *Core::createSession(UserId uid, bool restore)
     SessionThread *sess = new SessionThread(uid, restore, this);
     sessions[uid] = sess;
     sess->start();
+    connect(sess, SIGNAL(passwordChangeRequested(UserId, QString)), _storage, SLOT(updateUser(UserId, QString)));
     return sess;
 }
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -524,6 +524,8 @@ private slots:
     void socketError(QAbstractSocket::SocketError err, const QString &errorString);
     void setupClientSession(RemotePeer *, UserId);
 
+    void changeUserPass(const QString &username);
+
 private:
     Core();
     ~Core();
@@ -541,7 +543,6 @@ private:
     void unregisterStorageBackend(Storage *);
     bool selectBackend(const QString &backend);
     void createUser();
-    void changeUserPass(const QString &username);
     void saveBackendSettings(const QString &backend, const QVariantMap &settings);
     QVariantMap promptForSettings(const Storage *storage);
 

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -100,6 +100,8 @@ CoreSession::CoreSession(UserId uid, bool restoreState, QObject *parent)
     p->attachSlot(SIGNAL(createNetwork(const NetworkInfo &, const QStringList &)), this, SLOT(createNetwork(const NetworkInfo &, const QStringList &)));
     p->attachSlot(SIGNAL(removeNetwork(NetworkId)), this, SLOT(removeNetwork(NetworkId)));
 
+    p->attachSlot(SIGNAL(clientChangePassword(QString)), this, SLOT(changePassword(QString)));
+
     loadSettings();
     initScriptEngine();
 
@@ -637,4 +639,9 @@ void CoreSession::globalAway(const QString &msg)
 
         net->userInputHandler()->issueAway(msg, false /* no force away */);
     }
+}
+
+void CoreSession::changePassword(QString password)
+{
+    emit passwordChangeRequested(_user, password);
 }

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -132,6 +132,8 @@ public slots:
     //! Marks us away (or unaway) on all networks
     void globalAway(const QString &msg = QString());
 
+    void changePassword(QString password);
+
 signals:
     void initialized();
     void sessionState(const Protocol::SessionState &sessionState);
@@ -157,6 +159,8 @@ signals:
     void networkCreated(NetworkId);
     void networkRemoved(NetworkId);
     void networkDisconnected(NetworkId);
+
+    void passwordChangeRequested(UserId user, QString password);
 
 protected:
     virtual void customEvent(QEvent *event);

--- a/src/core/sessionthread.cpp
+++ b/src/core/sessionthread.cpp
@@ -121,6 +121,7 @@ void SessionThread::addInternalClientToSession(InternalPeer *internalPeer)
 void SessionThread::run()
 {
     _session = new CoreSession(user(), _restoreState);
+    connect(_session, SIGNAL(passwordChangeRequested(UserId, QString)), SIGNAL(passwordChangeRequested(UserId, QString)));
     connect(this, SIGNAL(addRemoteClient(RemotePeer*)), _session, SLOT(addClient(RemotePeer*)));
     connect(this, SIGNAL(addInternalClient(InternalPeer*)), _session, SLOT(addClient(InternalPeer*)));
     connect(_session, SIGNAL(sessionState(Protocol::SessionState)), Core::instance(), SIGNAL(sessionState(Protocol::SessionState)));

--- a/src/core/sessionthread.h
+++ b/src/core/sessionthread.h
@@ -57,6 +57,8 @@ signals:
     void addRemoteClient(RemotePeer *peer);
     void addInternalClient(InternalPeer *peer);
 
+    void passwordChangeRequested(UserId user, QString newPassword);
+
 private:
     CoreSession *_session;
     UserId _user;

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -193,8 +193,6 @@ void MainWin::init()
     connect(Client::coreConnection(), SIGNAL(handleSslErrors(const QSslSocket *, bool *, bool *)), SLOT(handleSslErrors(const QSslSocket *, bool *, bool *)));
 #endif
 
-    connect(this, SIGNAL(changePassword(QString)), Client::instance(), SLOT(changePassword(QString)));
-
     // Setup Dock Areas
     setDockNestingEnabled(true);
     setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
@@ -1083,6 +1081,18 @@ void MainWin::setConnectedState()
         connect(Client::backlogManager(), SIGNAL(messagesProcessed(const QString &)), this, SLOT(showStatusBarMessage(const QString &)));
     }
 
+    disconnect(this, SIGNAL(changePassword(QString)), Client::instance(), SLOT(changePassword(QString)));
+    if (Client::internalCore()) {
+        coll->action("ChangePassword")->setVisible(false);
+    }
+    else if((Client::coreFeatures() & Quassel::PasswordChange)) {
+        connect(this, SIGNAL(changePassword(QString)), Client::instance(), SLOT(changePassword(QString)));
+        coll->action("ChangePassword")->setEnabled(true);
+    }
+    else {
+        coll->action("ChangePassword")->setEnabled(false);
+    }
+
     // _viewMenu->setEnabled(true);
     if (!Client::internalCore())
         statusBar()->showMessage(tr("Connected to core."));
@@ -1183,6 +1193,7 @@ void MainWin::setDisconnectedState()
     coll->action("ConnectCore")->setEnabled(true);
     coll->action("DisconnectCore")->setEnabled(false);
     coll->action("CoreInfo")->setEnabled(false);
+    coll->action("ChangePassword")->setEnabled(false);
     //_viewMenu->setEnabled(false);
     statusBar()->showMessage(tr("Not connected to core."));
     if (_msgProcessorStatusWidget)

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -25,6 +25,7 @@
 #include <QMessageBox>
 #include <QStatusBar>
 #include <QToolBar>
+#include <QInputDialog>
 
 #ifdef HAVE_KDE
 #  include <KAction>
@@ -191,6 +192,8 @@ void MainWin::init()
 #ifdef HAVE_SSL
     connect(Client::coreConnection(), SIGNAL(handleSslErrors(const QSslSocket *, bool *, bool *)), SLOT(handleSslErrors(const QSslSocket *, bool *, bool *)));
 #endif
+
+    connect(this, SIGNAL(changePassword(QString)), Client::instance(), SLOT(changePassword(QString)));
 
     // Setup Dock Areas
     setDockNestingEnabled(true);
@@ -406,6 +409,10 @@ void MainWin::setupActions()
   #endif
     coll->addAction("ConfigureQuassel", configureQuasselAct);
 
+    QAction *changePasswordAct = new Action(QIcon::fromTheme("dialog-password"), tr("&Change password..."), coll,
+        this, SLOT(showChangePasswordDialog()));
+    coll->addAction("ChangePassword", changePasswordAct);
+
     // Help
     QAction *aboutQuasselAct = new Action(QIcon(":/icons/quassel.png"), tr("&About Quassel"), coll,
         this, SLOT(showAboutDlg()));
@@ -548,7 +555,9 @@ void MainWin::setupMenus()
 #else
     _settingsMenu->addAction(coll->action("ConfigureShortcuts"));
 #endif
+    _settingsMenu->addAction(coll->action("ChangePassword"));
     _settingsMenu->addAction(coll->action("ConfigureQuassel"));
+
 
     _helpMenu = menuBar()->addMenu(tr("&Help"));
     _helpMenu->addAction(coll->action("AboutQuassel"));
@@ -724,6 +733,15 @@ void MainWin::changeActiveBufferView(int bufferViewId)
     }
 
     nextBufferView(); // fallback
+}
+
+void MainWin::showChangePasswordDialog()
+{
+    bool ok;
+    QString newPassword = QInputDialog::getText(this, tr("Set new password"), tr("New password:"), QLineEdit::Password, QString(), &ok);
+    if (ok && !newPassword.isEmpty()) {
+        emit changePassword(newPassword);
+    }
 }
 
 

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -164,9 +164,12 @@ private slots:
     void changeActiveBufferView(bool backwards);
     void changeActiveBufferView(int bufferViewId);
 
+    void showChangePasswordDialog();
+
 signals:
     void connectToCore(const QVariantMap &connInfo);
     void disconnectFromCore();
+    void changePassword(QString newPassword);
 
 private:
 #ifdef HAVE_KDE


### PR DESCRIPTION
Add menu item and dialog for getting a new password from the user,
signal from client to core to give the new password, and wire up the
signal on the core to change the password in the database.

Also update the stored password on the client side.

No idea if this could be simplified, it seems like a really round-about way to do it, passing the signal through a ton of classes. But it was the simplest way I could find.