### PR TITLE
Update the schema creation DDL for the new password hashing

### DIFF
--- a/src/core/SQL/PostgreSQL/17/setup_000_quasseluser.sql
+++ b/src/core/SQL/PostgreSQL/17/setup_000_quasseluser.sql
@@ -1,5 +1,6 @@
 CREATE TABLE quasseluser (
        userid serial NOT NULL PRIMARY KEY,
        username varchar(64) UNIQUE NOT NULL,
-       password char(40) NOT NULL -- hex reppresentation of sha1 hashes
+       password TEXT NOT NULL,
+       hashversion integer NOT NULL DEFAULT 0
 )

--- a/src/core/SQL/SQLite/18/setup_000_quasseluser.sql
+++ b/src/core/SQL/SQLite/18/setup_000_quasseluser.sql
@@ -1,7 +1,6 @@
 CREATE TABLE quasseluser (
        userid INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
        username TEXT UNIQUE NOT NULL,
-       password TEXT NOT NULL
+       password TEXT NOT NULL,
+       hashversion INTEGER NOT NULL DEFAULT 0
 )
-
-	  


### PR DESCRIPTION
I'm not sure whether this slipped out in a merge or whether I
forgot to add it in the first place, but it should have been part
of commit 5924533c6d0f9777d38c01ed7e1510a55db2b876.  This
completely broke setting up a new Quassel instance from scratch
with 0.12-rc1, but upgrades from previous versions are unaffected.