### PR TITLE
Implement IRCv3.2 CAP LS, away-notify and friends

### DIFF
--- a/src/common/eventmanager.h
+++ b/src/common/eventmanager.h
@@ -88,6 +88,7 @@ public :
 
         IrcEvent                    = 0x00030000,
         IrcEventAuthenticate,
+        IrcEventAccount,
         IrcEventAway,
         IrcEventCap,
         IrcEventInvite,

--- a/src/common/eventmanager.h
+++ b/src/common/eventmanager.h
@@ -88,6 +88,7 @@ public :
 
         IrcEvent                    = 0x00030000,
         IrcEventAuthenticate,
+        IrcEventAway,
         IrcEventCap,
         IrcEventInvite,
         IrcEventJoin,

--- a/src/common/ircuser.cpp
+++ b/src/common/ircuser.cpp
@@ -346,9 +346,11 @@ void IrcUser::channelDestroyed()
 
 void IrcUser::setUserModes(const QString &modes)
 {
-    _userModes = modes;
-    SYNC(ARG(modes))
-    emit userModesSet(modes);
+    if (_userModes != modes) {
+        _userModes = modes;
+        SYNC(ARG(modes))
+        emit userModesSet(modes);
+    }
 }
 
 
@@ -357,13 +359,19 @@ void IrcUser::addUserModes(const QString &modes)
     if (modes.isEmpty())
         return;
 
+    // Don't needlessly sync when no changes are made
+    bool changesMade = false;
     for (int i = 0; i < modes.count(); i++) {
-        if (!_userModes.contains(modes[i]))
+        if (!_userModes.contains(modes[i])) {
             _userModes += modes[i];
+            changesMade = true;
+        }
     }
 
-    SYNC(ARG(modes))
-    emit userModesAdded(modes);
+    if (changesMade) {
+        SYNC(ARG(modes))
+        emit userModesAdded(modes);
+    }
 }
 
 

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -141,6 +141,15 @@ public:
      */
     inline bool useCapSASL() const { return capEnabled("sasl"); }
 
+    /**
+     * Gets the status of the away-notify capability.
+     *
+     * http://ircv3.net/specs/extensions/away-notify-3.1.html
+     *
+     * @returns True if away-notify is enabled, otherwise false
+     */
+    inline bool useCapAwayNotify() const { return capEnabled("away-notify"); }
+
 public slots:
     virtual void setMyNick(const QString &mynick);
 
@@ -216,6 +225,16 @@ public slots:
     void setAutoWhoEnabled(bool enabled);
     void setAutoWhoInterval(int interval);
     void setAutoWhoDelay(int delay);
+
+    /**
+     * Appends the given channel/nick to the front of the AutoWho queue.
+     *
+     * When 'away-notify' is enabled, this will trigger an immediate AutoWho since regular
+     * who-cycles are disabled as per IRCv3 specifications.
+     *
+     * @param[in] channelOrNick Channel or nickname to WHO
+     */
+    void queueAutoWhoOneshot(const QString &channelOrNick);
 
     bool setAutoWhoDone(const QString &channel);
 

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -168,6 +168,15 @@ public:
      */
     inline bool useCapExtendedJoin() const { return capEnabled("extended-join"); }
 
+    /**
+     * Gets the status of the userhost-in-names capability.
+     *
+     * http://ircv3.net/specs/extensions/userhost-in-names-3.2.html
+     *
+     * @returns True if userhost-in-names is enabled, otherwise false
+     */
+    inline bool useCapUserhostInNames() const { return capEnabled("userhost-in-names"); }
+
 public slots:
     virtual void setMyNick(const QString &mynick);
 

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -177,6 +177,15 @@ public:
      */
     inline bool useCapUserhostInNames() const { return capEnabled("userhost-in-names"); }
 
+    /**
+     * Gets the status of the multi-prefix capability.
+     *
+     * http://ircv3.net/specs/extensions/multi-prefix-3.1.html
+     *
+     * @returns True if multi-prefix is enabled, otherwise false
+     */
+    inline bool useCapMultiPrefix() const { return capEnabled("multi-prefix"); }
+
 public slots:
     virtual void setMyNick(const QString &mynick);
 

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -150,6 +150,24 @@ public:
      */
     inline bool useCapAwayNotify() const { return capEnabled("away-notify"); }
 
