### PR TITLE
Implement Highlight-Only ignore

### DIFF
--- a/src/client/messagefilter.cpp
+++ b/src/client/messagefilter.cpp
@@ -156,9 +156,12 @@ bool MessageFilter::filterAcceptsRow(int sourceRow, const QModelIndex &sourcePar
 
     // ignorelist handling
     // only match if message is not flagged as server msg
-    if (!(flags & Message::ServerMsg) && Client::ignoreListManager()
-        && Client::ignoreListManager()->match(sourceIdx.data(MessageModel::MessageRole).value<Message>(), Client::networkModel()->networkName(bufferId)))
-        return false;
+    if (!(flags & Message::ServerMsg) && Client::ignoreListManager()) {
+        IgnoreListManager::StrictnessType strictness;
+        strictness = Client::ignoreListManager()->match(sourceIdx.data(MessageModel::MessageRole).value<Message>(), Client::networkModel()->networkName(bufferId));
+        if (strictness != IgnoreListManager::UnmatchedStrictness && strictness != IgnoreListManager::HighlightOnlyStrictness)
+            return false;
+    }
 
     if (flags & Message::Redirected) {
         int redirectionTarget = 0;

--- a/src/common/ignorelistmanager.h
+++ b/src/common/ignorelistmanager.h
@@ -44,7 +44,8 @@ public:
     enum StrictnessType {
         UnmatchedStrictness = 0,
         SoftStrictness = 1,
-        HardStrictness = 2
+        HardStrictness = 2,
+        HighlightOnlyStrictness = 3
     };
 
     enum ScopeType {
@@ -97,7 +98,7 @@ public:
     /** This method checks if a message matches the users ignorelist.
       * \param msg The Message that should be checked
       * \param network The networkname the message belongs to
-      * \return UnmatchedStrictness, HardStrictness or SoftStrictness representing the match type
+      * \return UnmatchedStrictness, HardStrictness, SoftStrictness or IgnoreOnlyStrictness representing the match type
       */
     inline StrictnessType match(const Message &msg, const QString &network = QString()) { return _match(msg.contents(), msg.sender(), msg.type(), network, msg.bufferInfo().bufferName()); }
 

--- a/src/qtui/qtuimessageprocessor.cpp
+++ b/src/qtui/qtuimessageprocessor.cpp
@@ -21,6 +21,7 @@
 #include "qtuimessageprocessor.h"
 
 #include "client.h"
+#include "clientignorelistmanager.h"
 #include "clientsettings.h"
 #include "identity.h"
 #include "messagemodel.h"
@@ -112,6 +113,8 @@ void QtUiMessageProcessor::processNextMessage()
 void QtUiMessageProcessor::checkForHighlight(Message &msg)
 {
     if (!((msg.type() & (Message::Plain | Message::Notice | Message::Action)) && !(msg.flags() & Message::Self)))
+        return;
+    if (Client::ignoreListManager()->match(msg, Client::networkModel()->networkName(msg.bufferId())) == IgnoreListManager::HighlightOnlyStrictness)
         return;
 
     // TODO: Cache this (per network)

--- a/src/qtui/settingspages/ignorelisteditdlg.ui
+++ b/src/qtui/settingspages/ignorelisteditdlg.ui
@@ -7,8 +7,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>389</width>
-    <height>368</height>
+    <width>390</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,6 +25,8 @@
       <widget class="QGroupBox" name="strictnessGroupBox">
        <property name="toolTip">
         <string>&lt;p&gt;&lt;b&gt;Strictness:&lt;/b&gt;&lt;/p&gt;
+&lt;p&gt;&lt;u&gt;Highlight only:&lt;/u&gt;&lt;/p&gt;
+&lt;p&gt;Do not ignore messages, simply ignore highlights caused by them.&lt;/p&gt;
 &lt;p&gt;&lt;u&gt;Dynamic:&lt;/u&gt;&lt;/p&gt;
 &lt;p&gt;Messages are filtered &quot;on the fly&quot;.
 Whenever you disable/delete the ignore rule, the messages are shown again.&lt;/p&gt;
@@ -35,6 +37,13 @@ Whenever you disable/delete the ignore rule, the messages are shown again.&lt;/p
         <string>Strictness</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QRadioButton" name="highlightOnlyButton">
+          <property name="text">
+           <string>Highlight only</string>
+          </property>
+         </widget>
+        </item>
         <item>
          <widget class="QRadioButton" name="dynamicStrictnessButton">
           <property name="text">

--- a/src/qtui/settingspages/ignorelistsettingspage.cpp
+++ b/src/qtui/settingspages/ignorelistsettingspage.cpp
@@ -241,8 +241,9 @@ IgnoreListEditDlg::IgnoreListEditDlg(const IgnoreListManager::IgnoreListItem &it
     _typeButtonGroup.addButton(ui.senderTypeButton, 0);
     _typeButtonGroup.addButton(ui.messageTypeButton, 1);
     _typeButtonGroup.addButton(ui.ctcpTypeButton, 2);
-    _strictnessButtonGroup.addButton(ui.dynamicStrictnessButton, 0);
-    _strictnessButtonGroup.addButton(ui.permanentStrictnessButton, 1);
+    _strictnessButtonGroup.addButton(ui.highlightOnlyButton, 0);
+    _strictnessButtonGroup.addButton(ui.dynamicStrictnessButton, 1);
+    _strictnessButtonGroup.addButton(ui.permanentStrictnessButton, 2);
     _scopeButtonGroup.addButton(ui.globalScopeButton, 0);
     _scopeButtonGroup.addButton(ui.networkScopeButton, 1);
     _scopeButtonGroup.addButton(ui.channelScopeButton, 2);
@@ -263,6 +264,8 @@ IgnoreListEditDlg::IgnoreListEditDlg(const IgnoreListManager::IgnoreListItem &it
 
     if (item.strictness == IgnoreListManager::HardStrictness)
         ui.permanentStrictnessButton->setChecked(true);
+    else if (item.strictness == IgnoreListManager::HighlightOnlyStrictness)
+        ui.highlightOnlyButton->setChecked(true);
     else
         ui.dynamicStrictnessButton->setChecked(true);
 
@@ -309,6 +312,8 @@ void IgnoreListEditDlg::widgetHasChanged()
 
     if (ui.permanentStrictnessButton->isChecked())
         _clonedIgnoreListItem.strictness = IgnoreListManager::HardStrictness;
+    else if (ui.highlightOnlyButton->isChecked())
+        _clonedIgnoreListItem.strictness = IgnoreListManager::HighlightOnlyStrictness;
     else
         _clonedIgnoreListItem.strictness = IgnoreListManager::SoftStrictness;
 


### PR DESCRIPTION
This new strictness allows for only ignoring highlights caused by messages matching a certain ignore rule, not the actual messages themselves.

This can be useful to ignore highlights produced by bots.
