### PR TITLE
Disable checkbox if no DockManager is present

### DIFF
--- a/src/qtui/dockmanagernotificationbackend.cpp
+++ b/src/qtui/dockmanagernotificationbackend.cpp
@@ -46,11 +46,11 @@ DockManagerNotificationBackend::DockManagerNotificationBackend(QObject *parent)
         if (_dock->isValid()) {
             _bus.connect("org.freedesktop.DockManager", "/org/freedesktop/DockManager", "org.freedesktop.DockManager", "ItemAdded", this, SLOT(itemAdded(QDBusObjectPath)));
         } else {
-            qDebug() << "No DockManager available";
-            _enabled = false;
+            _available = _enabled = false;
             return;
         }
     }
+    _available = true;
 
     itemAdded(QDBusObjectPath());
 
@@ -171,18 +171,18 @@ void DockManagerNotificationBackend::enabledChanged(const QVariant &v)
 
 SettingsPage *DockManagerNotificationBackend::createConfigWidget() const
 {
-    return new ConfigWidget();
+    return new ConfigWidget(_available);
 }
 
 
 /***************************************************************************/
 
-DockManagerNotificationBackend::ConfigWidget::ConfigWidget(QWidget *parent)
+DockManagerNotificationBackend::ConfigWidget::ConfigWidget(bool enabled, QWidget *parent)
     : SettingsPage("Internal", "DockManagerNotification", parent)
 {
     QHBoxLayout *layout = new QHBoxLayout(this);
     layout->addWidget(enabledBox = new QCheckBox(tr("Mark dockmanager entry"), this));
-    enabledBox->setEnabled(true);
+    enabledBox->setEnabled(enabled);
 
     connect(enabledBox, SIGNAL(toggled(bool)), SLOT(widgetChanged()));
 }

--- a/src/qtui/dockmanagernotificationbackend.h
+++ b/src/qtui/dockmanagernotificationbackend.h
@@ -50,6 +50,7 @@ private slots:
 private:
     class ConfigWidget;
     bool _enabled;
+    bool _available;
     QDBusConnection _bus;
     QDBusInterface *_dock;
     QDBusInterface *_item;
@@ -62,7 +63,7 @@ class DockManagerNotificationBackend::ConfigWidget : public SettingsPage
     Q_OBJECT
 
 public:
-    ConfigWidget(QWidget *parent = 0);
+    ConfigWidget(bool enabled, QWidget *parent = 0);
 
     void save();
     void load();


### PR DESCRIPTION
This gets rid of the stray debug message introduced by 0bf9227 and adds
some visual feedback on the settingspage instead.