### PR TITLE
Increase varchar to avoid Migration-fault due to really long identities

### DIFF
--- a/src/core/SQL/PostgreSQL/16/setup_010_sender.sql
+++ b/src/core/SQL/PostgreSQL/16/setup_010_sender.sql
@@ -1,4 +1,4 @@
 CREATE TABLE sender ( -- THE SENDER OF IRC MESSAGES
        senderid serial NOT NULL PRIMARY KEY,
-       sender varchar(128) UNIQUE NOT NULL
+       sender varchar(255) UNIQUE NOT NULL
 )


### PR DESCRIPTION
Fixes http://bugs.quassel-irc.org/issues/1339

Basically, if an irc-server has a long nickname limit, you can have a really long nickname, e.g. spam of letters or symbols, Instead of giving the users whom is migrating from SQLite to PostgresSQL an error, and forcing the user to truncate the values by finding (sqlite> 'select * from sender where length(sender) > 128;') and updating.