### PR TITLE
Fix SQL errors caused by sender insertion from multiple threads

### DIFF
--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1381,8 +1381,7 @@ bool PostgreSqlStorage::logMessage(Message &msg)
 
         if (addSenderQuery.lastError().isValid()) {
             rollbackSavePoint("sender_sp1", db);
-            getSenderIdQuery.prepare(getSenderIdQuery.lastQuery());
-            safeExec(getSenderIdQuery);
+            getSenderIdQuery = executePreparedQuery("select_senderid", msg.sender(), db);
             watchQuery(getSenderIdQuery);
             getSenderIdQuery.first();
             senderId = getSenderIdQuery.value(0).toInt();
@@ -1452,8 +1451,7 @@ bool PostgreSqlStorage::logMessages(MessageList &msgs)
             if (addSenderQuery.lastError().isValid()) {
                 // seems it was inserted meanwhile... by a different thread
                 rollbackSavePoint("sender_sp", db);
-                selectSenderQuery.prepare(selectSenderQuery.lastQuery());
-                safeExec(selectSenderQuery);
+                selectSenderQuery = executePreparedQuery("select_senderid", sender, db);
                 watchQuery(selectSenderQuery);
                 selectSenderQuery.first();
                 senderIdList << selectSenderQuery.value(0).toInt();


### PR DESCRIPTION
At least on Qt5, the QSqlQuery.lastQuery() function, when used with
prepared queries, returns the EXECUTE statement and not the actual
query.  Qt then attempts to PREPARE this statement, which causes
a syntax error, aborting the transaction and dropping the message that
was to be inserted.  A better idea would be to execute the named
prepared query directly, which avoids the problem.