### PR TITLE
Fix potential state desync in disconnectFromIrc()

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -232,17 +232,18 @@ void CoreNetwork::disconnectFromIrc(bool requested, const QString &reason, bool 
         _quitReason = reason;
 
     displayMsg(Message::Server, BufferInfo::StatusBuffer, "", tr("Disconnecting. (%1)").arg((!requested && !withReconnect) ? tr("Core Shutdown") : _quitReason));
-    switch (socket.state()) {
-    case QAbstractSocket::ConnectedState:
-        userInputHandler()->issueQuit(_quitReason);
+    if (socket.state() == QAbstractSocket::UnconnectedState) {
+        socketDisconnected();
+    } else {
+        if (socket.state() == QAbstractSocket::ConnectedState) {
+            userInputHandler()->issueQuit(_quitReason);
+        } else {
+            socket.close();
+        }
         if (requested || withReconnect) {
             // the irc server has 10 seconds to close the socket
             _socketCloseTimer.start(10000);
-            break;
         }
-    default:
-        socket.close();
-        socketDisconnected();
     }
 }
 


### PR DESCRIPTION
Previously, disconnectFromIrc() would assume that if the socket was
in any state other than ConnectedState that it was disconnected and
send the socketDisconnected() signal.  However, if the socket was
in a different state, such as ConnectingState, this caused the
corenetwork state and the socket state to become desynchronized.
This patch causes disconnectFromIrc() to close the socket and
start the socketCloseTimer in the event that the socket is in a
state other than UnconnectedState or ConnectedState.