### PR TITLE
Keep _wantReconnect set to true by default instead of false

### DIFF
--- a/src/client/coreconnection.cpp
+++ b/src/client/coreconnection.cpp
@@ -216,6 +216,8 @@ void CoreConnection::setState(ConnectionState state)
     if (state != _state) {
         _state = state;
         emit stateChanged(state);
+        if (state == Connected)
+            _wantReconnect = true;
         if (state == Disconnected)
             emit disconnected();
     }


### PR DESCRIPTION
Previously _wantReconnect was set to false by default (unless the
client was actually disconnected).  If the disconnect() signal was
fired without any other signals (socketError(), for example), this
would cause the client to not reconnect.  This seems to be
happening rather often with Qt5 client builds because a vast
majority of the time when I restart my core (or the entire core
server), the Qt5 clients do not reconnect.  This patch keeps
_wantReconnect set to true whenever the client is connected so that
problem will not occur anymore.  Disconnecting manually will set
it back to false so that the client won't try to reconnect after
a manual disconnect.