### PR TITLE
Implement IRCv3 CAP LS negotiation, away-notify

### DIFF
--- a/src/common/eventmanager.h
+++ b/src/common/eventmanager.h
@@ -88,6 +88,7 @@ public :
 
         IrcEvent                    = 0x00030000,
         IrcEventAuthenticate,
+        IrcEventAway,
         IrcEventCap,
         IrcEventInvite,
         IrcEventJoin,

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -139,6 +139,9 @@ public slots:
     void setAutoWhoInterval(int interval);
     void setAutoWhoDelay(int delay);
 
+    void queueAutoWhoOneshot(const QStringList &channelsOrNicks);
+    void queueAutoWhoOneshot(const QString &channelOrNick);
+
     void setCapAwayNotifyEnabled(bool enabled);
 
     bool setAutoWhoDone(const QString &channel);

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -88,6 +88,7 @@ public:
     inline void storeChannelCipherKey(const QString &channel, const QByteArray &key) { _cipherKeys[channel.toLower()] = key; }
 
     inline bool isAutoWhoInProgress(const QString &channel) const { return _autoWhoPending.value(channel.toLower(), 0); }
+    inline bool useCapAwayNotify() const { return _useCapAwayNotify; }
 
     inline UserId userId() const { return _coreSession->user(); }
 
@@ -137,6 +138,8 @@ public slots:
     void setAutoWhoEnabled(bool enabled);
     void setAutoWhoInterval(int interval);
     void setAutoWhoDelay(int delay);
+
+    void setCapAwayNotifyEnabled(bool enabled);
 
     bool setAutoWhoDone(const QString &channel);
 
@@ -239,6 +242,9 @@ private:
     QStringList _autoWhoQueue;
     QHash<QString, int> _autoWhoPending;
     QTimer _autoWhoTimer, _autoWhoCycleTimer;
+    /* Keep track of IRCv3 away-notify state.  With away-notify enabled,
+     * poll every channel once regardless of size, then disable polling. */
+    bool _useCapAwayNotify;
 
     QTimer _tokenBucketTimer;
     int _messageDelay;      // token refill speed in ms

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -137,26 +137,80 @@ void CoreSessionEventProcessor::processIrcEventAuthenticate(IrcEvent *e)
 #endif
 }
 
