### PR TITLE
Add support for Appvayor Windows ci.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,136 @@
+version: '{build}'
+build_script:
+- ps: |
+    if ( !(Test-Path "$env:APPVEYOR_BUILD_FOLDER\work\appveyorHelp.psm1"))
+    {
+        mkdir $env:APPVEYOR_BUILD_FOLDER\work\
+        Start-FileDownload https://raw.githubusercontent.com/TheOneRing/appVeyorHelp/master/appveyorHelp.psm1 -FileName $env:APPVEYOR_BUILD_FOLDER\work\appveyorHelp.psm1 
+    }    
+    $ErrorActionPreference="Stop"
+
+    Import-Module $env:APPVEYOR_BUILD_FOLDER\work\appveyorHelp.psm1
+
+    Init @("ninja", "png2ico", "nsis") ([ordered]@{"git://anongit.kde.org/extra-cmake-modules.git" = @{"branch" = "master"};
+                                 "https://github.com/Snorenotify/SnoreGrowl.git" = @{"branch" = "v0.4.0"; "buildType" = "Release"};
+                                 "git://anongit.kde.org/snorenotify.git" = @{"branch" = "v0.6.0"; "buildType" = "Release"}})
+
+
+    mkdir -Force $env:APPVEYOR_BUILD_FOLDER\work\build\$env:APPVEYOR_PROJECT_NAME
+    cd $env:APPVEYOR_BUILD_FOLDER\work\build\$env:APPVEYOR_PROJECT_NAME
+    LogExec cmake -G"Ninja" $env:APPVEYOR_BUILD_FOLDER -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$CMAKE_INSTALL_ROOT" -DUSE_QT5=ON -DCMAKE_DISABLE_FIND_PACKAGE_Qt5DBus=ON -DWITH_WEBKIT=OFF
+    CmakeImageInstall
+    
+    $imageDir = CreateDeployImage @(
+                            # whitelist
+                            #quassel
+                            "quassel.*",
+                            #
+                            #gccruntime",
+                            "bin\\libgomp.*\.dll",
+                            "bin\\libgcc_s_.*\.dll",
+                            "bin\\libwinpthread.*\.dll",
+                            "bin\\libstdc.*\.dll",
+                            #
+                            #snore
+                            "bin\\.*snore.*\.dll",
+                            "lib\\plugins\\libsnore.*\\libsnore_backend.*\.dll",
+                            "lib\\plugins\\libsnore.*\\libsnore_secondary_backend.*\.dll",
+                            #snorenotify 0.5
+                            "lib\\libsnore.*\\libsnore_backend.*\.dll",
+                            #
+                            "bin\\SnoreToast\.exe",
+                            #
+                            #Growl
+                            "bin\\.*snoregrowl.*\.dll",
+                            #
+                            #ssl
+                            "bin\\libeay32\.dll",
+                            "bin\\ssleay32\.dll",
+                            #
+                            #icu
+                            "bin\\icuin\d+\.dll",
+                            "bin\\icuuc\d+\.dll",
+                            "bin\\icudt\d+\.dll",
+                            #
+                            #qt
+                            "bin\\Qt5Core\.dll",
+                            "bin\\Qt5Declarative\.dll",
+                            "bin\\Qt5Gui\.dll",
+                            "bin\\Qt5Network\.dll",
+                            "bin\\Qt5Opengl\.dll",
+                            "bin\\Qt5Multimedia\.dll",
+                            "bin\\Qt5MultimediaWidgets\.dll",
+                            "bin\\Qt5Qml\.dll",
+                            "bin\\Qt5Quick\.dll",
+                            "bin\\Qt5Script\.dll",
+                            "bin\\Qt5Sql\.dll",
+                            "bin\\Qt5Widgets\.dll",
+                            "bin\\Qt5XmlPatterns\.dll",
+                            "bin\\.*libglesv2\.dll",
+                            "bin\\.*libEGL\.dll",
+                            "qml\\.*",
+                            #bin\\QtXml\.dll
+                            #
+                            "plugins\\imageformats\\(?!.*d\.dll).*\.dll$",
+                            "plugins\\sqldrivers\\qsqlite(?!.*d\.dll).*\.dll$",
+                            "plugins\\codecs\\(?!.*d\.dll).*\.dll$",
+                            "plugins\\platforms\\qwindows(?!.*d\.dll).*\.dll$",
+                            #
+                            #
+                            #zlib
+                            "bin\\libz.dll",
+                            #
+                            #qca
+                            "bin\\libqca.*\.dll",
+                            "lib\\qca-qt5\\crypto\\.*",
+                            "certs\\.*",
+                            #
+                            #phonon
+                            "bin\\libphonon.*\.dll",
+                            "bin\\phonon.*\.dll",
+                            "bin\\libphononexperimental.*\.dll",
+                            "bin\\phonon_backend\\.*",
+                            "plugins\\phonon_backend\\.*",
+                            "plugins\\phonon4qt5_backend\\.*") @(
+                            #blacklist
+                            ".*\.h",
+                            "lib\\plugins\\libsnore.*\\libsnore_backend_freedesktop\.dll"
+                            )
+                            
+
+    mv "$imageDir\bin\*" "$imageDir\"
+    #mv "$imageDir\lib\qca-qt5\crypto" "$imageDir\crypto"
+    mv "$imageDir\plugins\*" "$imageDir"
+    if(Test-Path "$imageDir\lib\plugins")
+    {
+        mv "$imageDir\lib\plugins\*" "$imageDir"
+    }
+    #snorenotify 0.5 plugins
+    if(Test-Path "$imageDir\lib\libsnore-qt5") 
+    {
+        mv "$imageDir\lib\libsnore-qt5\*" "$imageDir"
+    }
+    rm -Recurse "$imageDir\plugins\*"
+    rm -Recurse "$imageDir\lib"
+    rm -Recurse "$imageDir\bin"
+    7ZipDeployImage
+    NsisDeployImage $env:APPVEYOR_BUILD_FOLDER\scripts\build\NullsoftInstaller.nsi
+    
+environment:
+    QT_VER: 5.5
+    
+    matrix:
+    #mingw
+    - COMPILER: mingw492_32
+    #msvc
+    - COMPILER: msvc2013
+    - COMPILER: msvc2013_64
+    
+    
+test: off
+
+cache:
+    - work\install -> appveyor.yml
+    - C:\ProgramData\chocolatey\bin -> appveyor.yml
+    - C:\ProgramData\chocolatey\lib -> appveyor.yml
+    - work\appveyorHelp.psm1 -> appveyor.yml

