### PR TITLE
Fix build for latest libsnore

### DIFF
--- a/src/qtui/snorenotificationbackend.cpp
+++ b/src/qtui/snorenotificationbackend.cpp
@@ -43,9 +43,9 @@ SnoreNotificationBackend::SnoreNotificationBackend (QObject *parent)
 
     Snore::SnoreCore::instance().loadPlugins(
 #ifndef HAVE_KDE
-                Snore::SnorePlugin::BACKEND |
+                Snore::SnorePlugin::PluginType::Backend |
 #endif
-                Snore::SnorePlugin::SECONDARY_BACKEND);
+                Snore::SnorePlugin::PluginType::SecondaryBackend);
     m_application = Snore::Application("Quassel", m_icon);
     m_application.hints().setValue("windows-app-id","QuasselProject.QuasselIRC");
     m_application.hints().setValue("pushover-token", "arNtsi983QSZUqU3KAZrFLKHGFPkdL");
@@ -91,7 +91,7 @@ void SnoreNotificationBackend::close(uint notificationId)
     }
 #endif
     Snore::Notification n = Snore::SnoreCore::instance().getActiveNotificationByID(m_notificationIds.take(notificationId));
-    Snore::SnoreCore::instance().requestCloseNotification(n, Snore::Notification::CLOSED);
+    Snore::SnoreCore::instance().requestCloseNotification(n, Snore::Notification::CloseReasons::Activated);
 }
 
 void SnoreNotificationBackend::actionInvoked(Snore::Notification n)

--- a/src/qtui/ui/snorentificationconfigwidget.ui
+++ b/src/qtui/ui/snorentificationconfigwidget.ui
@@ -55,7 +55,7 @@
   <customwidget>
    <class>Snore::SettingsDialog</class>
    <extends>QWidget</extends>
-   <header location="global">libsnore/settingsdialog.h</header>
+   <header location="global">libsnore/settings/settingsdialog.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
`libsnore` have changed a bit and when I tried to build Quassel with latest `libsnore` it failed. With this patch it compiles but still getting linking error and not really sure what's wrong there...

```
Scanning dependencies of target quasselclient
[100%] Building CXX object src/CMakeFiles/quasselclient.dir/common/main.cpp.o
[100%] Building CXX object src/CMakeFiles/quasselclient.dir/quasselclient_automoc.cpp.o
[100%] Linking CXX executable ../quasselclient
qtui/libmod_qtui.a(snorenotificationbackend.cpp.o): In function `SnoreNotificationBackend::ConfigWidget::save()':
/mnt/GitHub/quassel/src/qtui/snorenotificationbackend.cpp:165: undefined reference to `Snore::SettingsDialog::accept()'
qtui/libmod_qtui.a(snorenotificationbackend.cpp.o): In function `SnoreNotificationBackend::ConfigWidget::defaults()':
/mnt/GitHub/quassel/src/qtui/snorenotificationbackend.cpp:148: undefined reference to `Snore::SettingsDialog::reset()'
qtui/libmod_qtui.a(snorenotificationbackend.cpp.o): In function `Ui_SnoreNotificationConfigWidget::setupUi(QWidget*)':
/mnt/GitHub/quassel/build/src/src/qtui/ui_snorentificationconfigwidget.h:52: undefined reference to `Snore::SettingsDialog::SettingsDialog(QWidget*)'
collect2: error: ld returned 1 exit status
src/CMakeFiles/quasselclient.dir/build.make:125: recipe for target 'src/../quasselclient' failed
make[2]: *** [src/../quasselclient] Error 1
CMakeFiles/Makefile2:238: recipe for target 'src/CMakeFiles/quasselclient.dir/all' failed
make[1]: *** [src/CMakeFiles/quasselclient.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2
```