+    /**
+     * Gets the status of the account-notify capability.
+     *
+     * http://ircv3.net/specs/extensions/account-notify-3.1.html
+     *
+     * @returns True if account-notify is enabled, otherwise false
+     */
+    inline bool useCapAccountNotify() const { return capEnabled("account-notify"); }
+
+    /**
+     * Gets the status of the extended-join capability.
+     *
+     * http://ircv3.net/specs/extensions/extended-join-3.1.html
+     *
+     * @returns True if extended-join is enabled, otherwise false
+     */
+    inline bool useCapExtendedJoin() const { return capEnabled("extended-join"); }
+
 public slots:
     virtual void setMyNick(const QString &mynick);
 

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -987,10 +987,9 @@ void CoreSessionEventProcessor::processIrcEvent353(IrcEvent *e)
             // See: http://ircv3.net/specs/extensions/multi-prefix-3.1.html
             while (e->network()->prefixes().contains(nick[0])) {
                 // Mode found in 1 left-most character, add it to the list.
-                // FIXME Only allow one possible mode to avoid a warning in older clients
-                if (mode.isEmpty())
-                    mode.append(e->network()->prefixToMode(nick[0]));
-                //mode.append(e->network()->prefixToMode(nick[0]));
+                // Note: sending multiple modes may cause a warning in older clients.
+                // In testing, the clients still seemed to function fine.
+                mode.append(e->network()->prefixToMode(nick[0]));
                 // Remove this mode from the nick
                 nick = nick.remove(0, 1);
             }

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -193,7 +193,8 @@ void CoreSessionEventProcessor::processIrcEventCap(IrcEvent *e)
                         queueCurrentCap = true;
                 } else if (availableCapPair.at(0).startsWith("away-notify") ||
                            availableCapPair.at(0).startsWith("account-notify") ||
-                           availableCapPair.at(0).startsWith("extended-join")) {
+                           availableCapPair.at(0).startsWith("extended-join") ||
+                           availableCapPair.at(0).startsWith("userhost-in-names")) {
                     // Always request these capabilities if available
                     queueCurrentCap = true;
                 }
@@ -958,6 +959,11 @@ void CoreSessionEventProcessor::processIrcEvent353(IrcEvent *e)
             mode = e->network()->prefixToMode(nick[0]);
             nick = nick.mid(1);
         }
+
+        // If userhost-in-names capability is enabled, the following will be
+        // in the form "nick!user@host" rather than "nick".  This works without
+        // special handling as the following use nickFromHost() as needed.
+        // See: http://ircv3.net/specs/extensions/userhost-in-names-3.2.html
 
         nicks << nick;
         modes << mode;

--- a/src/core/coresessioneventprocessor.h
+++ b/src/core/coresessioneventprocessor.h
@@ -48,6 +48,7 @@ public:
 
     Q_INVOKABLE void processIrcEventAuthenticate(IrcEvent *event); /// SASL authentication
     Q_INVOKABLE void processIrcEventCap(IrcEvent *event);          /// CAP framework negotiation
+    Q_INVOKABLE void processIrcEventAccount(IrcEvent *event);      /// account-notify received
     Q_INVOKABLE void processIrcEventAway(IrcEvent *event);         /// away-notify received
     Q_INVOKABLE void processIrcEventInvite(IrcEvent *event);
     Q_INVOKABLE void processIrcEventJoin(IrcEvent *event);

--- a/src/core/coresessioneventprocessor.h
+++ b/src/core/coresessioneventprocessor.h
@@ -46,8 +46,8 @@ public:
 
     Q_INVOKABLE void processIrcEventNumeric(IrcEventNumeric *event);
 
