### PR TITLE
Don't embed the build date in the binary

### DIFF
--- a/src/client/clientauthhandler.cpp
+++ b/src/client/clientauthhandler.cpp
@@ -284,7 +284,8 @@ void ClientAuthHandler::startRegistration()
     useSsl = _account.useSsl();
 #endif
 
-    _peer->dispatch(RegisterClient(Quassel::buildInfo().fancyVersionString, Quassel::buildInfo().buildDate, useSsl));
+    // dummy build date for compatibility
+    _peer->dispatch(RegisterClient(Quassel::buildInfo().fancyVersionString, "Jan  1 1970 00:00:00", useSsl));
 }
 
 

--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -259,9 +259,6 @@ void Quassel::setupBuildInfo()
     _buildInfo.baseVersion = QUASSEL_VERSION_STRING;
     _buildInfo.generatedVersion = GIT_DESCRIBE;
 
-    // This will be imprecise for incremental builds not touching this file, but we really don't want to always recompile
-    _buildInfo.buildDate = QString("%1 %2").arg(__DATE__, __TIME__);
-
     // Check if we got a commit hash
     if (!QString(GIT_HEAD).isEmpty())
         _buildInfo.commitHash = GIT_HEAD;

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -48,7 +48,6 @@ public:
         QString generatedVersion;
         QString commitHash;
         uint commitDate;
-        QString buildDate;
 
         uint protocolVersion; // deprecated
 

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -174,9 +174,7 @@ void CoreAuthHandler::handle(const RegisterClient &msg)
     int uphours = uptime / 3600; uptime %= 3600;
     int upmins = uptime / 60;
     QString coreInfo = tr("<b>Quassel Core Version %1</b><br>"
-                          "Built: %2<br>"
                           "Up %3d%4h%5m (since %6)").arg(Quassel::buildInfo().fancyVersionString)
-                          .arg(Quassel::buildInfo().buildDate)
                           .arg(updays).arg(uphours, 2, 10, QChar('0')).arg(upmins, 2, 10, QChar('0')).arg(Core::instance()->startTime().toString(Qt::TextDate));
 
     // useSsl and coreInfo are only used for the legacy protocol

--- a/src/core/corecoreinfo.cpp
+++ b/src/core/corecoreinfo.cpp
@@ -37,7 +37,8 @@ QVariantMap CoreCoreInfo::coreData() const
 {
     QVariantMap data;
     data["quasselVersion"] = Quassel::buildInfo().fancyVersionString;
-    data["quasselBuildDate"] = Quassel::buildInfo().buildDate;
+    // dummy build date for compatibility
+    data["quasselBuildDate"] = "Jan  1 1970 00:00:00";
     data["startTime"] = Core::instance()->startTime();
     data["sessionConnectedClients"] = _coreSession->signalProxy()->peerCount();
     return data;

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -1088,6 +1088,6 @@ void CoreSessionEventProcessor::handleCtcpTime(CtcpEvent *e)
 
 void CoreSessionEventProcessor::handleCtcpVersion(CtcpEvent *e)
 {
-    e->setReply(QString("Quassel IRC %1 (built on %2) -- http://www.quassel-irc.org")
-        .arg(Quassel::buildInfo().plainVersionString).arg(Quassel::buildInfo().buildDate));
+    e->setReply(QString("Quassel IRC %1 -- http://www.quassel-irc.org")
+        .arg(Quassel::buildInfo().plainVersionString));
 }

--- a/src/qtui/aboutdlg.cpp
+++ b/src/qtui/aboutdlg.cpp
@@ -35,10 +35,9 @@ AboutDlg::AboutDlg(QWidget *parent)
     ui.setupUi(this);
     ui.quasselLogo->setPixmap(QIcon(":/icons/quassel-64.png").pixmap(64)); // don't let the icon theme affect our logo here
 
-    ui.versionLabel->setText(QString(tr("<b>Version:</b> %1<br><b>Protocol version:</b> %2<br><b>Built:</b> %3"))
+    ui.versionLabel->setText(QString(tr("<b>Version:</b> %1<br><b>Protocol version:</b> %2"))
         .arg(Quassel::buildInfo().fancyVersionString)
-        .arg(Quassel::buildInfo().protocolVersion)
-        .arg(Quassel::buildInfo().buildDate));
+        .arg(Quassel::buildInfo().protocolVersion));
     ui.aboutTextBrowser->setHtml(about());
     ui.authorTextBrowser->setHtml(authors());
     ui.contributorTextBrowser->setHtml(contributors());

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -38,7 +38,6 @@ CoreInfoDlg::CoreInfoDlg(QWidget *parent)
 void CoreInfoDlg::coreInfoAvailable()
 {
     ui.labelCoreVersion->setText(_coreInfo["quasselVersion"].toString());
-    ui.labelCoreBuildDate->setText(_coreInfo["quasselBuildDate"].toString());
     ui.labelClientCount->setNum(_coreInfo["sessionConnectedClients"].toInt());
     updateUptime();
     startTimer(1000);

--- a/src/qtui/ui/coreinfodlg.ui
+++ b/src/qtui/ui/coreinfodlg.ui
@@ -29,45 +29,31 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0" >
+     <item row="1" column="0" >
       <widget class="QLabel" name="label_4" >
        <property name="text" >
         <string>Uptime:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0" >
+     <item row="2" column="0" >
       <widget class="QLabel" name="label_3" >
        <property name="text" >
         <string>Connected Clients:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1" >
+     <item row="2" column="1" >
       <widget class="QLabel" name="labelClientCount" >
        <property name="text" >
         <string>&lt;connected clients></string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1" >
+     <item row="1" column="1" >
       <widget class="QLabel" name="labelUptime" >
        <property name="text" >
         <string>&lt;core uptime></string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0" >
-      <widget class="QLabel" name="label" >
-       <property name="text" >
-        <string>Build date:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1" >
-      <widget class="QLabel" name="labelCoreBuildDate" >
-       <property name="text" >
-        <string>&lt;build date></string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
For compatibility send a dummy date in the client/core handshake.

This makes it possible to create reproducible builds.

See also:
https://wiki.debian.org/ReproducibleBuilds/About