### PR TITLE
Add support for compiling with QCA on Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,14 +235,12 @@ if (USE_QT5)
             DESCRIPTION "the database support module for Qt5"
         )
 
-        # While QCA2 seems to support Qt5, it is not actually co-installable or distinguishable from the Qt4 version...
-        # In order to avoid linking against the Qt4 version (which is probably the one installed), disable this for now
-        #find_package(QCA2 QUIET)
-        #set_package_properties(QCA2 PROPERTIES TYPE RECOMMENDED
-        #    URL "https://projects.kde.org/projects/kdesupport/qca"
-        #    DESCRIPTION "Qt Cryptographic Architecture"
-        #    PURPOSE "Required for encryption support"
-        #)
+        find_package(QCA2-QT5)
+        set_package_properties(QCA2-QT5 PROPERTIES TYPE RECOMMENDED
+            URL "https://projects.kde.org/projects/kdesupport/qca"
+            DESCRIPTION "Qt Cryptographic Architecture"
+            PURPOSE "Required for encryption support"
+        )
 
     endif(BUILD_CORE)
 

--- a/cmake/FindQCA2-QT5.cmake
+++ b/cmake/FindQCA2-QT5.cmake
@@ -1,0 +1,48 @@
+# - Try to find QCA2 (Qt Cryptography Architecture 2) for QT5
+# Once done this will define
+#
+#  QCA2-QT5_FOUND - system has QCA2-QT5
+#  QCA2-QT5_INCLUDE_DIR - the QCA2-QT5 include directory
+#  QCA2-QT5_LIBRARIES - the libraries needed to use QCA2-QT5
+#  QCA2-QT5_DEFINITIONS - Compiler switches required for using QCA2-QT5
+#
+# use pkg-config to get the directories and then use these values
+# in the FIND_PATH() and FIND_LIBRARY() calls
+
+# Copyright (c) 2006, Michael Larouche, <michael.larouche@kdemail.net>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+include(FindLibraryWithDebug)
+
+if (QCA2-QT5_INCLUDE_DIR AND QCA2-QT5_LIBRARIES)
+
+  # in cache already
+  set(QCA2-QT5_FOUND TRUE)
+
+else (QCA2-QT5_INCLUDE_DIR AND QCA2-QT5_LIBRARIES)
+
+
+  if (NOT WIN32)
+    find_package(PkgConfig)
+    pkg_check_modules(PC_QCA2-QT5 QUIET qca2-qt5)
+    set(QCA2-QT5_DEFINITIONS ${PC_QCA2-QT5_CFLAGS_OTHER})
+  endif (NOT WIN32)
+
+  find_library_with_debug(QCA2-QT5_LIBRARIES
+                  WIN32_DEBUG_POSTFIX d
+                  NAMES qca-qt5
+                  HINTS ${PC_QCA2-QT5_LIBDIR} ${PC_QCA2-QT5_LIBRARY_DIRS}
+                  )
+
+  find_path(QCA2-QT5_INCLUDE_DIR QtCrypto
+            HINTS ${PC_QCA2-QT5_INCLUDEDIR} ${PC_QCA2-QT5_INCLUDE_DIRS}
+            PATH_SUFFIXES QtCrypto)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(QCA2-QT5 DEFAULT_MSG QCA2-QT5_LIBRARIES QCA2-QT5_INCLUDE_DIR)
+
+  mark_as_advanced(QCA2-QT5_INCLUDE_DIR QCA2-QT5_LIBRARIES)
+
+endif (QCA2-QT5_INCLUDE_DIR AND QCA2-QT5_LIBRARIES)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -47,7 +47,7 @@ set(SOURCES
 )
 
 
-if (QCA2_FOUND)
+if (QCA2_FOUND OR QCA2-QT5_FOUND)
     set(SOURCES ${SOURCES} keyevent.cpp)
 endif()
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -54,6 +54,13 @@ if (QCA2_FOUND)
     list(APPEND LIBS ${QCA2_LIBRARIES})
 endif()
 
+if (QCA2-QT5_FOUND)
+    add_definitions(-DHAVE_QCA2)
+    include_directories(${QCA2-QT5_INCLUDE_DIR})
+    list(APPEND SOURCES cipher.cpp)
+    list(APPEND LIBS ${QCA2-QT5_LIBRARIES})
+endif()
+
 include_directories(${CMAKE_SOURCE_DIR}/src/common)
 
 set(CORE_RCS ${CORE_RCS} ${CMAKE_CURRENT_SOURCE_DIR}/sql.qrc)


### PR DESCRIPTION
The maintainer for QCA insists on adding a suffix to the QCA
libname, forcing us to make a few changes to support it.