### PR TITLE
Performance tweak: rem. pointless recursive calls

### DIFF
--- a/src/common/ircchannel.cpp
+++ b/src/common/ircchannel.cpp
@@ -183,7 +183,7 @@ void IrcChannel::joinIrcUsers(const QList<IrcUser *> &users, const QStringList &
         }
 
         _userModes[ircuser] = modes[i];
-        ircuser->joinChannel(this);
+        ircuser->joinChannel(this, true);
         connect(ircuser, SIGNAL(nickSet(QString)), this, SLOT(ircUserNickSet(QString)));
 
         // connect(ircuser, SIGNAL(destroyed()), this, SLOT(ircUserDestroyed()));

--- a/src/common/ircuser.cpp
+++ b/src/common/ircuser.cpp
@@ -275,12 +275,13 @@ void IrcUser::updateHostmask(const QString &mask)
 }
 
 
-void IrcUser::joinChannel(IrcChannel *channel)
+void IrcUser::joinChannel(IrcChannel *channel, bool skip_channel_join)
 {
     Q_ASSERT(channel);
     if (!_channels.contains(channel)) {
         _channels.insert(channel);
-        channel->joinIrcUser(this);
+        if (!skip_channel_join)
+            channel->joinIrcUser(this);
     }
 }
 

--- a/src/common/ircuser.h
+++ b/src/common/ircuser.h
@@ -118,7 +118,12 @@ public slots:
 
     void setUserModes(const QString &modes);
 
-    void joinChannel(IrcChannel *channel);
+    /*!
+     * \brief joinChannel Called when user joins some channel, this function inserts the channel to internal list of channels this user is in.
+     * \param channel Pointer to a channel this user just joined
+     * \param skip_channel_join If this is false, this function will also call IrcChannel::joinIrcUser, can be set to true as a performance tweak.
+     */
+    void joinChannel(IrcChannel *channel, bool skip_channel_join = false);
     void joinChannel(const QString &channelname);
     void partChannel(IrcChannel *channel);
     void partChannel(const QString &channelname);


### PR DESCRIPTION
For some reason there was an extra call to IrcChannel::joinIrcUser from IrcUser::joinIrcChannel. That means that in past we did:

* Call to                                 IrcChannel::joinIrcUsers(...)
* From there we call              IrcUser::joinIrcChannel(this)
* And from there we called    IrcChannel::joinIrcUser(this)
* Which again called             IrcChannel::joinIrcUsers(list that contained only this 1 user)
* Which figured out this user is already in this channel and exits

That is a pointless overhead, so now we call the second function with extra parameter that tells it not to call joinIrcUser because we know this user doesn't need to be added there, thus saves few thousands of pointless function calls and user list contructions, especially while joining large channels.