### PR TITLE
Fix OIdentdConfigGenerator double-printing on ssl

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -81,7 +81,7 @@ CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
     connect(this, SIGNAL(newEvent(Event *)), coreSession()->eventManager(), SLOT(postEvent(Event *)));
 
     if (Quassel::isOptionSet("oidentd")) {
-        connect(this, SIGNAL(socketOpen(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(addSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Qt::BlockingQueuedConnection);
+        connect(this, SIGNAL(socketInitialized(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(addSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Qt::BlockingQueuedConnection);
         connect(this, SIGNAL(socketDisconnected(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(removeSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)));
     }
 }


### PR DESCRIPTION
Examining ~/.oidentd.conf after quassel core has been running with the --oidentd option for a while:

lport 56590 { reply "quassel" } # stanza created by Quassel
lport 56590 { reply "quassel" } # stanza created by Quassel
lport 56597 { reply "quassel" } # stanza created by Quassel
lport 56597 { reply "quassel" } # stanza created by Quassel

connected() is always connected to socketInitialized().
encrypted() is also connected to socketInitialized() when ssl is enabled.

socketInitialized() fires socketOpen(...) unconditionally, but does not fire socketInitialized(...) if we're using SSL without encryption yet - see line 464.

With socketOpen(...) connected to OIdentdConfigurationGenerator::addSocket, OIdentdConfigurationGenerator writes to .oidentd.conf twice for every connection.

Changing this to have socketInitialized(...) connected instead prevents this duplication.