### PR TITLE
Set the PostgreSQL session timezone to 'UTC'

### DIFF
--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -136,6 +136,14 @@ bool PostgreSqlStorage::initDbSession(QSqlDatabase &db)
         return false;
         break;
     }
+
+    // Set the PostgreSQL session timezone to UTC, since we want timestamps stored in UTC
+    QSqlQuery tzQuery = db.exec("SET timezone = 'UTC'");
+    if (tzQuery.lastError().isValid()) {
+        quError() << "Failed to set timezone to UTC!";
+        return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
With Qt5, the PostgreSQL driver will transparently convert times
to the database's timezone before inserting.  Because the default
is 'localtime', this causes the local time to be stored in the DB
instead of the UTC time.  This in turn causes the time displayed
in the client to be wrong by the same offset as that timezone's
offset.  To fix the issue, just make sure the PostgreSQL is in the
'UTC' timezone, so the passed UTC time will not be converted.