### PR TITLE
set GIT_HEAD and GIT_DESCRIBE from environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,11 +555,11 @@ git_describe(GIT_DESCRIBE --long)
 # If not in a Git repo try to read GIT_HEAD and GIT_DESCRIBE from
 # enviroment
 if (NOT GIT_HEAD OR NOT GIT_DESCRIBE)
-  if (ENV_GIT_HEAD)
-      set(GIT_HEAD ${ENV_GIT_HEAD}) 
+  if (DEFINED ENV{GIT_HEAD})
+      set(GIT_HEAD ${GIT_HEAD}) 
   endif ()
-  if (ENV_GIT_DESCRIBE)
-     set(GIT_DESCRIBE ${ENV_GIT_DESCRIBE})
+  if (DEFINED ENV{GIT_DESCRIBE})
+     set(GIT_DESCRIBE ${GIT_DESCRIBE})
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,6 +552,17 @@ include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC GIT_HEAD)
 git_describe(GIT_DESCRIBE --long)
 
+# If not in a Git repo try to read GIT_HEAD and GIT_DESCRIBE from
+# enviroment
+if (NOT GIT_HEAD OR NOT GIT_DESCRIBE)
+  if (ENV_GIT_HEAD)
+      set(GIT_HEAD ${ENV_GIT_HEAD}) 
+  endif ()
+  if (ENV_GIT_DESCRIBE)
+     set(GIT_DESCRIBE ${ENV_GIT_DESCRIBE})
+  endif()
+endif()
+
 # Sanitize things if we're not in a Git repo
 if (NOT GIT_HEAD OR NOT GIT_DESCRIBE)
     set(GIT_HEAD "")


### PR DESCRIPTION
some additional cmake magic, make sense in a build chroot where the upstream repo is not available - i don't want to build git snapshots local - but i would like to have the information, what is build in the about box