### PR TITLE
Set the version of the QDataStream in ClientAuthHandler

### DIFF
--- a/src/client/clientauthhandler.cpp
+++ b/src/client/clientauthhandler.cpp
@@ -169,6 +169,7 @@ void ClientAuthHandler::onSocketConnected()
         _probing = true;
 
         QDataStream stream(socket()); // stream handles the endianness for us
+        stream.setVersion(QDataStream::Qt_4_2);
 
         quint32 magic = Protocol::magic;
 #ifdef HAVE_SSL


### PR DESCRIPTION
The QDataStream used to talk to the core is set to version Qt_4_2 everywhere except in the ClientAuthHandler. It works without problems at the moment because the ClientAuthHandler only transmits a quint32, but for consistency it makes sense to set the version here too.