### PR TITLE
Don't update IrcUser modes with channel-specific modes

### DIFF
--- a/src/common/ircchannel.cpp
+++ b/src/common/ircchannel.cpp
@@ -198,9 +198,6 @@ void IrcChannel::joinIrcUsers(const QList<IrcUser *> &users, const QStringList &
         // If you wonder why there is no counterpart to ircUserJoined:
         // the joins are propagated by the ircuser. The signal ircUserJoined is only for convenience
 
-        // Also update the IRC user's record of modes; this allows easier tracking
-        ircuser->addUserModes(modes[i]);
-
         newNicks << ircuser->nick();
         newModes << modes[i];
         newUsers << ircuser;
@@ -291,8 +288,6 @@ void IrcChannel::addUserMode(IrcUser *ircuser, const QString &mode)
 
     if (!_userModes[ircuser].contains(mode)) {
         _userModes[ircuser] += mode;
-        // Also update the IRC user's record of modes; this allows easier tracking
-        ircuser->addUserModes(mode);
         QString nick = ircuser->nick();
         SYNC_OTHER(addUserMode, ARG(nick), ARG(mode))
         emit ircUserModeAdded(ircuser, mode);
@@ -314,8 +309,6 @@ void IrcChannel::removeUserMode(IrcUser *ircuser, const QString &mode)
 
     if (_userModes[ircuser].contains(mode)) {
         _userModes[ircuser].remove(mode);
-        // Also update the IRC user's record of modes; this allows easier tracking
-        ircuser->removeUserModes(mode);
         QString nick = ircuser->nick();
         SYNC_OTHER(removeUserMode, ARG(nick), ARG(mode));
         emit ircUserModeRemoved(ircuser, mode);

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -105,6 +105,7 @@ public:
     /**
      * Checks if a given capability is enabled.
      *
+     * @param[in] capability Name of capability
      * @returns True if enabled, otherwise false
      */
     inline bool capEnabled(const QString &capability) const { return _capsSupported.contains(capability); }
@@ -119,6 +120,7 @@ public:
     /**
      * Gets the value of an enabled or pending capability, e.g. sasl=plain.
      *
+     * @param[in] capability Name of capability
      * @returns Value of capability if one was specified, otherwise empty string
      */
     QString capValue(const QString &capability) const;

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -942,8 +942,22 @@ void CoreSessionEventProcessor::processIrcEvent352(IrcEvent *e)
             // Some IRC servers decide to not follow the spec, returning only -some- of the user
             // modes in WHO despite listing them all in NAMES.  For now, assume it can only add
             // and not take away.  *sigh*
-            if (!validModes.isEmpty())
-                ircuser->addUserModes(validModes);
+            if (!validModes.isEmpty()) {
+                if (channel != "*") {
+                    // Channel-specific modes received, apply to given channel only
+                    IrcChannel *ircChan = e->network()->ircChannel(channel);
+                    if (ircChan) {
+                        // Do one mode at a time
+                        // TODO Better way of syncing this without breaking protocol?
+                        for (int i = 0; i < validModes.count(); ++i) {
+                            ircChan->addUserMode(ircuser, validModes.at(i));
+                        }
+                    }
+                } else {
+                    // Modes apply to the user everywhere
+                    ircuser->addUserModes(validModes);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Channel-specific user modes in ```IrcChannel``` should not be applied to ```IrcUser``` objects shared between channels.  Otherwise, this results in getting ```+o``` operator status in one channel implying ```+o``` in other channels.  Fortunately, only tooltips seem affected.

User modes shown in the nick list of Quassel should instead check the current channel user modes in ```IrcUserItem::toolTip()```, perhaps as part of pull-request #186.