### PR TITLE
Fix the SSL check on systems that don't use OpenSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,7 +421,7 @@ set(CMAKE_REQUIRED_INCLUDES ${QT_INCLUDES} ${Qt5Core_INCLUDE_DIRS})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5Core_EXECUTABLE_COMPILE_FLAGS}")
 check_cxx_source_compiles("
     #include \"qglobal.h\"
-    #if defined QT_NO_OPENSSL || defined QT_NO_SSL
+    #if defined QT_NO_SSL
     #  error \"No SSL support\"
     #endif
     int main() {}"


### PR DESCRIPTION
OSX uses another backend than OpenSSL according to someone on #qt, so we shouldn't check for it in cmake. Instead we should only check if `QT_NO_SSL` is defined and do runtime checks with `QSslSocket::supportsSsl()` (which I still have to do in all the right places).