### PR TITLE
Preserve white-space in the input history.

### DIFF
--- a/src/uisupport/multilineedit.cpp
+++ b/src/uisupport/multilineedit.cpp
@@ -54,6 +54,9 @@ MultiLineEdit::MultiLineEdit(QWidget *parent)
     setLineWrapEnabled(false);
     reset();
 
+    // Prevent QTextHtmlImporter::appendNodeText from eating whitespace
+    document()->setDefaultStyleSheet("span { white-space: pre-wrap; }");
+
     connect(this, SIGNAL(textChanged()), this, SLOT(on_textChanged()));
 
     _mircColorMap["00"] = "#ffffff";


### PR DESCRIPTION
By default QTextHtmlImporter::appendNodeText replaces white-space
characters with a single space and leading white-space is removed. When
white-space is set to pre-wrap in the style of the node, it is preserved
instead.

Given that contents are in a span element, setting white-space to
pre-wrap on span makes the setHtml call do the expected thing.