--- a/scripts/build/NullsoftInstaller.nsi
+++ b/scripts/build/NullsoftInstaller.nsi
@@ -1,0 +1,277 @@
+; basic script template for NullsoftInstallerPackager
+;
+; Copyright 2013 Patrick von Reth <vonreth@kde.org>
+; Copyright 2010 Patrick Spendrin <ps_ml@gmx.de>
+; adapted from marble.nsi
+
+var ToBeRunned
+var nameOfToBeRunend
+
+!define productname "Quassel"
+!define company "KDE"
+
+!include MUI2.nsh
+!include LogicLib.nsh
+!include SnoreNotify.nsh
+
+
+; registry stuff
+!define regkey "Software\${company}\${productname}"
+!define uninstkey "Software\Microsoft\Windows\CurrentVersion\Uninstall\Quassel"
+ 
+!define startmenu "$SMPROGRAMS\${productname}"
+!define uninstaller "uninstall.exe"
+
+Var StartMenuFolder
+ 
+!define PRODUCT_WEB_SITE http://quassel-irc.org/
+!define MyApp_AppUserModelId  QuasselProject.QuasselIRC
+!define SnoreToastExe "$INSTDIR\SnoreToast.exe"
+
+;Start Menu Folder Page Configuration
+!define MUI_STARTMENUPAGE_REGISTRY_ROOT "HKLM" 
+!define MUI_STARTMENUPAGE_REGISTRY_KEY "${regkey}" 
+!define MUI_STARTMENUPAGE_REGISTRY_VALUENAME "Start Menu Folder"
+
+InstType "Minimal"
+InstType "Full"
+;--------------------------------
+ 
+
+XPStyle on
+ShowInstDetails hide
+ShowUninstDetails hide
+
+SetCompressor /SOLID lzma
+ 
+Name ${productname}
+Caption "${caption}"
+ 
+OutFile "${setupname}"
+
+!define MUI_ICON ${gitDir}\pics\quassel.ico
+
+!insertmacro MUI_PAGE_WELCOME
+
+;!insertmacro MUI_PAGE_LICENSE
+#${license}
+;!insertmacro MUI_PAGE_LICENSE
+
+!insertmacro MUI_PAGE_DIRECTORY
+
+!insertmacro MUI_PAGE_STARTMENU Application $StartMenuFolder
+
+!define MUI_COMPONENTSPAGE_NODESC
+!insertmacro MUI_PAGE_COMPONENTS
+
+!insertmacro MUI_PAGE_INSTFILES
+
+!define MUI_FINISHPAGE_RUN $ToBeRunned
+!define MUI_FINISHPAGE_RUN_TEXT $nameOfToBeRunend
+!define MUI_FINISHPAGE_LINK "Visit project homepage"
+!define MUI_FINISHPAGE_LINK_LOCATION "${PRODUCT_WEB_SITE}"
+!insertmacro MUI_PAGE_FINISH
+
+;uninstaller
+!insertmacro MUI_UNPAGE_WELCOME
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_UNPAGE_FINISH
+;-------
+
+!insertmacro MUI_LANGUAGE "English"
+ 
+SetDateSave on
+SetDatablockOptimize on
+CRCCheck on
+SilentInstall normal
+ 
+InstallDir "$PROGRAMFILES\${productname}"
+InstallDirRegKey HKLM "${regkey}" ""
+
+ 
+;--------------------------------
+ 
+AutoCloseWindow false
+ 
+ 
+; beginning (invisible) section
+Section "--hidden Quassel Base" QUASSEL_BASE
+   SectionIn RO
+   SetOutPath $INSTDIR
+   SetShellVarContext all
+   StrCpy $ToBeRunned ""
+    
+    WriteRegStr HKLM "${regkey}" "Install_Dir" "$INSTDIR"
+    WriteRegStr HKLM "${regkey}" "Version" "${version}"
+    WriteRegStr HKLM "${regkey}" "" "$INSTDIR\uninstall.exe"
+    
+    WriteRegStr HKLM "${uninstkey}" "DisplayName" "Quassel (remove only)"
+    WriteRegStr HKLM "${uninstkey}" "DisplayIcon" "$INSTDIR\${MUI_ICON}"
+    WriteRegStr HKLM "${uninstkey}" "DisplayVersion" "${version}"
+    WriteRegStr HKLM "${uninstkey}" "URLInfoAbout" "${PRODUCT_WEB_SITE}"
+    WriteRegStr HKLM "${uninstkey}" "UninstallString" '"$INSTDIR\${uninstaller}"'
+    WriteRegStr HKLM "${uninstkey}" "Publisher" "${company}"
+ 
+  SetOutPath $INSTDIR
+ 
+ 
+    ; package all files, recursively, preserving attributes
+    ; assume files are in the correct places
+
+    File /a /r /x "*.nsi" /x "*quassel.exe" /x "*quasselclient.exe" /x "*quasselcore.exe" /x "${setupname}" "${srcdir}\*.*" 
+    File /a  ${MUI_ICON}
+
+    !if "${vcredist}" != "none"
+        File /a /oname=vcredist.exe "${vcredist}"
+        ExecWait '"$INSTDIR\vcredist.exe" /passive'
+        Delete "$INSTDIR\vcredist.exe"
+    !endif
+    
+    WriteUninstaller "${uninstaller}"
+   
+    
+    ;Create shortcuts
+    !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+        CreateDirectory "$SMPROGRAMS\$StartMenuFolder"
+        CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk" "$INSTDIR\uninstall.exe"
+    !insertmacro MUI_STARTMENU_WRITE_END
+SectionEnd
+
+
+Section "Quassel"  QUASSEL_ALL_IN_ONE
+    SectionIn 1 2
+    SetOutPath $INSTDIR
+    StrCpy $ToBeRunned "$INSTDIR\quassel.exe"
+    StrCpy $nameOfToBeRunend "Run Quassel"
+    File /a /oname=quassel.exe "${srcdir}\quassel.exe"
+    !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+        !insertmacro SnoreShortcut "$SMPROGRAMS\$StartMenuFolder\Quassel.lnk" "$INSTDIR\quassel.exe" "${MyApp_AppUserModelId}"
+    !insertmacro MUI_STARTMENU_WRITE_END
+SectionEnd
+
+Section /o "QuasselClient"  QUASSEL_CLIENT
+    SectionIn 2
+    SetOutPath $INSTDIR
+    ${If} $ToBeRunned == ""
+        StrCpy $ToBeRunned "$INSTDIR\quasselclient.exe"
+        StrCpy $nameOfToBeRunend "Run QuasselClient"
+    ${Endif}
+    File /a /oname=quasselclient.exe "${srcdir}\quasselclient.exe"
+    !insertmacro MUI_STARTMENU_WRITE_BEGIN Application        
+        !insertmacro SnoreShortcut "$SMPROGRAMS\$StartMenuFolder\Quassel Client.lnk" "$INSTDIR\quasselclient.exe" "${MyApp_AppUserModelId}"
+    !insertmacro MUI_STARTMENU_WRITE_END
+SectionEnd
+
+Section /o "QuasselCore"  QUASSEL_CORE
+    SectionIn 2
+    SetOutPath $INSTDIR
+    ${If} $ToBeRunned == ""
+        StrCpy $ToBeRunned "$INSTDIR\quasselcore.exe"
+        StrCpy $nameOfToBeRunend "Run QuasselCore"
+    ${Endif}
+     File /a /oname=quasselcore.exe "${srcdir}\quasselcore.exe"
+    !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+        CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Quassel Core.lnk" "$INSTDIR\quasselcore.exe"
+    !insertmacro MUI_STARTMENU_WRITE_END
+SectionEnd
+
+; Section /o "QuasselCoreService"  QUASSEL_CORE_SERVICE
+    ; SimpleSC::ExistsService "QuasselCore"
+    ; Pop $0 ; returns an errorcode if the service doesn´t exists (<>0)/service exists (0)
+    ; ${If} $0 == 0
+        ; MessageBox MB_OK|MB_ICONSTOP "Install Service QUassel failed - Reason: Service already exists"
+    ; ${Else}
+        ; SimpleSC::InstallService "QuasselCore" "QuasselCore" "16" "2" "$INSTDIR\bin\quasselcore.exe" "" "" ""
+        ; Pop $0 ; returns an errorcode (<>0) otherwise success (0)
+            ; ${If} $0 != 0
+                ; Push $0
+                ; SimpleSC::GetErrorMessage
+                ; Pop $0
+                ; MessageBox MB_OK|MB_ICONSTOP "Install of Service QUassel failed - Reason: $0"
+            ; ${Else}
+                ; SimpleSC::StartService "QuasselCore" "" 30
+                ; Pop $0 ; returns an errorcode (<>0) otherwise success (0)
+                ; ${If} $0 != 0
+                    ; Push $0
+                    ; SimpleSC::GetErrorMessage
+                    ; Pop $0
+                    ; MessageBox MB_OK|MB_ICONSTOP "Install of Service QUassel failed - Reason: $0"
+                ; ${EndIf}
+            ; ${EndIf}
+    ; ${EndIf}
+; SectionEnd
+
+; Uninstaller
+; All section names prefixed by "Un" will be in the uninstaller
+ 
+UninstallText "This will uninstall Quassel."
+ 
+
+Section "Uninstall"
+    SetShellVarContext all
+    SetShellVarContext all
+
+    DeleteRegKey HKLM "${uninstkey}"
+    DeleteRegKey HKLM "${regkey}"
+
+    !insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuFolder
+
+
+    
+  ; SimpleSC::ExistsService "QuasselCore"
+  ; Pop $0   ; returns an errorcode if the service doesn´t exists (<>0)/service exists (0)
+  ; ${If} $0 == 0
+    ; SimpleSC::ServiceIsStopped "QuasselCore"
+    ; Pop $0 ; returns an errorcode (<>0) otherwise success (0)
+    ; Pop $1 ; returns 1 (service is stopped) - returns 0 (service is not stopped)
+    ; ${If} $0 == 0 
+    ; ${AndIf} $1 == 0
+        ; SimpleSC::StopService "QuasselCore" 1 30
+        ; Pop $0 ; returns an errorcode (<>0) otherwise success (0)
+        ; ${If} $0 != 0
+            ; Push $0
+            ; SimpleSC::GetErrorMessage
+            ; Pop $0
+            ; MessageBox MB_OK|MB_ICONSTOP "Stopping failed - Reason: $0"
+        ; ${Else}
+             ; SimpleSC::RemoveService "QuasselCore"
+             ; Pop $0 ; returns an errorcode (<>0) otherwise success (0)
+             ; ${If} $0 != 0  
+                    ; Push $0
+                    ; SimpleSC::GetErrorMessage
+                    ; Pop $0
+                    ; MessageBox MB_OK|MB_ICONSTOP "Remove fails - Reason: $0"
+                ; ${EndIf}
+        ; ${EndIf}
+    ; ${EndIf}
+  ; ${EndIf}
+      
+    RMDir /r "$SMPROGRAMS\$StartMenuFolder"
+    RMDir /r "$INSTDIR"
+SectionEnd
+
+Function .onSelChange
+    ${If} ${SectionIsSelected} ${QUASSEL_CORE}
+    ${OrIf}  ${SectionIsSelected} ${QUASSEL_CLIENT}
+    ${OrIf}  ${SectionIsSelected} ${QUASSEL_ALL_IN_ONE}
+        GetDlgItem $0 $HWNDPARENT 1
+        EnableWindow $0 1
+    ${Else}
+        GetDlgItem $0 $HWNDPARENT 1
+        EnableWindow $0 0
+    ${EndIf}
+FunctionEnd
+
+
+Function .onInit
+    
+    ReadRegStr $R0 HKLM "${uninstkey}" "UninstallString"
+    StrCmp $R0 "" done
+    ReadRegStr $INSTDIR HKLM "${regkey}" "Install_Dir"
+    ;Run the uninstaller
+    ;uninst:
+    ClearErrors
+    ExecWait '$R0 _?=$INSTDIR' ;Do not copy the uninstaller to a temp file
+    done:
+FunctionEnd

