### PR TITLE
Disable SSLv3

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -20,6 +20,8 @@
 
 #include <cstdlib>
 
+#include <QSslCipher>
+#include <QSslConfiguration>
 #include <QTextCodec>
 
 #ifdef BUILD_CORE
@@ -67,6 +69,27 @@ Q_IMPORT_PLUGIN(qgif)
 
 int main(int argc, char **argv)
 {
+    {
+        QSslConfiguration sslconf = QSslConfiguration::defaultConfiguration();
+#if QT_VERSION >= 0x050500
+        // Because of the POODLE attack it is recommended to disable SSLv3 (https://disablessl3.com/),
+        // so set SSL protocols to TLS1.0+.
+        sslconf.setProtocol(QSsl::TlsV1_0OrLater);
+#else
+        // QT versions prior to 5.5 do not have the flag for saying "TLSv1 or later" (https://bugreports.qt.io/browse/QTBUG-43168)
+        // We don't have enum values for 1.1 or 1.2, nor for whatever may come next, so we must manually go through the list and strip anything from SSLv3 or earlier
+        QList<QSslCipher> defaultPermitted = sslconf.ciphers(), safe;
+        for (auto i = defaultPermitted.begin(); i != defaultPermitted.end(); ++i) {
+            if (i->protocol() == QSsl::SslV3 || i->protocol() == QSsl::SslV2) {
+                qDebug() << "Disabling insecure (<= SSLv3) protocol" << i->protocolString() << i->name();
+            } else {
+                safe.append(*i);
+            }
+        }
+        sslconf.setCiphers(safe);
+#endif
+        QSslConfiguration::setDefaultConfiguration(sslconf);
+    }
 #if QT_VERSION < 0x050000
     // All our source files are in UTF-8, and Qt5 even requires that
     QTextCodec::setCodecForCStrings(QTextCodec::codecForName("UTF-8"));


### PR DESCRIPTION
irssi has done this since late 2014, shortly after POODLE disclosure:
  https://github.com/irssi/irssi/commit/8bd575df2ec0d4a17b6f59116d555b64f5bb1312

See https://bugreports.qt.io/browse/QTBUG-43168