### PR TITLE
Add back the SSL protocol selection dialog box for old cores.

### DIFF
--- a/src/client/coreconnection.h
+++ b/src/client/coreconnection.h
@@ -73,6 +73,8 @@ public:
     //! Check if we consider the last connect as reconnect
     bool wasReconnect() const { return _wasReconnect; }
 
+    QPointer<Peer> peer() { return _peer; }
+
 public slots:
     bool connectToCore(AccountId = 0);
     void reconnectToCore();

--- a/src/common/internalpeer.h
+++ b/src/common/internalpeer.h
@@ -42,6 +42,7 @@ public:
     InternalPeer(QObject *parent = 0);
     virtual ~InternalPeer();
 
+    Protocol::Type protocol() const { return Protocol::InternalProtocol; }
     QString description() const;
 
     SignalProxy *signalProxy() const;

--- a/src/common/peer.h
+++ b/src/common/peer.h
@@ -35,6 +35,7 @@ class Peer : public QObject
 public:
     Peer(AuthHandler *authHandler, QObject *parent = 0);
 
+    virtual Protocol::Type protocol() const = 0;
     virtual QString description() const = 0;
 
     virtual SignalProxy *signalProxy() const = 0;

--- a/src/common/protocol.h
+++ b/src/common/protocol.h
@@ -30,6 +30,7 @@ namespace Protocol {
 const quint32 magic = 0x42b33f00;
 
 enum Type {
+    InternalProtocol = 0x00,
     LegacyProtocol = 0x01,
     DataStreamProtocol = 0x02
 };

--- a/src/common/remotepeer.h
+++ b/src/common/remotepeer.h
@@ -45,7 +45,6 @@ public:
 
     void setSignalProxy(SignalProxy *proxy);
 
-    virtual Protocol::Type protocol() const = 0;
     virtual QString protocolName() const = 0;
     virtual QString description() const;
     virtual quint16 enabledFeatures() const { return 0; }

--- a/src/qtui/settingspages/servereditdlg.ui
+++ b/src/qtui/settingspages/servereditdlg.ui
@@ -120,6 +120,52 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>SSL Version:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="sslVersion">
+           <property name="toolTip">
+            <string>Use only TLSv1 unless you know what you are doing!</string>
+           </property>
+           <item>
+            <property name="text">
+             <string>SSLv3 (insecure)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>SSLv2 (insecure)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>TLSv1</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <widget class="QGroupBox" name="useProxy">
          <property name="title">
           <string>Use a Proxy</string>
@@ -263,6 +309,7 @@
   <tabstop>port</tabstop>
   <tabstop>password</tabstop>
   <tabstop>useSSL</tabstop>
+  <tabstop>sslVersion</tabstop>
   <tabstop>useProxy</tabstop>
   <tabstop>proxyType</tabstop>
   <tabstop>proxyHost</tabstop>


### PR DESCRIPTION
Cores before 0.10 will default to SSLv3 if the user doesn't make a
selection.  If a >=0.10 client is used with a <0.10 core to connect
to a server that has SSLv3 disabled, it is impossible to connect
to that server without upgrading the core or using an old client
to change the SSL protocol settings.

This also changes the SSLv2 and SSLv3 options to indicate their
insecurity and therefore discourage their use.

Cores from 0.10 and up use SSL autonegotiation and to not need the
protocol setting.

This partially reverts commit
e53fc69a91553b57932ba599b39999d550114588.