### PR TITLE
Fix ident race condition

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -457,16 +457,24 @@ void CoreNetwork::socketInitialized()
         return;
     }
 
-    emit socketOpen(identity, localAddress(), localPort(), peerAddress(), peerPort());
-
     Server server = usedServer();
-#ifdef HAVE_SSL
-    if (server.useSsl && !socket.isEncrypted())
-        return;
-#endif
-    socket.setSocketOption(QAbstractSocket::KeepAliveOption, true);
 
+#ifdef HAVE_SSL
+    // Non-SSL connections enter here only once, always emit socketInitialized(...) in these cases
+    // SSL connections call socketInitialized() twice, only emit socketInitialized(...) on the first (not yet encrypted) run
+    if (!server.useSsl || !socket.isEncrypted()) {
+        emit socketInitialized(identity, localAddress(), localPort(), peerAddress(), peerPort());
+    }
+
+    if (server.useSsl && !socket.isEncrypted()) {
+        // We'll finish setup once we're encrypted, and called again
+        return;
+    }
+#else
     emit socketInitialized(identity, localAddress(), localPort(), peerAddress(), peerPort());
+#endif
+
+    socket.setSocketOption(QAbstractSocket::KeepAliveOption, true);
 
     // TokenBucket to avoid sending too much at once
     _messageDelay = 2200;  // this seems to be a safe value (2.2 seconds delay)

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -165,7 +165,6 @@ signals:
     void sslErrors(const QVariant &errorData);
 
     void newEvent(Event *event);
-    void socketOpen(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
     void socketInitialized(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
     void socketDisconnected(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
 


### PR DESCRIPTION
This creates an entry for the port as soon as the socket is opened,
without duplicates. This allows an identd service to respond correctly
if a request is received before the SSL handshake has finished and been
processed on our side.

Since socketOpen is not used in the project, it is removed here.
Since the only usage of socketInitialized(...) is with oidentd, its
semantic meaning is slightly changed to occur earlier, like socketOpen,
but only once, like the former socketInitialized(...).