### PR TITLE
Allow buffer merge over networks.

### DIFF
--- a/src/uisupport/bufferview.cpp
+++ b/src/uisupport/bufferview.cpp
@@ -253,16 +253,12 @@ void BufferView::dropEvent(QDropEvent *event)
     if (bufferList.count() != 1)
         return QTreeView::dropEvent(event);
 
-    NetworkId networkId = bufferList[0].first;
     BufferId bufferId2 = bufferList[0].second;
 
     if (index.data(NetworkModel::ItemTypeRole) != NetworkModel::BufferItemType)
         return QTreeView::dropEvent(event);
 
     if (index.data(NetworkModel::BufferTypeRole) != BufferInfo::QueryBuffer)
-        return QTreeView::dropEvent(event);
-
-    if (index.data(NetworkModel::NetworkIdRole).value<NetworkId>() != networkId)
         return QTreeView::dropEvent(event);
 
     BufferId bufferId1 = index.data(NetworkModel::BufferIdRole).value<BufferId>();


### PR DESCRIPTION
Allows merging buffers over networks, feature request at http://bugs.quassel-irc.org/issues/1334

> As stated in Issue 83 merge is only possible with chats on the same network.
> As the usage of Bitlbee etc has increased, it would be useful to be able to merge chats across all networks as well. The issue rises as people are now using alternative methods (Facebook, Lync etc) during the day and returning to IRC in the evening.
