### PR TITLE
Use SHA2-512 to store the core certificate digest in the client

### DIFF
--- a/src/client/clientauthhandler.h
+++ b/src/client/clientauthhandler.h
@@ -36,6 +36,12 @@ class ClientAuthHandler : public AuthHandler
 public:
     ClientAuthHandler(CoreAccount account, QObject *parent = 0);
 
+    enum DigestVersion {
+        Md5,
+        Sha2_512,
+        Latest=Sha2_512
+    };
+
 public slots:
     void connectToCore();
 
@@ -82,6 +88,10 @@ private:
     void setPeer(RemotePeer *peer);
     void checkAndEnableSsl(bool coreSupportsSsl);
     void startRegistration();
+
+#if QT_VERSION < 0x050000
+    QByteArray sha2_512(const QByteArray &input);
+#endif
 
 private slots:
     void onSocketConnected();


### PR DESCRIPTION
Previously, MD5 was used.  Like the core password hashing update,
this implements a versioning system so that the digest will be
automagically upgraded without bugging the user.  If for some
reason the user downgrades again, the client will still work but
the user will be asked to validate the certificate again.

SHA2-256 is more common for storing certificate digests, but in
this case, SHA2-512 was used.  This is because Qt4 does not
implement any hash higher than SHA1 and a SHA2-512 implementation
is already bundled for use with the core password hashing.