-    Q_INVOKABLE void processIrcEventAuthenticate(IrcEvent *event); // SASL auth
-    Q_INVOKABLE void processIrcEventCap(IrcEvent *event);          // CAP framework
+    Q_INVOKABLE void processIrcEventAuthenticate(IrcEvent *event); /// SASL authentication
+    Q_INVOKABLE void processIrcEventCap(IrcEvent *event);          /// CAP framework negotiation
     Q_INVOKABLE void processIrcEventInvite(IrcEvent *event);
     Q_INVOKABLE void processIrcEventJoin(IrcEvent *event);
     Q_INVOKABLE void lateProcessIrcEventKick(IrcEvent *event);
@@ -152,6 +152,17 @@ private:
     // key: quit message
     // value: the corresponding netsplit object
     QHash<Network *, QHash<QString, Netsplit *> > _netsplits;
+
+    // IRCv3 capability negotiation
+    /**
+     * Sends the next capability from the queue.
+     *
+     * During nick registration if any capabilities remain queued, this will take the next and
+     * request it.  When no capabilities remain, capability negotiation is ended.
+     *
+     * @param[in,out] A network currently undergoing capability negotiation
+     */
+    void sendNextCap(Network *net);
 };
 
 

--- a/src/core/coresessioneventprocessor.h
+++ b/src/core/coresessioneventprocessor.h
@@ -48,6 +48,7 @@ public:
 
     Q_INVOKABLE void processIrcEventAuthenticate(IrcEvent *event); /// SASL authentication
     Q_INVOKABLE void processIrcEventCap(IrcEvent *event);          /// CAP framework negotiation
+    Q_INVOKABLE void processIrcEventAway(IrcEvent *event);         /// away-notify received
     Q_INVOKABLE void processIrcEventInvite(IrcEvent *event);
     Q_INVOKABLE void processIrcEventJoin(IrcEvent *event);
     Q_INVOKABLE void lateProcessIrcEventKick(IrcEvent *event);

--- a/src/core/ircparser.cpp
+++ b/src/core/ircparser.cpp
@@ -273,6 +273,15 @@ void IrcParser::processNetworkIncoming(NetworkDataEvent *e)
         }
         break;
 
+    case EventManager::IrcEventAway:
+        {
+            QString nick = nickFromMask(prefix);
+            decParams << nick;
+            decParams << (params.count() >= 1 ? net->userDecode(nick, params.at(0)) : QString());
+            net->updateNickFromMask(prefix);
+        }
+        break;
+
     case EventManager::IrcEventNumeric:
         switch (num) {
         case 301: /* RPL_AWAY */

--- a/src/core/ircparser.cpp
+++ b/src/core/ircparser.cpp
@@ -298,6 +298,17 @@ void IrcParser::processNetworkIncoming(NetworkDataEvent *e)
                 decParams << net->channelDecode(channel, params.at(2));
             }
             break;
+        case 451: /* You have not registered... */
+            if (target.compare("CAP", Qt::CaseInsensitive) == 0) {
+                // :irc.server.com 451 CAP :You have not registered
+                // If server doesn't support capabilities, it will report this message.  Turn it
+                // into a nicer message since it's not a real error.
+                defaultHandling = false;
+                events << new MessageEvent(Message::Server, e->network(),
+                                           tr("Capability negotiation not supported"),
+                                           QString(), QString(), Message::None, e->timestamp());
+            }
+            break;
         }
 
     default:

--- a/src/core/ircparser.cpp
+++ b/src/core/ircparser.cpp
@@ -180,6 +180,7 @@ void IrcParser::processNetworkIncoming(NetworkDataEvent *e)
 
         if (checkParamCount(cmd, params, 1)) {
             QString senderNick = nickFromMask(prefix);
+            net->updateNickFromMask(prefix);
             QByteArray msg = params.count() < 2 ? QByteArray() : params.at(1);
 
             QStringList targets = net->serverDecode(params.at(0)).split(',', QString::SkipEmptyParts);
@@ -226,8 +227,10 @@ void IrcParser::processNetworkIncoming(NetworkDataEvent *e)
                 else {
                     if (!target.isEmpty() && net->prefixes().contains(target.at(0)))
                         target = target.mid(1);
-                    if (!net->isChannelName(target))
+                    if (!net->isChannelName(target)) {
                         target = nickFromMask(prefix);
+                        net->updateNickFromMask(prefix);
+                    }
                 }
 
 #ifdef HAVE_QCA2
@@ -256,12 +259,14 @@ void IrcParser::processNetworkIncoming(NetworkDataEvent *e)
             QString channel = net->serverDecode(params.at(0));
             decParams << channel;
             decParams << net->userDecode(nickFromMask(prefix), params.at(1));
+            net->updateNickFromMask(prefix);
         }
         break;
 
     case EventManager::IrcEventQuit:
         if (params.count() >= 1) {
             decParams << net->userDecode(nickFromMask(prefix), params.at(0));
+            net->updateNickFromMask(prefix);
         }
         break;
 


