### PR TITLE
Add an edit menu on Mac

### DIFF
--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -536,7 +536,35 @@ void MainWin::setupMenus()
 
 #ifdef Q_OS_MAC
     _editMenu = menuBar()->addMenu(tr("&Edit"));
-    _editMenu->addAction("")->setEnabled(false);
+
+    QAction *undoAct = new QAction(tr("&Undo"), this);
+    undoAct->setShortcuts(QKeySequence::Undo);
+
+    QAction *redoAct = new QAction(tr("&Redo"), this);
+    redoAct->setShortcuts(QKeySequence::Redo);
+
+    QAction *cutAct = new QAction(tr("Cu&t"), this);
+    cutAct->setShortcuts(QKeySequence::Cut);
+    cutAct->setStatusTip(tr("Cut the current selection's contents to the "
+                            "clipboard"));
+
+    QAction *copyAct = new QAction(tr("&Copy"), this);
+    copyAct->setShortcuts(QKeySequence::Copy);
+    copyAct->setStatusTip(tr("Copy the current selection's contents to the "
+                             "clipboard"));
+
+    QAction *pasteAct = new QAction(tr("&Paste"), this);
+    pasteAct->setShortcuts(QKeySequence::Paste);
+    pasteAct->setStatusTip(tr("Paste the clipboard's contents into the current "
+                              "selection"));
+
+    _editMenu->addAction(undoAct);
+    _editMenu->addAction(redoAct);
+    _editMenu->addSeparator();
+    _editMenu->addAction(cutAct);
+    _editMenu->addAction(copyAct);
+    _editMenu->addAction(pasteAct);
+
 #endif
 
     _viewMenu = menuBar()->addMenu(tr("&View"));

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -534,6 +534,11 @@ void MainWin::setupMenus()
     _fileMenu->addSeparator();
     _fileMenu->addAction(coll->action("Quit"));
 
+#ifdef Q_OS_MAC
+    _editMenu = menuBar()->addMenu(tr("&Edit"));
+    _editMenu->addAction("")->setEnabled(false);
+#endif
+
     _viewMenu = menuBar()->addMenu(tr("&View"));
     _bufferViewsMenu = _viewMenu->addMenu(tr("&Chat Lists"));
     _bufferViewsMenu->addAction(coll->action("ConfigureBufferViews"));

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -206,6 +206,11 @@ private:
 
     QAction *_fullScreenAction;
     QMenu *_fileMenu, *_networksMenu, *_viewMenu, *_bufferViewsMenu, *_settingsMenu, *_helpMenu, *_helpDebugMenu;
+
+  #ifdef Q_OS_MAC
+    QMenu *_editMenu;
+  #endif
+
     QMenu *_toolbarMenu;
     QToolBar *_mainToolBar, *_chatViewToolBar, *_nickToolBar;
 


### PR DESCRIPTION
Adds an empty edit menu on macs, because this adds the `Start dictation...` and `Emoji&Symbols` entries that allow users to use those as input.

 ![screen shot 2016-01-27 at 14 26 48](https://cloud.githubusercontent.com/assets/1388039/12614738/0cfdbf14-c502-11e5-95eb-37836c996284.png) ![screen shot 2016-01-27 at 14 25 49](https://cloud.githubusercontent.com/assets/1388039/12614723/f5ec9d36-c501-11e5-8155-e6a0ae1b0989.png)