### PR TITLE
Fix SSL detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,6 +413,20 @@ if (NOT WIN32)
     )
 endif()
 
+# Check for SSL support in Qt
+# As there's no easy way to get Qt's configuration in particular for Qt5, let's just compile
+# a small test program checking the defines. This works for both Qt4 and Qt5.
+cmake_push_check_state(RESET)
+set(CMAKE_REQUIRED_INCLUDES ${QT_INCLUDES} ${Qt5Core_INCLUDE_DIRS})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5Core_EXECUTABLE_COMPILE_FLAGS}")
+check_cxx_source_compiles("
+    #include \"qglobal.h\"
+    #if defined QT_NO_OPENSSL || defined QT_NO_SSL
+    #  error \"No SSL support\"
+    #endif
+    int main() {}"
+    HAVE_SSL)
+cmake_pop_check_state()
 
 # Additional compile settings
 #####################################################################
@@ -475,20 +489,6 @@ if (NOT ZLIB_FOUND)
         message(STATUS "WARNING: This may be slow on 32 bit systems!")
     endif()
 endif()
-
-# Check for SSL support in Qt
-# As there's no easy way to get Qt's configuration in particular for Qt5, let's just compile
-# a small test program checking the defines. This works for both Qt4 and Qt5.
-cmake_push_check_state(RESET)
-set(CMAKE_REQUIRED_INCLUDES ${QT_INCLUDES} ${Qt5Core_INCLUDE_DIRS})
-check_cxx_source_compiles("
-    #include \"qglobal.h\"
-    #if defined QT_NO_OPENSSL || defined QT_NO_SSL
-    #  error \"No SSL support\"
-    #endif
-    int main() {}"
-    HAVE_SSL)
-cmake_pop_check_state()
 
 if (HAVE_SSL)
     add_definitions(-DHAVE_SSL)


### PR DESCRIPTION
CMAKE_POSITION_INDEPENDENT_CODE will always append fPIE flag as last compiler flag when calling try_compile which makes check_cxx_source_compiles fails. Move the SSL check before set CMAKE_POSITION_INDEPENDENT_CODE and append Qt5Core_EXECUTABLE_COMPILE_FLAGS to CMAKE_CXX_FLAGS solve the problem.