### PR TITLE
Make "/ " use the rest of the message as a literal

### DIFF
--- a/src/common/aliasmanager.cpp
+++ b/src/common/aliasmanager.cpp
@@ -128,11 +128,14 @@ void AliasManager::processInput(const BufferInfo &info, const QString &msg_, Com
     QString msg = msg_;
 
     // leading slashes indicate there's a command to call unless there is another one in the first section (like a path /proc/cpuinfo)
+    // For those habitally tied to irssi, "/ " also makes the rest of the line a literal message
     int secondSlashPos = msg.indexOf('/', 1);
     int firstSpacePos = msg.indexOf(' ');
-    if (!msg.startsWith('/') || (secondSlashPos != -1 && (secondSlashPos < firstSpacePos || firstSpacePos == -1))) {
+    if (!msg.startsWith('/') || firstSpacePos == 1 || (secondSlashPos != -1 && (secondSlashPos < firstSpacePos || firstSpacePos == -1))) {
         if (msg.startsWith("//"))
-            msg.remove(0, 1);  // //asdf is transformed to /asdf
+            msg.remove(0, 1);  // "//asdf" is transformed to "/asdf"
+        else if (msg.startsWith("/ "))
+            msg.remove(0, 2);  // "/ /asdf" is transformed to "/asdf"
         msg.prepend("/SAY "); // make sure we only send proper commands to the core
     }
     else {


### PR DESCRIPTION
"/ /asdf" now works the same as "//asdf". This is just a convenience for
those of us used to irssi habits, which tend to die hard. :)