### PR TITLE
Warn when IRC server SSL validation fails

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -1040,9 +1040,15 @@ void CoreNetwork::sendAutoWho()
 #ifdef HAVE_SSL
 void CoreNetwork::sslErrors(const QList<QSslError> &sslErrors)
 {
-    Q_UNUSED(sslErrors)
+    displayMsg(Message::Error, BufferInfo::StatusBuffer, "",
+               tr("WARNING: Encrypted connection is insecure and might not be trustworthy"));
+    if (!sslErrors.empty()) {
+        displayMsg(Message::Error, BufferInfo::StatusBuffer, "",
+                   tr("Reason: %1").arg(sslErrors.first().errorString()));
+    }
     socket.ignoreSslErrors();
-    // TODO errorhandling
+    // TODO Implement an off-by-default "Allow insecure connections" setting for networks.
+    // Don't ignore SSL errors unless that setting is enabled.
 }
 
 


### PR DESCRIPTION
During connection, warn if the SSL validation fails, then continue connecting as before.  This isn't ideal, but it's better than silently accepting the error without any indication.

In the future, Quassel should stop connecting entirely and require toggling an override in the IRC server network settings.  That will require a database schema change, a new checkbox in the UI, CoreFeature, etc.

Example output:
```
[6:04:32 pm] * Connecting to irc.rizon.net:6697...
[6:04:32 pm] * WARNING: Encrypted connection is insecure and might not be trustworthy
[6:04:32 pm] * Reason: The certificate is self-signed, and untrusted
```