### PR TITLE
Support session management with Qt5

### DIFF
--- a/src/qtui/qtuiapplication.cpp
+++ b/src/qtui/qtuiapplication.cpp
@@ -33,7 +33,6 @@
 #include "qtui.h"
 #include "qtuisettings.h"
 
-
 QtUiApplication::QtUiApplication(int &argc, char **argv)
 #ifdef HAVE_KDE4
     : KApplication(),  // KApplication is deprecated in KF5
@@ -91,6 +90,12 @@ QtUiApplication::QtUiApplication(int &argc, char **argv)
     qInstallMsgHandler(Client::logMessage);
 #else
     qInstallMessageHandler(Client::logMessage);
+    connect(this, &QGuiApplication::commitDataRequest, this, &QtUiApplication::commitData, Qt::DirectConnection);
+    connect(this, &QGuiApplication::saveStateRequest, this, &QtUiApplication::saveState, Qt::DirectConnection);
+#endif
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+    QGuiApplication::setFallbackSessionManagementEnabled(false);
 #endif
 }
 

--- a/src/qtui/qtuiapplication.h
+++ b/src/qtui/qtuiapplication.h
@@ -50,10 +50,15 @@ public:
     virtual bool init();
 
     void resumeSessionIfPossible();
-    virtual void commitData(QSessionManager &manager);
-    virtual void saveState(QSessionManager &manager);
-
     inline bool isAboutToQuit() const { return _aboutToQuit; }
+
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+    void commitData(QSessionManager &manager) override;
+    void saveState(QSessionManager &manager) override;
+#else
+    void commitData(QSessionManager &manager);
+    void saveState(QSessionManager &manager);
+#endif
 
 protected:
     virtual void quit();


### PR DESCRIPTION
Qt5 moved away from virtual methods towards signals for commitData() and saveState().
These were simply not called anymore in our code.

In Qt 5.6 a bug was fixed that broke session management at least with KF5.
As we do handle the session management, we can safely disable the fallback.
See QTBUG-49667 and https://codereview.qt-project.org/#/c/148274/ for details.

Please test this with Qt4 as I don't have a setup for it anymore.
Applying this patch allows my local KDE 5.12.3 to successfully restore quasselclient built against Qt 5.6.0. I also verified that it actually uses the session restoring code path in resumeSessionIfPossible().