### PR TITLE
Add QNetworkConfigurationManager-based connection detection

### DIFF
--- a/src/client/clientsettings.cpp
+++ b/src/client/clientsettings.cpp
@@ -252,7 +252,7 @@ CoreConnectionSettings::NetworkDetectionMode CoreConnectionSettings::networkDete
 #ifdef HAVE_KDE4
     NetworkDetectionMode def = UseSolid;
 #else
-    NetworkDetectionMode def = UsePingTimeout;
+    NetworkDetectionMode def = UseQNetworkConfigurationManager;
 #endif
     return (NetworkDetectionMode)localValue("NetworkDetectionMode", def).toInt();
 }

--- a/src/client/clientsettings.h
+++ b/src/client/clientsettings.h
@@ -125,6 +125,7 @@ class CoreConnectionSettings : public ClientSettings
 public:
     enum NetworkDetectionMode {
         UseSolid,
+        UseQNetworkConfigurationManager,
         UsePingTimeout,
         NoActiveDetection
     };

--- a/src/client/coreconnection.h
+++ b/src/client/coreconnection.h
@@ -34,6 +34,8 @@
 #  include <Solid/Networking>
 #endif
 
+#include <QNetworkConfigurationManager>
+
 #include "coreaccount.h"
 #include "remotepeer.h"
 #include "types.h"
@@ -151,6 +153,7 @@ private slots:
 #ifdef HAVE_KDE4
     void solidNetworkStatusChanged(Solid::Networking::Status status);
 #endif
+    void onlineStateChanged(bool isOnline);
 
 private:
     QPointer<ClientAuthHandler> _authHandler;
@@ -170,6 +173,8 @@ private:
 
     CoreAccount _account;
     CoreAccountModel *accountModel() const;
+
+    QPointer<QNetworkConfigurationManager> _qNetworkConfigurationManager;
 
     friend class CoreConfigWizard;
 };

--- a/src/qtui/settingspages/coreconnectionsettingspage.cpp
+++ b/src/qtui/settingspages/coreconnectionsettingspage.cpp
@@ -31,6 +31,7 @@ CoreConnectionSettingsPage::CoreConnectionSettingsPage(QWidget *parent)
     initAutoWidgets();
 
     connect(ui.useSolid, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
+    connect(ui.useQNetworkConfigurationManager, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
     connect(ui.usePingTimeout, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
     connect(ui.useNoTimeout, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
 }
@@ -52,7 +53,7 @@ void CoreConnectionSettingsPage::defaults()
 #ifdef HAVE_KDE4
     setRadioButtons(CoreConnectionSettings::UseSolid);
 #else
-    setRadioButtons(CoreConnectionSettings::UsePingTimeout);
+    setRadioButtons(CoreConnectionSettings::UseQNetworkConfigurationManager);
 #endif
 
     SettingsPage::defaults();
@@ -85,6 +86,9 @@ void CoreConnectionSettingsPage::setRadioButtons(CoreConnectionSettings::Network
         ui.useSolid->setChecked(true);
         break;
 #endif
+    case CoreConnectionSettings::UseQNetworkConfigurationManager:
+        ui.useQNetworkConfigurationManager->setChecked(true);
+        break;
     case CoreConnectionSettings::UsePingTimeout:
         ui.usePingTimeout->setChecked(true);
         break;
@@ -100,6 +104,8 @@ CoreConnectionSettings::NetworkDetectionMode CoreConnectionSettingsPage::modeFro
     if (ui.useSolid->isChecked())
         return CoreConnectionSettings::UseSolid;
 #endif
+    if (ui.useQNetworkConfigurationManager->isChecked())
+        return CoreConnectionSettings::UseQNetworkConfigurationManager;
     if (ui.usePingTimeout->isChecked())
         return CoreConnectionSettings::UsePingTimeout;
 

--- a/src/qtui/settingspages/coreconnectionsettingspage.ui
+++ b/src/qtui/settingspages/coreconnectionsettingspage.ui
@@ -34,6 +34,19 @@
        </widget>
       </item>
       <item>
+       <widget class="QRadioButton" name="useQNetworkConfigurationManager">
+        <property name="toolTip">
+         <string>Rely on Qt's network configuration manager to detect if we're online.</string>
+        </property>
+        <property name="text">
+         <string>Use Qt's network status detection (via QNetworkConfigurationManager)</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QRadioButton" name="usePingTimeout">


### PR DESCRIPTION
A new network detection mode is added to use QNetworkConfigurationManager, available in Qt4.7+ including Qt5. This becomes the default mode when KDE4 integration is not available.

CMakeLists.txt just assumes the availability of QNetworkConfigurationManager based on Qt version. I haven't figured out how to actually check it, and I don't know if it will be necessary.

I've tested that it compiles with -DUSE_QT4 or -DUSE_QT5.

By the way, Networking is not available in KF5 Solid, and [porting notes](https://community.kde.org/Frameworks/Porting_Notes#Solid_Networking) point to QNetworkConfigurationManager.