### PR DESCRIPTION
## In short
* Support IRCv3 capability negotiation, allowing for more than just SASL
* Opt-in to immediate notification of away messages for other users
 * No need for ```WHO``` polling, works on arbitrarily large channels
 * Get away messages without ```WHOIS```
* Add more sources of nick information updates (```nick!user@host```)
* Track multiple user modes instead of just the highest, e.g. ```qohv``` instead of ```q```

## Rationale
Modern chat systems such as Jabber and Telegram provide multiple ways to indicate status and presence, raising expectations for all conversation platforms.

IRC offers two forms of status, "Here" or "Gone", with an optional message for the latter.  Quassel's current approach requires polling ```WHO``` to update presence information, introducing minutes of delay between updates for smaller channels while not offering any status for channels above the nick limit.  Status messages are only seen after a ```WHOIS nick``` or sending a message.

IRCv3 adds a set of new features to help bridge the gap between IRC of old and new technology.  [```away-notify```](http://ircv3.net/specs/extensions/away-notify-3.1.html ) offers near-instant updating of away status and message *without* any ```WHO``` polling, allowing tracking the status of arbitrarily large channels.  These away notifications also provide the IRC user's away message without need of a ```WHOIS```, allowing easy checking of why someone's away without manual action on the Quassel user's part.

Quassel should implement more of IRCv3 in order to provide a faster, more capable platform for conversation on IRC.

## Approaches to Negotiation
### Always negotiate IRCv3 capabilities (selected approach)
When the Quassel core connects, send a ```CAP LS 302``` at the start, only requesting capabilities from the list provided by the IRC server.

* Benefits
 * Provides access to useful IRCv3 features such as [```away-notify```](http://ircv3.net/specs/extensions/away-notify-3.1.html ) - instant away notification, [```userhost-in-names```](http://ircv3.net/specs/extensions/userhost-in-names-3.2.html ) - ```user@host``` information when joining a channel, etc
 * Enables supporting new specifications with minimal additional work
 * Will allow existing SASL support to [optionally detect if ```PLAIN``` or ```EXTERNAL``` is supported](http://ircv3.net/specs/extensions/sasl-3.2.html ), rather than forcing the Quassel user to figure it out
 * Follows IRCv3 recommendations
* Drawbacks
 * IRC servers might behave erratically.  This affects any client and is not specific to Quassel.
 * Slightly increased connection time on IRCv3 servers as capabilities are negotiated.  *In testing, this adds 1-8 seconds, negligible when the Quassel core stays connected as designed.*
 * IRC servers that technically support SASL but don't announce it as required by IRCv3 would no longer make use of SASL authentication.  *According to Freenode #ircv3, this is rare.*

This is the approach recommended by the [IRCv3 specifications](http://ircv3.net/specs/core/capability-negotiation-3.1.html ) and already implemented by [ZNC](https://github.com/znc/znc/blob/1f226d2adeb2cfa08fa54d360c110c16fd361f18/src/IRCSock.cpp#L1184 ) and [HexChat](https://github.com/hexchat/hexchat/blob/4362085847f359ed13df6f8f488a06eb52ecd767/src/common/proto-irc.c#L51 ).

### Make capability negotiation optional
Keep the capability negotiation code from above, but optionally revert to prior behavior depending on a "Use capability negotiation" setting, akin to the "Use SASL" setting available now.
* Benefits
 * Easy way to return to previous behavior if it causes issues, whether case-by-case or changing the default from "Negotiate" to "Don't negotiate"
 * *See benefits listed for "Always negotiate"*
* Drawbacks
 * Increases code, database, and UI complexity
 * Requires a database schema change, potentially preventing downgrading.  *I have not confirmed this.*

### Other options
**Continue ignoring IRCv3**
* Benefits
 * Easiest as there's no change from today
* Drawbacks
 * Limits Quassel's ability to compete with other IRC client/bouncer setups that support new IRCv3 features

**Always blindly request all IRCv3 capabilities implemented in Quassel**
* Benefits
 * Follows the current pattern with SASL authentication and might be slightly less prone to breaking older servers
* Drawbacks
 * Doesn't allow for checking capability parameters offered in ```CAP LS *``` replies, e.g. ```sasl=PLAIN```
 * Adds a fixed overhead to connection as every supported capability must be tried

## Implementation
- Always send ```CAP LS```, similar to [ZNC](https://github.com/znc/znc/blob/1f226d2adeb2cfa08fa54d360c110c16fd361f18/src/IRCSock.cpp#L1184 ) and [HexChat](https://github.com/hexchat/hexchat/blob/4362085847f359ed13df6f8f488a06eb52ecd767/src/common/proto-irc.c#L51 ).  ```IrcEventCap``` checks returned capabilities, queuing up desired ones until all replies finish, then requests each capability one-by-one.  This prevents an error with one capability from blocking all of them.
- Add support for ```away-notify```.  As nicks change status, update ```ircuser``` objects with new away status and messages, no ```/whois``` needed.
  - Modify automatic ```WHO``` polling when away-notify is active to poll all channels ONCE regardless of polling settings and nick-limit.  This captures away state for existing nicks in the channel.  Channels joined after this will queue a separate one-off WHO poll.
  - Queue one-time ```WHO``` of nicks who join a channel when ```away-notify``` is active as some servers won't send an ```AWAY``` message in this situation.  To support this, ```autoWhoQueue``` can now check specific users.
- Add support for ```account-notify``` alongside ```extended-join```.  For now, this only updates user/hostname information.  In the future it will track logged in accounts in ```ircuser```, pending a new feature flag and inclusion of ```WHOX``` support.
- Add support for ```userhost-in-names```, which, if enabled, allows getting the user/hostname information of a channel without using ```WHO``` polling.
- Add support for ```multi-prefix``` to get the full list of user modes in ```NAMES``` and ```WHO``` replies, e.g. ```qohv``` for a nick in a channel that's owner, operator, half-operator, and voiced.
 - Send extra modes via a non-breaking protocol change, at most causing older clients to log a warning to console (see commit for more details)

See: http://ircv3.net/irc/ for more information on 3.1 and 3.2 specs.

### Availability of IRCv3
Most popular IRC servers support IRCv3, ```away-notify```, etc according to the [IRCv3 compliant servers list](http://ircv3.net/software/servers.html ).  IRC networks themselves still have some catching up.

As of 2016-2-12:
* [Bitlbee](https://www.bitlbee.org/main.php/news.r.html ) supports ```sasl=PLAIN multi-prefix extended-join away-notify userhost-in-names```, but no ```account-notify``` (not really applicable)
* [Freenode](https://www.freenode.net/ ) supports ```account-notify extended-join identify-msg multi-prefix sasl```, but no ```away-notify``` or ```userhost-in-names```.  *It seems they will eventually add support for ```away-notify``` since searching online found references to it, e.g. [this post on TLS that uses Freenode](https://gist.github.com/grawity/f661adc10fb2d7a580ea ).*
* [GNOME](https://wiki.gnome.org/Community/GettingInTouch/IRC ) offers ```account-notify away-notify multi-prefix tls userhost-in-names```, but no ```extended-join```
* [OFTC](http://www.oftc.net/ ) supports ```multi-prefix```, but no other IRCv3 features

IRCCloud has a useful [summary of IRCv3 features and network support](https://blog.irccloud.com/ircv3/ ).

----
I closed my [previous pull request](https://github.com/quassel/quassel/pull/179 ) and started anew due to significant changes in how I approached the problem.  Let me know if you have any questions or find issues during testing.

## Critique, questions, and other feedback welcome!