### PR TITLE
Execute initDbSession() on DB reconnects

### DIFF
--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -87,6 +87,7 @@ private slots:
 
 private:
     void addConnectionToPool();
+    void dbConnect(QSqlDatabase &db);
 
     int _schemaVersion;
     bool _debug;


### PR DESCRIPTION
Previously, the initDbSession() function would only be run on the
initial connect.  Since the initDbSession() code in PostgreSQL is
used to fix the CVE-2013-4422 SQL Injection bug, this means that
Quassel was still vulnerable to that CVE if the PostgreSQL server
is restarted or the connection is lost at any point while Quassel
is running.

This bug also causes the Qt5 psql timezone fix to stop working
after a reconnect.

The fix is to disable Qt's automatic reconnecting, check the
connection status ourselves, and reconnect if necessary, executing
the initDbSession() function afterward.