### PR TITLE
Replace build date with commit date (Alternative to #127)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,6 +582,16 @@ include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC GIT_HEAD)
 git_describe(GIT_DESCRIBE --long)
 
+# If in a Git repo we can get the commit-date from a git command
+if (GIT_HEAD)
+    execute_process(
+        COMMAND git show -s --format=%ct
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_COMMIT_DATE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+endif()
+
 # If not in a Git repo try to read GIT_HEAD and GIT_DESCRIBE from
 # enviroment
 if (NOT GIT_HEAD OR NOT GIT_DESCRIBE)
@@ -597,6 +607,7 @@ endif()
 if (NOT GIT_HEAD OR NOT GIT_DESCRIBE)
     set(GIT_HEAD "")
     set(GIT_DESCRIBE "")
+    set(GIT_COMMIT_DATE 0)
 endif()
 
 configure_file(version.h.in ${CMAKE_BINARY_DIR}/version.h @ONLY)

--- a/src/client/clientauthhandler.cpp
+++ b/src/client/clientauthhandler.cpp
@@ -288,7 +288,7 @@ void ClientAuthHandler::startRegistration()
     useSsl = _account.useSsl();
 #endif
 
-    _peer->dispatch(RegisterClient(Quassel::buildInfo().fancyVersionString, Quassel::buildInfo().buildDate, useSsl));
+    _peer->dispatch(RegisterClient(Quassel::buildInfo().fancyVersionString, Quassel::buildInfo().commitDate, useSsl));
 }
 
 

--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -261,15 +261,16 @@ void Quassel::setupBuildInfo()
     _buildInfo.baseVersion = QUASSEL_VERSION_STRING;
     _buildInfo.generatedVersion = GIT_DESCRIBE;
 
-    // This will be imprecise for incremental builds not touching this file, but we really don't want to always recompile
-    _buildInfo.buildDate = QString("%1 %2").arg(__DATE__, __TIME__);
-
     // Check if we got a commit hash
-    if (!QString(GIT_HEAD).isEmpty())
+    if (!QString(GIT_HEAD).isEmpty()) {
         _buildInfo.commitHash = GIT_HEAD;
+        QDateTime date;
+        date.setTime_t(GIT_COMMIT_DATE);
+        _buildInfo.commitDate = date.toString();
+    }
     else if (!QString(DIST_HASH).contains("Format")) {
         _buildInfo.commitHash = DIST_HASH;
-        _buildInfo.commitDate = QString(DIST_DATE).toUInt();
+        _buildInfo.commitDate = QString(DIST_DATE);
     }
 
     // create a nice version string

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -47,8 +47,7 @@ public:
         QString baseVersion;
         QString generatedVersion;
         QString commitHash;
-        uint commitDate;
-        QString buildDate;
+        QString commitDate;
 
         uint protocolVersion; // deprecated
 

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -175,9 +175,9 @@ void CoreAuthHandler::handle(const RegisterClient &msg)
     int uphours = uptime / 3600; uptime %= 3600;
     int upmins = uptime / 60;
     QString coreInfo = tr("<b>Quassel Core Version %1</b><br>"
-                          "Built: %2<br>"
+                          "Version date: %2<br>"
                           "Up %3d%4h%5m (since %6)").arg(Quassel::buildInfo().fancyVersionString)
-                          .arg(Quassel::buildInfo().buildDate)
+                          .arg(Quassel::buildInfo().commitDate)
                           .arg(updays).arg(uphours, 2, 10, QChar('0')).arg(upmins, 2, 10, QChar('0')).arg(Core::instance()->startTime().toString(Qt::TextDate));
 
     // useSsl and coreInfo are only used for the legacy protocol

--- a/src/core/corecoreinfo.cpp
+++ b/src/core/corecoreinfo.cpp
@@ -37,7 +37,7 @@ QVariantMap CoreCoreInfo::coreData() const
 {
     QVariantMap data;
     data["quasselVersion"] = Quassel::buildInfo().fancyVersionString;
-    data["quasselBuildDate"] = Quassel::buildInfo().buildDate;
+    data["quasselBuildDate"] = Quassel::buildInfo().commitDate; // "BuildDate" for compatibility
     data["startTime"] = Core::instance()->startTime();
     data["sessionConnectedClients"] = _coreSession->signalProxy()->peerCount();
     return data;

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -1292,5 +1292,5 @@ void CoreSessionEventProcessor::handleCtcpTime(CtcpEvent *e)
 void CoreSessionEventProcessor::handleCtcpVersion(CtcpEvent *e)
 {
     e->setReply(QString("Quassel IRC %1 (built on %2) -- http://www.quassel-irc.org")
-        .arg(Quassel::buildInfo().plainVersionString).arg(Quassel::buildInfo().buildDate));
+        .arg(Quassel::buildInfo().plainVersionString).arg(Quassel::buildInfo().commitDate));
 }

--- a/src/qtui/aboutdlg.cpp
+++ b/src/qtui/aboutdlg.cpp
@@ -35,10 +35,10 @@ AboutDlg::AboutDlg(QWidget *parent)
     ui.setupUi(this);
     ui.quasselLogo->setPixmap(QIcon(":/icons/quassel-64.png").pixmap(64)); // don't let the icon theme affect our logo here
 
-    ui.versionLabel->setText(QString(tr("<b>Version:</b> %1<br><b>Protocol version:</b> %2<br><b>Built:</b> %3"))
+    ui.versionLabel->setText(QString(tr("<b>Version:</b> %1<br><b>Version date:</b> %2<br><b>Protocol version:</b> %3"))
         .arg(Quassel::buildInfo().fancyVersionString)
-        .arg(Quassel::buildInfo().protocolVersion)
-        .arg(Quassel::buildInfo().buildDate));
+        .arg(Quassel::buildInfo().commitDate)
+        .arg(Quassel::buildInfo().protocolVersion));
     ui.aboutTextBrowser->setHtml(about());
     ui.authorTextBrowser->setHtml(authors());
     ui.contributorTextBrowser->setHtml(contributors());

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -38,7 +38,7 @@ CoreInfoDlg::CoreInfoDlg(QWidget *parent)
 void CoreInfoDlg::coreInfoAvailable()
 {
     ui.labelCoreVersion->setText(_coreInfo["quasselVersion"].toString());
-    ui.labelCoreBuildDate->setText(_coreInfo["quasselBuildDate"].toString());
+    ui.labelCoreVersionDate->setText(_coreInfo["quasselBuildDate"].toString()); // "BuildDate" for compatibility
     ui.labelClientCount->setNum(_coreInfo["sessionConnectedClients"].toInt());
     updateUptime();
     startTimer(1000);

--- a/src/qtui/ui/coreinfodlg.ui
+++ b/src/qtui/ui/coreinfodlg.ui
@@ -60,14 +60,14 @@
      <item row="1" column="0" >
       <widget class="QLabel" name="label" >
        <property name="text" >
-        <string>Build date:</string>
+        <string>Version date:</string>
        </property>
       </widget>
      </item>
      <item row="1" column="1" >
-      <widget class="QLabel" name="labelCoreBuildDate" >
+      <widget class="QLabel" name="labelCoreVersionDate" >
        <property name="text" >
-        <string>&lt;build date></string>
+        <string>&lt;version date></string>
        </property>
       </widget>
      </item>

--- a/version.h.in
+++ b/version.h.in
@@ -7,6 +7,7 @@
 // Determined from Git
 #define GIT_HEAD "@GIT_HEAD@"
 #define GIT_DESCRIBE "@GIT_DESCRIBE@"
+#define GIT_COMMIT_DATE @GIT_COMMIT_DATE@
 
 // Will be substituted in official tarballs
 #define DIST_HASH "$Format:%H$"


### PR DESCRIPTION
Alternative to and based on PR #127

This makes it possible to create reproducible builds.

Here using the git-commit date instead of a dummy date

See also:
https://wiki.debian.org/ReproducibleBuilds/About


Because I'm not yet very familiar with cmake and c++ please double check:
* that I didn't overlook something and _buildInfo.commitDate was really not used! (changed from uint to QString)
* that the change to CMakeLists.txt is ok...