### PR TITLE
Include dirty status in core information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,7 +561,7 @@ endif()
 
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC GIT_HEAD)
-git_describe(GIT_DESCRIBE --long)
+git_describe(GIT_DESCRIBE --long --dirty)
 
 # If not in a Git repo try to read GIT_HEAD and GIT_DESCRIBE from
 # enviroment


### PR DESCRIPTION
If a core was built with a dirty working tree, -dirty will be appended
to the version string. Interestingly, we already test for this in
quassel.cpp (line 292), but this was not being added in the cmake phase.