+/* IRCv3.1 away-notify - ":nick!user@host AWAY [:message]" */
+void CoreSessionEventProcessor::processIrcEventAway(IrcEvent *e)
+{
+    if (!checkParamCount(e, 2))
+        return;
+
+    IrcUser *ircuser = e->network()->ircUser(e->params().at(0));
+    if (ircuser) {
+        if (!e->params().at(1).isEmpty()) {
+            ircuser->setAway(true);
+            ircuser->setAwayMessage(e->params().at(1));
+        } else {
+            ircuser->setAway(false);
+        }
+    } else {
+        qDebug() << "Received away-notify data for unknown user" << e->params().at(0);
+    }
+}
 
 void CoreSessionEventProcessor::processIrcEventCap(IrcEvent *e)
 {
     // for SASL, there will only be a single param of 'sasl', however you can check here for
     // additional CAP messages (ls, multi-prefix, et cetera).
-
     if (e->params().count() == 3) {
-        if (e->params().at(2).startsWith("sasl")) { // Freenode (at least) sends "sasl " with a trailing space for some reason!
-            // FIXME use event
-            // if the current identity has a cert set, use SASL EXTERNAL
-#ifdef HAVE_SSL
-            if (!coreNetwork(e)->identityPtr()->sslCert().isNull()) {
-                coreNetwork(e)->putRawLine(coreNetwork(e)->serverEncode("AUTHENTICATE EXTERNAL"));
-            } else {
-#endif
-                // Only working with PLAIN atm, blowfish later
-                coreNetwork(e)->putRawLine(coreNetwork(e)->serverEncode("AUTHENTICATE PLAIN"));
-#ifdef HAVE_SSL
+        if (e->params().at(1).compare("LS", Qt::CaseInsensitive) == 0) {
+            // We know what capabilities are available, request what we want.
+            QString cap_request = "";
+            QStringList caps_available = e->params().at(2).split(' ');
+            for (int i = 0; i < caps_available.count(); ++i) {
+                if (caps_available[i].startsWith("sasl")) {
+                    // Only request SASL if it's enabled
+                    if (coreNetwork(e)->networkInfo().useSasl)
+                        cap_request.append(QString("%1 ").arg(caps_available[i]));
+                } else if (caps_available[i].startsWith("away-notify")) {
+                    cap_request.append(QString("%1 ").arg(caps_available[i]));
+                }
             }
+            if (!cap_request.trimmed().isEmpty()) {
+                // We've got at least one to request that we want
+                coreNetwork(e)->putRawLine(coreNetwork(e)->serverEncode(QString("CAP REQ :%1").arg(cap_request)));
+            } else {
+                // No available desired capabilities, end negotiation
+                coreNetwork(e)->putRawLine(coreNetwork(e)->serverEncode(QString("CAP END")));
+            }
+        } else if (e->params().at(1).compare("ACK", Qt::CaseInsensitive) == 0) {
+            // Got the capabilities we want, proceed as needed.
+            QStringList caps_available = e->params().at(2).split(' ');
+            // Some capabilities (e.g. SASL) require additional configuration
+            // If so, don't end negotiation right after processing capabilities
+            bool _canEndCap = true;
+            for (int i = 0; i < caps_available.count(); ++i) {
+                if (caps_available[i].startsWith("sasl")) {
+                    _canEndCap = false;
+                    // Freenode (at least) sends "sasl " with a trailing space for some reason!
+                    // FIXME use event
+                    // if the current identity has a cert set, use SASL EXTERNAL
+#ifdef HAVE_SSL
+                    if (!coreNetwork(e)->identityPtr()->sslCert().isNull()) {
+                        coreNetwork(e)->putRawLine(coreNetwork(e)->serverEncode("AUTHENTICATE EXTERNAL"));
+                    } else {
 #endif
+                        // Only working with PLAIN atm, blowfish later
+                        coreNetwork(e)->putRawLine(coreNetwork(e)->serverEncode("AUTHENTICATE PLAIN"));
+#ifdef HAVE_SSL
+                    }
+#endif
+                } else if (caps_available[i].startsWith("away-notify")) {
+                    coreNetwork(e)->setCapAwayNotifyEnabled(true);
+                }
+            }
+            if (_canEndCap) {
+                // Safe to end capability negotiation, do so here
+                coreNetwork(e)->putRawLine(coreNetwork(e)->serverEncode(QString("CAP END")));
+            }
         }
     }
 }

--- a/src/core/coresessioneventprocessor.h
+++ b/src/core/coresessioneventprocessor.h
@@ -47,6 +47,7 @@ public:
     Q_INVOKABLE void processIrcEventNumeric(IrcEventNumeric *event);
 
     Q_INVOKABLE void processIrcEventAuthenticate(IrcEvent *event); // SASL auth
+    Q_INVOKABLE void processIrcEventAway(IrcEvent *event);          // away-notify
     Q_INVOKABLE void processIrcEventCap(IrcEvent *event);          // CAP framework
     Q_INVOKABLE void processIrcEventInvite(IrcEvent *event);
     Q_INVOKABLE void processIrcEventJoin(IrcEvent *event);

--- a/src/core/ircparser.cpp
+++ b/src/core/ircparser.cpp
@@ -273,6 +273,14 @@ void IrcParser::processNetworkIncoming(NetworkDataEvent *e)
         }
         break;
 
+    case EventManager::IrcEventAway:
+        {
+            QString nick = nickFromMask(prefix);
+            decParams << nick;
+            decParams << (params.count() >= 1 ? net->userDecode(nick, params.at(0)) : QString());
+        }
+        break;
+
     case EventManager::IrcEventNumeric:
         switch (num) {
         case 301: /* RPL_AWAY */


### PR DESCRIPTION
Change IRC connection flow to unconditionally send ```CAP LS``` as part of the connection.  ```IrcEventCap``` now checks the capability list before requesting anything (currently ```sasl```, ```away-notify```) as ```CAP REQ``` only succeeds on an all-or-nothing basis.  If sasl is available and enabled, authentication continues as normal.

Add support for away-notify, including a new event type to parse any away events.  As nicks change status, update the ```ircuser``` objects, including away messages.  Any changes to away can be immediately seen without needing to ```/whois``` for the message.

Modify automatic WHO polling when away-notify is enabled to poll all channels ONCE regardless of polling settings and auto-who nick-limit, as directed by IRCv3 specs.  This is necessary to capture away state for any existing users in the channel.  Any new channels joined after this will queue for a separate one-off WHO poll.

See: http://ircv3.net/specs/core/capability-negotiation-3.1.html
And: http://ircv3.net/specs/extensions/away-notify-3.1.html