### PR TITLE
Fixed a tiny bug in aliasmanager

### DIFF
--- a/src/common/aliasmanager.cpp
+++ b/src/common/aliasmanager.cpp
@@ -198,7 +198,7 @@ void AliasManager::expand(const QString &alias, const BufferInfo &bufferInfo, co
 
     while (!expandedCommands.isEmpty()) {
         QString command;
-        if (expandedCommands[0].trimmed().toLower().startsWith("/wait")) {
+        if (expandedCommands[0].trimmed().toLower().startsWith("/wait ")) {
             command = expandedCommands.join("; ");
             expandedCommands.clear();
         }


### PR DESCRIPTION
The `/wait` check is to test if the first command is a `/wait`, which would operate synchronously.
But `/wait` matches also on other commands – so, if, for example, we’d have a command like `/waiting`, it would be matched.
Instead we actually want to match on `/wait_ ` (with space at the end, the `_` is supposed to represent a space).