### PR TITLE
Fixes a crash of the core when executing "/op *" in a query.

### DIFF
--- a/src/core/coreuserinputhandler.cpp
+++ b/src/core/coreuserinputhandler.cpp
@@ -228,7 +228,7 @@ void CoreUserInputHandler::doMode(const BufferInfo &bufferInfo, const QChar& add
     if (!isNumber || maxModes == 0) maxModes = 1;
 
     QStringList nickList;
-    if (nicks == "*") { // All users in channel
+    if (nicks == "*" && bufferInfo.type() == BufferInfo::ChannelBuffer) { // All users in channel
         const QList<IrcUser*> users = network()->ircChannel(bufferInfo.bufferName())->ircUsers();
         foreach(IrcUser *user, users) {
             if ((addOrRemove == '+' && !network()->ircChannel(bufferInfo.bufferName())->userModes(user).contains(mode))


### PR DESCRIPTION
Without the patch, the following backtrace is created:
```
2015-10-21 02:54:28 Debug: Quassel IRC:  "0.13-pre"   "b49c64970b6237fc95f8ca88c8bb6bcf04c251d7"  
2015-10-21 02:54:28 Debug: #  0 quasselcore          0x0000000000568617 Quassel::logBacktrace(QString const&)  
2015-10-21 02:54:28 Debug: #  1 quasselcore          0x000000000054908c Quassel::handleSignal(int)  
2015-10-21 02:54:28 Debug: #  2 libc.so.6            0x00007fb90e1e5670 0x0000000000000000  
2015-10-21 02:54:28 Debug: #  3 quasselcore          0x00000000004bf5c0 QHash<IrcUser*, QString>::size() const  
2015-10-21 02:54:28 Debug: #  4 quasselcore          0x00000000004c1849 QHash<IrcUser*, QString>::keys() const  
2015-10-21 02:54:28 Debug: #  5 quasselcore          0x00000000004c1901 IrcChannel::ircUsers() const  
2015-10-21 02:54:28 Debug: #  6 quasselcore          0x00000000004da743 CoreUserInputHandler::doMode(BufferInfo const&, QChar const&, QChar const&, QString const&)  
2015-10-21 02:54:28 Debug: #  7 quasselcore          0x00000000004daff3 CoreUserInputHandler::handleOp(BufferInfo const&, QString const&)  
2015-10-21 02:54:28 Debug: #  8 quasselcore          0x000000000048ffe3 0x0000000000000000  
2015-10-21 02:54:28 Debug: #  9 quasselcore          0x0000000000490c33 CoreUserInputHandler::qt_metacall(QMetaObject::Call, int, void**)  
2015-10-21 02:54:28 Debug: # 10 quasselcore          0x00000000005247b0 BasicHandler::handle(QString const&, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument)  
2015-10-21 02:54:28 Debug: # 11 quasselcore          0x00000000004d82bc CoreUserInputHandler::handleUserInput(BufferInfo const&, QString const&)  
2015-10-21 02:54:28 Debug: # 12 quasselcore          0x00000000004c4146 CoreSession::msgFromClient(BufferInfo, QString)  
2015-10-21 02:54:28 Debug: # 13 quasselcore          0x0000000000493f88 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 14 quasselcore          0x00000000004978c3 CoreSession::qt_metacall(QMetaObject::Call, int, void**)  
2015-10-21 02:54:28 Debug: # 15 quasselcore          0x000000000054e020 SignalProxy::invokeSlot(QObject*, int, QList<QVariant> const&, QVariant&, Peer*)  
2015-10-21 02:54:28 Debug: # 16 quasselcore          0x000000000054e15a SignalProxy::invokeSlot(QObject*, int, QList<QVariant> const&, Peer*)  
2015-10-21 02:54:28 Debug: # 17 quasselcore          0x000000000054e26e SignalProxy::handle(Peer*, Protocol::RpcCall const&)  
2015-10-21 02:54:28 Debug: # 18 quasselcore          0x0000000000531af1 void Peer::handle<Protocol::RpcCall>(Protocol::RpcCall const&)  
2015-10-21 02:54:28 Debug: # 19 quasselcore          0x000000000055cbb2 DataStreamPeer::handlePackedFunc(QList<QVariant> const&)  
2015-10-21 02:54:28 Debug: # 20 quasselcore          0x000000000055d216 DataStreamPeer::processMessage(QByteArray const&)  
2015-10-21 02:54:28 Debug: # 21 quasselcore          0x00000000005731a7 RemotePeer::onReadyRead()  
2015-10-21 02:54:28 Debug: # 22 quasselcore          0x000000000056b818 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 23 libQtCore.so.4       0x00007fb910179da9 QMetaObject::activate(QObject*, QMetaObject const*, int, void**)  
2015-10-21 02:54:28 Debug: # 24 quasselcore          0x00000000005723d0 Compressor::readData()  
2015-10-21 02:54:28 Debug: # 25 libQtCore.so.4       0x00007fb910179da9 QMetaObject::activate(QObject*, QMetaObject const*, int, void**)  
2015-10-21 02:54:28 Debug: # 26 libQtCore.so.4       0x00007fb9101d9471 QIODevice::readyRead()  
2015-10-21 02:54:28 Debug: # 27 libQtNetwork.so.4    0x00007fb90fd20e14 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 28 libQtNetwork.so.4    0x00007fb90fd1be2f 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 29 libQtNetwork.so.4    0x00007fb90fd1c725 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 30 libQtCore.so.4       0x00007fb910179da9 QMetaObject::activate(QObject*, QMetaObject const*, int, void**)  
2015-10-21 02:54:28 Debug: # 31 libQtCore.so.4       0x00007fb9101d9471 QIODevice::readyRead()  
2015-10-21 02:54:28 Debug: # 32 libQtNetwork.so.4    0x00007fb90fcf7b0a 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 33 libQtNetwork.so.4    0x00007fb90fcfdaee 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 34 libQtNetwork.so.4    0x00007fb90fce831f 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 35 libQtNetwork.so.4    0x00007fb90fd061a4 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 36 libQtCore.so.4       0x00007fb91015ac32 QCoreApplicationPrivate::notify_helper(QObject*, QEvent*)  
2015-10-21 02:54:28 Debug: # 37 libQtCore.so.4       0x00007fb91015a9c2 QCoreApplication::notify(QObject*, QEvent*)  
2015-10-21 02:54:28 Debug: # 38 libQtCore.so.4       0x00007fb91015a8d5 QCoreApplication::notifyInternal(QObject*, QEvent*)  
2015-10-21 02:54:28 Debug: # 39 libQtCore.so.4       0x00007fb91015e6bf QCoreApplication::sendEvent(QObject*, QEvent*)  
2015-10-21 02:54:28 Debug: # 40 libQtCore.so.4       0x00007fb910196d8b 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 41 libglib-2.0.so.0     0x00007fb90dc81336 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 42 libglib-2.0.so.0     0x00007fb90dc821f9 g_main_context_dispatch  
2015-10-21 02:54:28 Debug: # 43 libglib-2.0.so.0     0x00007fb90dc823ec 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 44 libglib-2.0.so.0     0x00007fb90dc824c4 g_main_context_iteration  
2015-10-21 02:54:28 Debug: # 45 libQtCore.so.4       0x00007fb910197d98 QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>)  
2015-10-21 02:54:28 Debug: # 46 libQtCore.so.4       0x00007fb9101581e5 QEventLoop::processEvents(QFlags<QEventLoop::ProcessEventsFlag>)  
2015-10-21 02:54:28 Debug: # 47 libQtCore.so.4       0x00007fb91015839e QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>)  
2015-10-21 02:54:28 Debug: # 48 libQtCore.so.4       0x00007fb91001452c QThread::exec()  
2015-10-21 02:54:28 Debug: # 49 quasselcore          0x00000000005064f3 SessionThread::run()  
2015-10-21 02:54:28 Debug: # 50 libQtCore.so.4       0x00007fb91001702d 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 51 libpthread.so.0      0x00007fb90df9d360 0x0000000000000000  
2015-10-21 02:54:28 Debug: # 52 libc.so.6            0x00007fb90e29eedd clone
```