### PR TITLE
Respect WITH_WEBKIT when defining HAVE_WEBKIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,11 @@ if (USE_QT5)
                 )
             endif()
         endif()
-        add_feature_info("WITH_WEBKIT, QtWebKit and QtWebKitWidgets modules" Qt5WebKitWidgets_FOUND "Support showing previews for URLs in chat")
+
+        if (WITH_WEBKIT AND Qt5WebKitWidgets_FOUND)
+            set(HAVE_WEBKIT true)
+        endif()
+        add_feature_info("WITH_WEBKIT, QtWebKit and QtWebKitWidgets modules" HAVE_WEBKIT "Support showing previews for URLs in chat")
 
         # KDE Frameworks
         ################

--- a/src/qtui/CMakeLists.txt
+++ b/src/qtui/CMakeLists.txt
@@ -130,7 +130,7 @@ if (QT_QTDBUS_FOUND OR Qt5DBus_FOUND)
     qt_add_dbus_adaptor  (SOURCES ../../interfaces/org.kde.StatusNotifierItem.xml statusnotifieritemdbus.h StatusNotifierItemDBus)
 endif()
 
-if (QT_QTWEBKIT_FOUND OR Qt5WebKitWidgets_FOUND)
+if (HAVE_WEBKIT)
     add_definitions(-DHAVE_WEBKIT)
     list(APPEND QT_MODULES WebKit)
     if (USE_QT5)


### PR DESCRIPTION
It seems that as of 2273a95b, Webkit support is always compiled in as long as it's available, regardless of the value of WITH_WEBKIT.

I've modified the Qt 5 portion of the Webkit detection to mirror the Qt 4 logic, so HAVE_WEBKIT should always be set correctly.