### PR TITLE
Improve the message-splitting algorithm for PRIVMSG and CTCP Query

### DIFF
--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -92,6 +92,12 @@ public:
     inline QHostAddress peerAddress() const { return socket.peerAddress(); }
     inline quint16 localPort() const { return socket.localPort(); }
     inline quint16 peerPort() const { return socket.peerPort(); }
+    
+    enum EncodingType {
+        ServerEncoding,
+        ChannelEncoding,
+        UserEncoding
+    };
 
 public slots:
     virtual void setMyNick(const QString &mynick);

--- a/src/core/coreuserinputhandler.h
+++ b/src/core/coreuserinputhandler.h
@@ -88,7 +88,7 @@ protected:
 private:
     void doMode(const BufferInfo& bufferInfo, const QChar &addOrRemove, const QChar &mode, const QString &nickList);
     void banOrUnban(const BufferInfo &bufferInfo, const QString &text, bool ban);
-    void putPrivmsg(const QByteArray &target, const QByteArray &message, Cipher *cipher = 0);
+    void putPrivmsg(const QString &target, const QString &message, const CoreNetwork::EncodingType encodingType, Cipher *cipher = 0);
 
 #ifdef HAVE_QCA2
     QByteArray encrypt(const QString &target, const QByteArray &message, bool *didEncrypt = 0) const;


### PR DESCRIPTION
This introduces a new message splitting algorithm based on
QTextBoundaryFinder.  It works by first starting with the entire
message to be sent, encoding it, and checking to see if it is over
the maximum message length.  If it is, it uses QTBF to find the
word boundary most immediately preceding the maximum length.  If no
suitable boundary can be found, it falls back to searching for
grapheme boundaries.  It repeats this process until the entire
message has been sent.

Unlike what it replaces, the new splitting code is not recursive
and cannot cause stack overflows.  Additionally, it can detect if
it is unable to make any progress and will give up to prevent the
thread from running away.

This patch fixes two bugs.  The first is garbage characters caused
by accidentally splitting the string in the middle of a multibyte
character.  Since the new code splits at a character level instead
of a byte level, this will no longer be an issue.  The second is
the core crash caused by sending an overlength CTCP query ("/me")
containing only multibyte characters.  This bug was caused by the
old CTCP splitter using the byte index from lastParamOverrun() as
a character index for a QString.