--- a/scripts/build/SnoreNotify.nsh
+++ b/scripts/build/SnoreNotify.nsh
@@ -1,0 +1,22 @@
+!include LogicLib.nsh
+!include WordFunc.nsh
+
+Function SnoreWinVer
+    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows NT\CurrentVersion" CurrentVersion
+    ${VersionCompare} "6.2" $R0 $R0
+    ${If} $R0 == 1
+        Push "NotWin8"
+    ${Else}
+        Push "AtLeastWin8"
+    ${EndIf}
+FunctionEnd
+
+!macro SnoreShortcut path exe appID
+    Call SnoreWinVer
+    Pop $0
+    ${If} $0 == "AtLeastWin8"
+        nsExec::ExecToLog '"${SnoreToastExe}" -install "${path}" "${exe}" "${appID}"'
+    ${Else}
+        CreateShortCut "${path}" "${exe}"
+    ${EndIf}
+!macroend

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -93,7 +93,11 @@ if (APPLE)
     target_link_libraries(mod_common "-framework CoreServices" "-framework CoreFoundation")
 endif(APPLE)
 
-target_link_libraries(mod_common ${CMAKE_DL_LIBS} ${EXECINFO_LIBRARIES} ${ZLIB_LIBRARIES})
+target_link_libraries(mod_common ${CMAKE_DL_LIBS} ${EXECINFO_LIBRARIES})
+
+if(ZLIB_FOUND)
+    target_link_libraries(mod_common ${ZLIB_LIBRARIES})
+endif()
 
 # This is needed so translations are generated before trying to build the qrc.
 # Should probably find a nicer solution with proper dependencies between the involved files, though...


### PR DESCRIPTION
Add build scripts for appveyor.com ci for mingw and msvc 2013.
The ci automatically creates a Nsis installer and a 7zip package.

While it is possible to download the archives from appveyor I would recommend to either push them automatically to the quassel servers or to continue hosting of selected builds.

To enable the ci you need to register at appveyor.com and enable the ci for this repository.