### PR TITLE
quasselcore: fixed return values for --add-user and --change-userpass

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -198,13 +198,13 @@ void Core::init()
     }
 
     if (Quassel::isOptionSet("add-user")) {
-        createUser();
-        exit(0);
+        exit(createUser() ? EXIT_SUCCESS : EXIT_FAILURE);
+
     }
 
     if (Quassel::isOptionSet("change-userpass")) {
-        changeUserPass(Quassel::optionValue("change-userpass"));
-        exit(0);
+        exit(changeUserPass(Quassel::optionValue("change-userpass")) ?
+                       EXIT_SUCCESS : EXIT_FAILURE);
     }
 
     connect(&_server, SIGNAL(newConnection()), this, SLOT(incomingConnection()));
@@ -739,7 +739,7 @@ bool Core::selectBackend(const QString &backend)
 }
 
 
-void Core::createUser()
+bool Core::createUser()
 {
     QTextStream out(stdout);
     QTextStream in(stdin);
@@ -761,30 +761,32 @@ void Core::createUser()
 
     if (password != password2) {
         qWarning() << "Passwords don't match!";
-        return;
+        return false;
     }
     if (password.isEmpty()) {
         qWarning() << "Password is empty!";
-        return;
+        return false;
     }
 
     if (_configured && _storage->addUser(username, password).isValid()) {
         out << "Added user " << username << " successfully!" << endl;
+        return true;
     }
     else {
         qWarning() << "Unable to add user:" << qPrintable(username);
+        return false;
     }
 }
 
 
-void Core::changeUserPass(const QString &username)
+bool Core::changeUserPass(const QString &username)
 {
     QTextStream out(stdout);
     QTextStream in(stdin);
     UserId userId = _storage->getUserId(username);
     if (!userId.isValid()) {
         out << "User " << username << " does not exist." << endl;
-        return;
+        return false;
     }
 
     out << "Change password for user: " << username << endl;
@@ -802,18 +804,20 @@ void Core::changeUserPass(const QString &username)
 
     if (password != password2) {
         qWarning() << "Passwords don't match!";
-        return;
+        return false;
     }
     if (password.isEmpty()) {
         qWarning() << "Password is empty!";
-        return;
+        return false;
     }
 
     if (_configured && _storage->updateUser(userId, password)) {
         out << "Password changed successfully!" << endl;
+        return true;
     }
     else {
         qWarning() << "Failed to change password!";
+        return false;
     }
 }
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -533,7 +533,7 @@ private slots:
     void socketError(QAbstractSocket::SocketError err, const QString &errorString);
     void setupClientSession(RemotePeer *, UserId);
 
-    void changeUserPass(const QString &username);
+    bool changeUserPass(const QString &username);
 
 private:
     Core();
@@ -551,7 +551,7 @@ private:
     void unregisterStorageBackends();
     void unregisterStorageBackend(Storage *);
     bool selectBackend(const QString &backend);
-    void createUser();
+    bool createUser();
     void saveBackendSettings(const QString &backend, const QVariantMap &settings);
     QVariantMap promptForSettings(const Storage *storage);
 


### PR DESCRIPTION
Maybe it is not a common use case to include a user addition in a script, but in such case we need this.