### PR TITLE
Don't require SSL for loopback connections with --require-ssl

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
     cliParser->addSwitch("oidentd", 0, "Enable oidentd integration");
     cliParser->addOption("oidentd-conffile", 0, "Set path to oidentd configuration file", "file");
 #ifdef HAVE_SSL
-    cliParser->addSwitch("require-ssl", 0, "Require SSL for client connections");
+    cliParser->addSwitch("require-ssl", 0, "Require SSL for remote (non-loopback) client connections");
 #endif
     cliParser->addSwitch("enable-experimental-dcc", 0, "Enable highly experimental and unfinished support for CTCP DCC (DANGEROUS)");
 #endif

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -158,7 +158,7 @@ void CoreAuthHandler::handle(const RegisterClient &msg)
     else
         useSsl = _connectionFeatures & Protocol::Encryption;
 
-    if (Quassel::isOptionSet("require-ssl") && !useSsl) {
+    if (Quassel::isOptionSet("require-ssl") && !useSsl && !_peer->isLocal()) {
         _peer->dispatch(ClientDenied(tr("<b>SSL is required!</b><br>You need to use SSL in order to connect to this core.")));
         _peer->close();
         return;


### PR DESCRIPTION
Encrypting a loopback connection is a pointless waste of computing
power.  This patch will allow people to use loopback connections
from things like quassel-webserver without encryption while still
requiring encryption for remote connections.