### PR TITLE
Improve MainPage

### DIFF
--- a/src/qtui/mainpage.cpp
+++ b/src/qtui/mainpage.cpp
@@ -38,6 +38,15 @@ MainPage::MainPage(QWidget *parent) : QWidget(parent)
 
     if (Quassel::runMode() != Quassel::Monolithic) {
         QPushButton *connectButton = new QPushButton(QIcon::fromTheme("network-connect"), tr("Connect to Core..."));
+        connectButton->setEnabled(Client::coreConnection()->state() == CoreConnection::Disconnected);
+
+        connect(Client::coreConnection(), &CoreConnection::stateChanged, [connectButton](CoreConnection::ConnectionState state){
+             if (state == CoreConnection::Disconnected) {
+                 connectButton->setEnabled(true);
+             } else {
+                 connectButton->setDisabled(true);
+             }
+        });
         connect(connectButton, &QPushButton::clicked, [this](){
             CoreConnectDlg dlg(this);
             if (dlg.exec() == QDialog::Accepted) {

--- a/src/qtui/mainpage.cpp
+++ b/src/qtui/mainpage.cpp
@@ -18,28 +18,34 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
+#include <QPushButton>
 #include <QImage>
+#include <QLabel>
+#include <QLayout>
 #include <QPainter>
 
 #include "mainpage.h"
+#include "coreconnectdlg.h"
+#include "client.h"
 
 MainPage::MainPage(QWidget *parent) : QWidget(parent)
 {
-}
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->setAlignment(Qt::AlignCenter);
+    QLabel *label = new QLabel(this);
+    label->setPixmap(QPixmap(":/pics/quassel-logo.png"));
+    layout->addWidget(label);
 
-
-void MainPage::paintEvent(QPaintEvent *event)
-{
-    Q_UNUSED(event);
-
-    QPainter painter(this);
-    QImage img(":/pics/quassel-logo.png"); // FIXME load externally
-
-    if (img.height() > height() || img.width() > width())
-        img = img.scaled(width(), height(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
-
-    int xmargin = (width() - img.width()) / 2;
-    int ymargin = (height() - img.height()) / 2;
-
-    painter.drawImage(xmargin, ymargin, img);
+    if (Quassel::runMode() != Quassel::Monolithic) {
+        QPushButton *connectButton = new QPushButton(QIcon::fromTheme("network-connect"), tr("Connect to Core..."));
+        connect(connectButton, &QPushButton::clicked, [this](){
+            CoreConnectDlg dlg(this);
+            if (dlg.exec() == QDialog::Accepted) {
+                AccountId accId = dlg.selectedAccount();
+                if (accId.isValid())
+                    Client::coreConnection()->connectToCore(accId);
+            }
+        });
+        layout->addWidget(connectButton);
+    }
 }

--- a/src/qtui/mainpage.h
+++ b/src/qtui/mainpage.h
@@ -23,6 +23,8 @@
 
 #include <QWidget>
 
+class QPushButton;
+
 class MainPage : public QWidget
 {
     Q_OBJECT
@@ -30,6 +32,12 @@ class MainPage : public QWidget
 public:
     MainPage(QWidget *parent = 0);
 
+private slots:
+    void showCoreConnectionDlg();
+    void coreConnectionStateChanged();
+
+private:
+    QPushButton *_connectButton;
 };
 
 

--- a/src/qtui/mainpage.h
+++ b/src/qtui/mainpage.h
@@ -30,8 +30,6 @@ class MainPage : public QWidget
 public:
     MainPage(QWidget *parent = 0);
 
-protected:
-    void paintEvent(QPaintEvent *event);
 };
 
 

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -879,6 +879,8 @@ void MainWin::setupNickWidget()
     // attach the NickListWidget to the BufferModel and the default selection
     _nickListWidget->setModel(Client::bufferModel());
     _nickListWidget->setSelectionModel(Client::bufferModel()->standardSelectionModel());
+
+    _nickListWidget->setVisible(false);
 }
 
 
@@ -1131,7 +1133,7 @@ void MainWin::loadLayout()
         _layoutLoaded = true;
         return;
     }
-
+    _nickListWidget->setVisible(true);
     restoreState(state, accountId);
     int bufferViewId = s.value(QString("ActiveBufferView-%1").arg(accountId), -1).toInt();
     if (bufferViewId >= 0)
@@ -1201,6 +1203,7 @@ void MainWin::setDisconnectedState()
         _msgProcessorStatusWidget->setProgress(0, 0);
     updateIcon();
     systemTray()->setState(SystemTray::Passive);
+    _nickListWidget->setVisible(false);
 }
 
 

--- a/src/qtui/nicklistwidget.cpp
+++ b/src/qtui/nicklistwidget.cpp
@@ -84,6 +84,19 @@ void NickListWidget::showWidget(bool visible)
     }
 }
 
+void NickListWidget::setVisible(bool visible)
+{
+    QWidget::setVisible(visible);
+    QDockWidget *dock_ = dock();
+    if (!dock_)
+        return;
+
+    if (visible)
+        dock_->show();
+    else
+        dock_->close();
+}
+
 
 void NickListWidget::currentChanged(const QModelIndex &current, const QModelIndex &previous)
 {

--- a/src/qtui/nicklistwidget.h
+++ b/src/qtui/nicklistwidget.h
@@ -43,6 +43,7 @@ public:
 
 public slots:
     void showWidget(bool visible);
+    void setVisible(bool visible) override;
 
 signals:
     void nickSelectionChanged(const QModelIndexList &);


### PR DESCRIPTION
Instead of overriding the paint function simply use a layout and a QLabel in MainPage, this also enables us to add a button to open the connect to core dialog.

This commit also hides the Nick list in a disconnected state, to make sure the Quassel logo is centred and to keep it in line with the All Chats view.
<img width="960" alt="snip_20151103152330" src="https://cloud.githubusercontent.com/assets/200626/10910290/dd716850-823e-11e5-8388-8a114ed641fa.png">
