### PR TITLE
Add core options to specify path to ssl certs.

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -170,6 +170,8 @@ int main(int argc, char **argv)
     cliParser->addOption("oidentd-conffile", 0, "Set path to oidentd configuration file", "file");
 #ifdef HAVE_SSL
     cliParser->addSwitch("require-ssl", 0, "Require SSL for remote (non-loopback) client connections");
+    cliParser->addOption("ssl-cert", 0, "Specify the path to the SSL Certificate", "path", "configdir/quasselCert.pem");
+    cliParser->addOption("ssl-key", 0, "Specify the path to the SSL key", "path", "ssl-cert-path");
 #endif
     cliParser->addSwitch("enable-experimental-dcc", 0, "Enable highly experimental and unfinished support for CTCP DCC (DANGEROUS)");
 #endif

--- a/src/core/sslserver.h
+++ b/src/core/sslserver.h
@@ -49,7 +49,7 @@ protected:
     virtual void incomingConnection(int socketDescriptor);
 #endif
 
-    virtual bool setCertificate(const QString &path);
+    virtual bool setCertificate(const QString &path, const QString &keyPath);
 
 private:
     QLinkedList<QTcpSocket *> _pendingConnections;


### PR DESCRIPTION
Add option to core to specify SSL certificate and
SSL key path, --ssl-cert and --ssl-key respectively.
If not set, the 'legacy' path configdir/quasselCert.pem
will be used for the cert and the key.