### PR TITLE
Fix migration of hashversion

### DIFF
--- a/src/core/SQL/PostgreSQL/17/migrate_write_quasseluser.sql
+++ b/src/core/SQL/PostgreSQL/17/migrate_write_quasseluser.sql
@@ -1,2 +1,2 @@
-INSERT INTO quasseluser (userid, username, password)
-VALUES (?, ?, ?)
+INSERT INTO quasseluser (userid, username, password, hashversion)
+VALUES (?, ?, ?, ?)

--- a/src/core/SQL/SQLite/18/migrate_read_quasseluser.sql
+++ b/src/core/SQL/SQLite/18/migrate_read_quasseluser.sql
@@ -1,2 +1,2 @@
-SELECT userid, username, password
+SELECT userid, username, password, hashversion
 FROM quasseluser

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -131,6 +131,7 @@ public:
         UserId id;
         QString username;
         QString password;
+        int hashversion;
     };
 
     struct SenderMO {

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1841,6 +1841,7 @@ bool PostgreSqlMigrationWriter::writeMo(const QuasselUserMO &user)
     bindValue(0, user.id.toInt());
     bindValue(1, user.username);
     bindValue(2, user.password);
+    bindValue(3, user.hashversion);
     return exec();
 }
 

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1808,6 +1808,7 @@ bool SqliteMigrationReader::readMo(QuasselUserMO &user)
     user.id = value(0).toInt();
     user.username = value(1).toString();
     user.password = value(2).toString();
+    user.hashversion = value(3).toInt();
     return true;
 }
 


### PR DESCRIPTION
Previously, hashversion was not migrated.  This would cause the
value to default to 0, causing login failures for existing users.