### PR TITLE
Sync IRCv3, account tracking, CAP NEW/DEL, polish, and more!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 build*
 *.pyc
 tags
+
+# Qt Creator configuration
+CMakeLists.txt.user

--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -569,12 +569,33 @@ QString QueryBufferItem::toolTip(int column) const
                    NetworkItem::escapeHTML(_ircUser->suserHost()),
                    !_ircUser->suserHost().isEmpty());
         }
+
+        // Keep track of whether or not the account information's been added.  Don't show it twice.
+        bool accountAdded = false;
+        if(!_ircUser->account().isEmpty()) {
+            // IRCv3 account-notify is supported by the core and IRC server.
+            // Assume logged out (seems to be more common)
+            QString accountHTML = QString("<p class='italic'>%1</p>").arg(tr("Not logged in"));
+
+            // If account is logged in, replace with the escaped account name.
+            if (_ircUser->account() != "*") {
+                accountHTML = NetworkItem::escapeHTML(_ircUser->account());
+            }
+            addRow(NetworkItem::escapeHTML(tr("Account"), true),
+                   accountHTML,
+                   true);
+            // Mark the row as added
+            accountAdded = true;
+        }
         // whoisServiceReply may return "<nick> is identified for this nick", which should be translated.
         // See https://www.alien.net.au/irc/irc2numerics.html
         if(_ircUser->whoisServiceReply().endsWith("identified for this nick")) {
             addRow(NetworkItem::escapeHTML(tr("Account"), true),
                    NetworkItem::escapeHTML(tr("Identified for this nick")),
-                   true);
+                   !accountAdded);
+            // Don't add the account row again if information's already added via account-notify
+            // Mark the row as added
+            accountAdded = true;
         } else {
             addRow(NetworkItem::escapeHTML(tr("Service Reply"), true),
                    NetworkItem::escapeHTML(_ircUser->whoisServiceReply()),
@@ -1100,12 +1121,33 @@ QString IrcUserItem::toolTip(int column) const
                NetworkItem::escapeHTML(_ircUser->suserHost()),
                !_ircUser->suserHost().isEmpty());
     }
+
+    // Keep track of whether or not the account information's been added.  Don't show it twice.
+    bool accountAdded = false;
+    if(!_ircUser->account().isEmpty()) {
+        // IRCv3 account-notify is supported by the core and IRC server.
+        // Assume logged out (seems to be more common)
+        QString accountHTML = QString("<p class='italic'>%1</p>").arg(tr("Not logged in"));
+
+        // If account is logged in, replace with the escaped account name.
+        if (_ircUser->account() != "*") {
+            accountHTML = NetworkItem::escapeHTML(_ircUser->account());
+        }
+        addRow(NetworkItem::escapeHTML(tr("Account"), true),
+               accountHTML,
+               true);
+        // Mark the row as added
+        accountAdded = true;
+    }
     // whoisServiceReply may return "<nick> is identified for this nick", which should be translated.
     // See https://www.alien.net.au/irc/irc2numerics.html
     if(_ircUser->whoisServiceReply().endsWith("identified for this nick")) {
         addRow(NetworkItem::escapeHTML(tr("Account"), true),
                NetworkItem::escapeHTML(tr("Identified for this nick")),
-               true);
+               !accountAdded);
+        // Don't add the account row again if information's already added via account-notify
+        // Mark the row as added
+        accountAdded = true;
     } else {
         addRow(NetworkItem::escapeHTML(tr("Service Reply"), true),
                NetworkItem::escapeHTML(_ircUser->whoisServiceReply()),

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCES
 
     # needed for automoc
     coreinfo.h
+    irccap.h
 )
 
 if (USE_QT5)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SOURCES
     # needed for automoc
     coreinfo.h
     irccap.h
+    protocol.h
 )
 
 if (USE_QT5)

--- a/src/common/eventmanager.h
+++ b/src/common/eventmanager.h
@@ -91,6 +91,7 @@ public :
         IrcEventAccount,
         IrcEventAway,
         IrcEventCap,
+        IrcEventChghost,
         IrcEventInvite,
         IrcEventJoin,
         IrcEventKick,

--- a/src/common/irccap.h
+++ b/src/common/irccap.h
@@ -42,6 +42,14 @@ namespace IrcCap {
     const QString ACCOUNT_NOTIFY = "account-notify";
 
     /**
+     * Magic number for WHOX, used to ignore user-requested WHOX replies from servers
+     *
+     * If a user initiates a WHOX, there's no easy way to tell what fields were requested.  It's
+     * simpler to not attempt to parse data from user-requested WHOX replies.
+     */
+    const uint ACCOUNT_NOTIFY_WHOX_NUM = 369;
+
+    /**
      * Away change notification.
      *
      * http://ircv3.net/specs/extensions/away-notify-3.1.html

--- a/src/common/irccap.h
+++ b/src/common/irccap.h
@@ -59,6 +59,13 @@ namespace IrcCap {
     const QString CAP_NOTIFY = "cap-notify";
 
     /**
+     * Hostname/user changed notification.
+     *
+     * http://ircv3.net/specs/extensions/chghost-3.2.html
+     */
+    const QString CHGHOST = "chghost";
+
+    /**
      * Extended join information.
      *
      * http://ircv3.net/specs/extensions/extended-join-3.1.html
@@ -93,6 +100,7 @@ namespace IrcCap {
             ACCOUNT_NOTIFY,
             AWAY_NOTIFY,
             CAP_NOTIFY,
+            CHGHOST,
             EXTENDED_JOIN,
             MULTI_PREFIX,
             SASL,

--- a/src/common/irccap.h
+++ b/src/common/irccap.h
@@ -1,0 +1,137 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2016 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#ifndef IRCCAP_H
+#define IRCCAP_H
+
+#include <QString>
+#include <QStringList>
+
+// Why a namespace instead of a class?  Seems to be a better fit for C++ than a 'static' class, as
+// compared to C# or Java.  However, feel free to change if needed.
+// See https://stackoverflow.com/questions/482745/namespaces-for-enum-types-best-practices
+/**
+ * IRCv3 capability names and values
+ */
+namespace IrcCap {
+
+    // NOTE: If you add or modify the constants below, update the knownCaps list.
+
+    /**
+     * Account change notification.
+     *
+     * http://ircv3.net/specs/extensions/account-notify-3.1.html
+     */
+    const QString ACCOUNT_NOTIFY = "account-notify";
+
+    /**
+     * Away change notification.
+     *
+     * http://ircv3.net/specs/extensions/away-notify-3.1.html
+     */
+    const QString AWAY_NOTIFY = "away-notify";
+
+    /**
+     * Capability added/removed notification.
+     *
+     * This is implicitly enabled via CAP LS 302, and is here for servers that only partially
+     * support IRCv3.2.
+     *
+     * http://ircv3.net/specs/extensions/cap-notify-3.2.html
+     */
+    const QString CAP_NOTIFY = "cap-notify";
+
+    /**
+     * Extended join information.
+     *
+     * http://ircv3.net/specs/extensions/extended-join-3.1.html
+     */
+    const QString EXTENDED_JOIN = "extended-join";
+
+    /**
+     * Multiple mode prefixes in MODE and WHO replies.
+     *
+     * http://ircv3.net/specs/extensions/multi-prefix-3.1.html
+     */
+    const QString MULTI_PREFIX = "multi-prefix";
+
+    /**
+     * SASL authentication.
+     *
+     * http://ircv3.net/specs/extensions/sasl-3.2.html
+     */
+    const QString SASL = "sasl";
+
+    /**
+     * Userhost in names replies.
+     *
+     * http://ircv3.net/specs/extensions/userhost-in-names-3.2.html
+     */
+    const QString USERHOST_IN_NAMES = "userhost-in-names";
+
+    /**
+     * List of capabilities currently implemented and requested during capability negotiation.
+     */
+    const QStringList knownCaps = QStringList {
+            ACCOUNT_NOTIFY,
+            AWAY_NOTIFY,
+            CAP_NOTIFY,
+            EXTENDED_JOIN,
+            MULTI_PREFIX,
+            SASL,
+            USERHOST_IN_NAMES
+    };
+    // NOTE: If you modify the knownCaps list, update the constants above as needed.
+
+    /**
+     * SASL authentication mechanisms
+     *
+     * http://ircv3.net/specs/extensions/sasl-3.1.html
+     */
+    namespace SaslMech {
+
+        /**
+         * Check if the given authentication mechanism is likely to be supported.
+         *
+         * @param[in] saslCapValue   QString of SASL capability value, e.g. capValue(IrcCap::SASL)
+         * @param[in] saslMechanism  Desired SASL mechanism
+         * @return True if mechanism supported or unknown, otherwise false
+         */
+        inline bool maybeSupported(const QString &saslCapValue, const QString &saslMechanism) { return
+                    ((saslCapValue.length() == 0) || (saslCapValue.contains(saslMechanism, Qt::CaseInsensitive))); }
+        // SASL mechanisms are only specified in capability values as part of SASL 3.2.  In
+        // SASL 3.1, it's handled differently.  If we don't know via capability value, assume it's
+        // supported to reduce the risk of breaking existing setups.
+        // See: http://ircv3.net/specs/extensions/sasl-3.1.html
+        // And: http://ircv3.net/specs/extensions/sasl-3.2.html
+
+        /**
+         * PLAIN authentication, e.g. hashed password
+         */
+        const QString PLAIN = "PLAIN";
+
+        /**
+         * EXTERNAL authentication, e.g. SSL certificate and keys
+         */
+        const QString EXTERNAL = "EXTERNAL";
+    }
+}
+
+#endif // IRCCAP_H

--- a/src/common/ircuser.cpp
+++ b/src/common/ircuser.cpp
@@ -146,6 +146,15 @@ void IrcUser::setRealName(const QString &realName)
 }
 
 
+void IrcUser::setAccount(const QString &account)
+{
+    if (_account != account) {
+        _account = account;
+        SYNC(ARG(account))
+    }
+}
+
+
 void IrcUser::setAway(const bool &away)
 {
     if (away != _away) {

--- a/src/common/ircuser.h
+++ b/src/common/ircuser.h
@@ -43,6 +43,7 @@ class IrcUser : public SyncableObject
     Q_PROPERTY(QString host READ host WRITE setHost)
     Q_PROPERTY(QString nick READ nick WRITE setNick)
     Q_PROPERTY(QString realName READ realName WRITE setRealName)
+    Q_PROPERTY(QString account READ account WRITE setAccount)
     Q_PROPERTY(bool away READ isAway WRITE setAway)
     Q_PROPERTY(QString awayMessage READ awayMessage WRITE setAwayMessage)
     Q_PROPERTY(QDateTime idleTime READ idleTime WRITE setIdleTime)
@@ -65,6 +66,12 @@ public :
     inline QString host() const { return _host; }
     inline QString nick() const { return _nick; }
     inline QString realName() const { return _realName; }
+    /**
+     * Account name, e.g. NickServ/SASL account
+     *
+     * @return Account name if logged in, * if logged out, or empty string if unknown
+     */
+    inline QString account() const { return _account; }
     QString hostmask() const;
     inline bool isAway() const { return _away; }
     inline QString awayMessage() const { return _awayMessage; }
@@ -104,6 +111,12 @@ public slots:
     void setHost(const QString &host);
     void setNick(const QString &nick);
     void setRealName(const QString &realName);
+    /**
+     * Set account name, e.g. NickServ/SASL account
+     *
+     * @param[in] account Account name if logged in, * if logged out, or empty string if unknown
+     */
+    void setAccount(const QString &account);
     void setAway(const bool &away);
     void setAwayMessage(const QString &awayMessage);
     void setIdleTime(const QDateTime &idleTime);
@@ -182,6 +195,7 @@ private:
     QString _user;
     QString _host;
     QString _realName;
+    QString _account;      /// Account name, e.g. NickServ/SASL account
     QString _awayMessage;
     bool _away;
     QString _server;

--- a/src/common/network.h
+++ b/src/common/network.h
@@ -269,6 +269,12 @@ public slots:
     inline void initSetServerList(const QVariantList &serverList) { _serverList = fromVariantList<Server>(serverList); }
     virtual void initSetIrcUsersAndChannels(const QVariantMap &usersAndChannels);
 
+    /**
+     * Update IrcUser hostmask and username from mask, creating an IrcUser if one does not exist.
+     *
+     * @param[in] mask   Full nick!user@hostmask string
+     * @return IrcUser of the matching nick if exists, otherwise a new IrcUser
+     */
     IrcUser *updateNickFromMask(const QString &mask);
 
     // these slots are to keep the hashlists of all users and the

--- a/src/common/network.h
+++ b/src/common/network.h
@@ -164,6 +164,18 @@ public :
     inline IdentityId identity() const { return _identity; }
     QStringList nicks() const;
     inline QStringList channels() const { return _ircChannels.keys(); }
+    /**
+     * Gets the list of available capabilities.
+     *
+     * @returns QStringList of available capabilities
+     */
+    inline const QStringList caps() const { return QStringList(_caps.keys()); }
+    /**
+     * Gets the list of enabled (acknowledged) capabilities.
+     *
+     * @returns QStringList of enabled (acknowledged) capabilities
+     */
+    inline const QStringList capsEnabled() const { return _capsEnabled; }
     inline const ServerList &serverList() const { return _serverList; }
     inline bool useRandomServer() const { return _useRandomServer; }
     inline const QStringList &perform() const { return _perform; }
@@ -188,6 +200,26 @@ public :
 
     bool supports(const QString &param) const { return _supports.contains(param); }
     QString support(const QString &param) const;
+
+    /**
+     * Checks if a given capability is acknowledged and active.
+     *
+     * @param[in] capability Name of capability
+     * @returns True if acknowledged (active), otherwise false
+     */
+    inline bool capEnabled(const QString &capability) const { return _capsEnabled.contains(capability.toLower()); }
+    // IRCv3 specs all use lowercase capability names
+
+    /**
+     * Gets the value of an available capability, e.g. for SASL, "EXTERNAL,PLAIN".
+     *
+     * @param[in] capability Name of capability
+     * @returns Value of capability if one was specified, otherwise empty string
+     */
+    QString capValue(const QString &capability) const { return _caps.value(capability.toLower()); }
+    // IRCv3 specs all use lowercase capability names
+    // QHash returns the default constructed value if not found, in this case, empty string
+    // See:  https://doc.qt.io/qt-4.8/qhash.html#value
 
     IrcUser *newIrcUser(const QString &hostmask, const QVariantMap &initData = QVariantMap());
     inline IrcUser *newIrcUser(const QByteArray &hostmask) { return newIrcUser(decodeServerString(hostmask)); }
@@ -256,16 +288,81 @@ public slots:
     void addSupport(const QString &param, const QString &value = QString());
     void removeSupport(const QString &param);
 
+    // IRCv3 capability negotiation (can be connected to signals)
+
+    /**
+     * Add an available capability, optionally providing a value.
+     *
+     * This may happen during first connect, or at any time later if a new capability becomes
+     * available (e.g. SASL service starting).
+     *
+     * @param[in] capability Name of the capability
+     * @param[in] value
+     * @parblock
+     * Optional value of the capability, e.g. sasl=plain.
+     * @endparblock
+     */
+    void addCap(const QString &capability, const QString &value = QString());
+
+    /**
+     * Marks a capability as acknowledged (enabled by the IRC server).
+     *
+     * @param[in] capability Name of the capability
+     */
+    void acknowledgeCap(const QString &capability);
+
+    /**
+     * Removes a capability from the list of available capabilities.
+     *
+     * This may happen during first connect, or at any time later if an existing capability becomes
+     * unavailable (e.g. SASL service stopping).  This also removes the capability from the list
+     * of acknowledged capabilities.
+     *
+     * @param[in] capability Name of the capability
+     */
+    void removeCap(const QString &capability);
+
+    /**
+     * Clears all capabilities from the list of available capabilities.
+     *
+     * This also removes the capability from the list of acknowledged capabilities.
+     */
+    void clearCaps();
+
     inline void addIrcUser(const QString &hostmask) { newIrcUser(hostmask); }
     inline void addIrcChannel(const QString &channel) { newIrcChannel(channel); }
 
     //init geters
     QVariantMap initSupports() const;
+    /**
+     * Get the initial list of available capabilities.
+     *
+     * @return QVariantMap of <QString, QString> indicating available capabilities and values
+     */
+    QVariantMap initCaps() const;
+    /**
+     * Get the initial list of enabled (acknowledged) capabilities.
+     *
+     * @return QVariantList of QString indicating enabled (acknowledged) capabilities and values
+     */
+    QVariantList initCapsEnabled() const { return toVariantList(capsEnabled()); }
     inline QVariantList initServerList() const { return toVariantList(serverList()); }
     virtual QVariantMap initIrcUsersAndChannels() const;
 
     //init seters
     void initSetSupports(const QVariantMap &supports);
+    /**
+     * Initialize the list of available capabilities.
+     *
+     * @param[in] caps QVariantMap of <QString, QString> indicating available capabilities and values
+     */
+    void initSetCaps(const QVariantMap &caps);
+    /**
+     * Initialize the list of enabled (acknowledged) capabilities.
+     *
+     * @param[in] caps QVariantList of QString indicating enabled (acknowledged) capabilities and values
+     */
+    inline void initSetCapsEnabled(const QVariantList &capsEnabled) { _capsEnabled = fromVariantList<QString>(capsEnabled); }
     inline void initSetServerList(const QVariantList &serverList) { _serverList = fromVariantList<Server>(serverList); }
     virtual void initSetIrcUsersAndChannels(const QVariantMap &usersAndChannels);
 
@@ -325,6 +422,34 @@ signals:
 //   void supportAdded(const QString &param, const QString &value);
 //   void supportRemoved(const QString &param);
 
+    // IRCv3 capability negotiation (can drive other slots)
+    /**
+     * Indicates a capability is now available, with optional value in Network::capValue().
+     *
+     * @see Network::addCap()
+     *
+     * @param[in] capability Name of the capability
+     */
+    void capAdded (const QString &capability);
+
+    /**
+     * Indicates a capability was acknowledged (enabled by the IRC server).
+     *
+     * @see Network::acknowledgeCap()
+     *
+     * @param[in] capability Name of the capability
+     */
+    void capAcknowledged(const QString &capability);
+
+    /**
+     * Indicates a capability was removed from the list of available capabilities.
+     *
+     * @see Network::removeCap()
+     *
+     * @param[in] capability Name of the capability
+     */
+    void capRemoved(const QString &capability);
+
 //   void ircUserAdded(const QString &hostmask);
     void ircUserAdded(IrcUser *);
 //   void ircChannelAdded(const QString &channelname);
@@ -357,6 +482,13 @@ private:
     QHash<QString, IrcUser *> _ircUsers; // stores all known nicks for the server
     QHash<QString, IrcChannel *> _ircChannels; // stores all known channels
     QHash<QString, QString> _supports; // stores results from RPL_ISUPPORT
+
+    QHash<QString, QString> _caps;  /// Capabilities supported by the IRC server
+    // By synchronizing the supported capabilities, the client could suggest certain behaviors, e.g.
+    // in the Network settings dialog, recommending SASL instead of using NickServ, or warning if
+    // SASL EXTERNAL isn't available.
+    QStringList _capsEnabled;       /// Enabled capabilities that received 'CAP ACK'
+    // _capsEnabled uses the same values from the <name>=<value> pairs stored in _caps
 
     ServerList _serverList;
     bool _useRandomServer;

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -71,10 +71,11 @@ public:
         SaslExternal = 0x0004,
         HideInactiveNetworks = 0x0008,
         PasswordChange = 0x0010,
+        CapNegotiation = 0x0020,           /// IRCv3 capability negotiation, account tracking
 
-        NumFeatures = 0x0010
+        NumFeatures = 0x0020
     };
-    Q_DECLARE_FLAGS(Features, Feature);
+    Q_DECLARE_FLAGS(Features, Feature)
 
     //! The features the current version of Quassel supports (\sa Feature)
     /** \return An ORed list of all enum values in Feature

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -29,6 +29,9 @@
 #include "coreuserinputhandler.h"
 #include "networkevent.h"
 
+// IRCv3 capabilities
+#include "irccap.h"
+
 INIT_SYNCABLE_OBJECT(CoreNetwork)
 CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
     : Network(networkid, session),
@@ -79,6 +82,12 @@ CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
     connect(&socket, SIGNAL(sslErrors(const QList<QSslError> &)), this, SLOT(sslErrors(const QList<QSslError> &)));
 #endif
     connect(this, SIGNAL(newEvent(Event *)), coreSession()->eventManager(), SLOT(postEvent(Event *)));
+
+    // IRCv3 capability handling
+    // These react to CAP messages from the server
+    connect(this, SIGNAL(capAdded(QString)), this, SLOT(serverCapAdded(QString)));
+    connect(this, SIGNAL(capAcknowledged(QString)), this, SLOT(serverCapAcknowledged(QString)));
+    connect(this, SIGNAL(capRemoved(QString)), this, SLOT(serverCapRemoved(QString)));
 
     if (Quassel::isOptionSet("oidentd")) {
         connect(this, SIGNAL(socketInitialized(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(addSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Qt::BlockingQueuedConnection);
@@ -158,10 +167,11 @@ void CoreNetwork::connectToIrc(bool reconnecting)
     // cleaning up old quit reason
     _quitReason.clear();
 
-    // reset capability negotiation in case server changes during a reconnect
+    // Reset capability negotiation tracking, also handling server changes during reconnect
     _capsQueued.clear();
-    _capsPending.clear();
-    _capsSupported.clear();
+    clearCaps();
+    _capNegotiationActive = false;
+    _capInitialNegotiationEnded = false;
 
     // use a random server?
     if (useRandomServer()) {
@@ -867,68 +877,80 @@ void CoreNetwork::setPingInterval(int interval)
 
 /******** IRCv3 Capability Negotiation ********/
 
-void CoreNetwork::addCap(const QString &capability, const QString &value)
+void CoreNetwork::serverCapAdded(const QString &capability)
 {
-    // Clear from pending list, add to supported list
-    if (!_capsSupported.contains(capability)) {
-        if (value != "") {
-            // Value defined, just use it
-            _capsSupported[capability] = value;
-        } else if (_capsPending.contains(capability)) {
-            // Value not defined, but a pending capability had a value.
-            // E.g. CAP * LS :sasl=PLAIN multi-prefix
-            // Preserve the capability value for later use.
-            _capsSupported[capability] = _capsPending[capability];
-        } else {
-            // No value ever given, assign to blank
-            _capsSupported[capability] = QString();
-        }
-    }
-    if (_capsPending.contains(capability))
-        _capsPending.remove(capability);
-
-    // Handle special cases here
-    // TODO Use events if it makes sense
-    if (capability == "away-notify") {
-        // away-notify enabled, stop the automatic timers, handle manually
-        setAutoWhoEnabled(false);
+    // Check if it's a known capability; if so, add it to the list
+    // Handle special cases first
+    if (capability == IrcCap::SASL) {
+        // Only request SASL if it's enabled
+        if (networkInfo().useSasl)
+            queueCap(capability);
+    } else if (IrcCap::knownCaps.contains(capability)) {
+        // Handling for general known capabilities
+        queueCap(capability);
     }
 }
 
-void CoreNetwork::removeCap(const QString &capability)
+void CoreNetwork::serverCapAcknowledged(const QString &capability)
 {
-    // Clear from pending list, remove from supported list
-    if (_capsPending.contains(capability))
-        _capsPending.remove(capability);
-    if (_capsSupported.contains(capability))
-        _capsSupported.remove(capability);
+    // This may be called multiple times in certain situations.
+
+    // Handle core-side configuration
+    if (capability == IrcCap::AWAY_NOTIFY) {
+        // away-notify enabled, stop the autoWho timers, handle manually
+        setAutoWhoEnabled(false);
+    }
+
+    // Handle capabilities that require further messages sent to the IRC server
+    // If you change this list, ALSO change the list in CoreNetwork::capsRequiringServerMessages
+    if (capability == IrcCap::SASL) {
+        // If SASL mechanisms specified, limit to what's accepted for authentication
+        // if the current identity has a cert set, use SASL EXTERNAL
+        // FIXME use event
+#ifdef HAVE_SSL
+        if (!identityPtr()->sslCert().isNull()) {
+            if (IrcCap::SaslMech::maybeSupported(capValue(IrcCap::SASL), IrcCap::SaslMech::EXTERNAL)) {
+                // EXTERNAL authentication supported, send request
+                putRawLine(serverEncode("AUTHENTICATE EXTERNAL"));
+            } else {
+                displayMsg(Message::Error, BufferInfo::StatusBuffer, "",
+                           tr("SASL EXTERNAL authentication not supported"));
+                sendNextCap();
+            }
+        } else {
+#endif
+            if (IrcCap::SaslMech::maybeSupported(capValue(IrcCap::SASL), IrcCap::SaslMech::PLAIN)) {
+                // PLAIN authentication supported, send request
+                // Only working with PLAIN atm, blowfish later
+                putRawLine(serverEncode("AUTHENTICATE PLAIN"));
+            } else {
+                displayMsg(Message::Error, BufferInfo::StatusBuffer, "",
+                           tr("SASL PLAIN authentication not supported"));
+                sendNextCap();
+            }
+#ifdef HAVE_SSL
+        }
+#endif
+    }
+}
+
+void CoreNetwork::serverCapRemoved(const QString &capability)
+{
+    // This may be called multiple times in certain situations.
 
     // Handle special cases here
-    // TODO Use events if it makes sense
-    if (capability == "away-notify") {
-        // away-notify disabled, enable autowho according to configuration
+    if (capability == IrcCap::AWAY_NOTIFY) {
+        // away-notify disabled, enable autoWho according to configuration
         setAutoWhoEnabled(networkConfig()->autoWhoEnabled());
     }
 }
 
-QString CoreNetwork::capValue(const QString &capability) const
+void CoreNetwork::queueCap(const QString &capability)
 {
-    // If a supported capability exists, good; if not, return pending value.
-    // If capability isn't supported after all, the pending entry will be removed.
-    if (_capsSupported.contains(capability))
-        return _capsSupported[capability];
-    else if (_capsPending.contains(capability))
-        return _capsPending[capability];
-    else
-        return QString();
-}
-
-void CoreNetwork::queuePendingCap(const QString &capability, const QString &value)
-{
-    if (!_capsQueued.contains(capability)) {
-        _capsQueued.append(capability);
-        // Some capabilities may have values attached, preserve them as pending
-        _capsPending[capability] = value;
+    // IRCv3 specs all use lowercase capability names
+    QString _capLowercase = capability.toLower();
+    if (!_capsQueued.contains(_capLowercase)) {
+        _capsQueued.append(_capLowercase);
     }
 }
 
@@ -938,6 +960,47 @@ QString CoreNetwork::takeQueuedCap()
         return _capsQueued.takeFirst();
     } else {
         return QString();
+    }
+}
+
+void CoreNetwork::beginCapNegotiation()
+{
+    // Don't begin negotiation if no capabilities are queued to request
+    if (!capNegotiationInProgress())
+        return;
+
+    _capNegotiationActive = true;
+    displayMsg(Message::Server, BufferInfo::StatusBuffer, "",
+               tr("Ready to negotiate (found: %1)").arg(caps().join(", ")));
+    displayMsg(Message::Server, BufferInfo::StatusBuffer, "",
+               tr("Negotiating capabilities (requesting: %1)...").arg(_capsQueued.join(", ")));
+    sendNextCap();
+}
+
+void CoreNetwork::sendNextCap()
+{
+    if (capNegotiationInProgress()) {
+        // Request the next capability and remove it from the list
+        // Handle one at a time so one capability failing won't NAK all of 'em
+        putRawLine(serverEncode(QString("CAP REQ :%1").arg(takeQueuedCap())));
+    } else {
+        // No pending desired capabilities, capability negotiation finished
+        // If SASL requested but not available, print a warning
+        if (networkInfo().useSasl && !capEnabled(IrcCap::SASL))
+            displayMsg(Message::Error, BufferInfo::StatusBuffer, "",
+                       tr("SASL authentication currently not supported by server"));
+
+        if (_capNegotiationActive) {
+            displayMsg(Message::Server, BufferInfo::StatusBuffer, "",
+                   tr("Capability negotiation finished (enabled: %1)").arg(capsEnabled().join(", ")));
+            _capNegotiationActive = false;
+        }
+
+        // If nick registration is already complete, CAP END is not required
+        if (!_capInitialNegotiationEnded) {
+            putRawLine(serverEncode(QString("CAP END")));
+            _capInitialNegotiationEnded = true;
+        }
     }
 }
 
@@ -959,7 +1022,7 @@ void CoreNetwork::queueAutoWhoOneshot(const QString &channelOrNick)
     if (!_autoWhoQueue.contains(channelOrNick.toLower())) {
         _autoWhoQueue.prepend(channelOrNick.toLower());
     }
-    if (useCapAwayNotify()) {
+    if (capEnabled(IrcCap::AWAY_NOTIFY)) {
         // When away-notify is active, the timer's stopped.  Start a new cycle to who this channel.
         setAutoWhoEnabled(true);
     }
@@ -1006,7 +1069,7 @@ void CoreNetwork::sendAutoWho()
             // state of everyone.  Auto-who won't run on a timer so network impact is minimal.
             if (networkConfig()->autoWhoNickLimit() > 0
                 && ircchan->ircUsers().count() >= networkConfig()->autoWhoNickLimit()
-                && !useCapAwayNotify())
+                && !capEnabled(IrcCap::AWAY_NOTIFY))
                 continue;
             _autoWhoPending[chanOrNick.toLower()]++;
         } else if (ircuser) {
@@ -1025,12 +1088,12 @@ void CoreNetwork::sendAutoWho()
     }
 
     if (_autoWhoQueue.isEmpty() && networkConfig()->autoWhoEnabled() && !_autoWhoCycleTimer.isActive()
-        && !useCapAwayNotify()) {
+        && !capEnabled(IrcCap::AWAY_NOTIFY)) {
         // Timer was stopped, means a new cycle is due immediately
         // Don't run a new cycle if using away-notify; server will notify as appropriate
         _autoWhoCycleTimer.start();
         startAutoWhoCycle();
-    } else if (useCapAwayNotify() && _autoWhoCycleTimer.isActive()) {
+    } else if (capEnabled(IrcCap::AWAY_NOTIFY) && _autoWhoCycleTimer.isActive()) {
         // Don't run another who cycle if away-notify is enabled
         _autoWhoCycleTimer.stop();
     }

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -1080,10 +1080,15 @@ void CoreNetwork::sendAutoWho()
             qDebug() << "Skipping who polling of unknown channel or nick" << chanOrNick;
             continue;
         }
-        // TODO Use WHO extended to poll away users and/or user accounts
-        // If a server supports it, supports("WHOX") will be true
-        // See: http://faerion.sourceforge.net/doc/irc/whox.var and HexChat
-        putRawLine("WHO " + serverEncode(chanOrNick));
+        if (supports("WHOX")) {
+            // Use WHO extended to poll away users and/or user accounts
+            // See http://faerion.sourceforge.net/doc/irc/whox.var
+            // And https://github.com/hexchat/hexchat/blob/c874a9525c9b66f1d5ddcf6c4107d046eba7e2c5/src/common/proto-irc.c#L750
+            putRawLine(serverEncode(QString("WHO %1 %%chtsunfra,%2")
+                                    .arg(serverEncode(chanOrNick), QString::number(IrcCap::ACCOUNT_NOTIFY_WHOX_NUM))));
+        } else {
+            putRawLine(serverEncode(QString("WHO %1").arg(chanOrNick)));
+        }
         break;
     }
 

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -1092,6 +1092,22 @@ void CoreSessionEventProcessor::processWhoInformation (Network *net, const QStri
 }
 
 
+/* ERR_NOSUCHCHANNEL - "<channel name> :No such channel" */
+void CoreSessionEventProcessor::processIrcEvent403(IrcEventNumeric *e)
+{
+    // If this is the result of an AutoWho, hide it.  It's confusing to show to the user.
+    if (!checkParamCount(e, 2))
+        return;
+
+    QString channelOrNick = e->params()[0];
+    // Check if channel name has a who in progress.
+    // If not, then check if user nick exists and has a who in progress.
+    if (coreNetwork(e)->isAutoWhoInProgress(channelOrNick)) {
+        qDebug() << "Channel/nick" << channelOrNick << "no longer exists during AutoWho, ignoring";
+        e->setFlag(EventManager::Silent);
+    }
+}
+
 /* ERR_ERRONEUSNICKNAME */
 void CoreSessionEventProcessor::processIrcEvent432(IrcEventNumeric *e)
 {

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -37,6 +37,9 @@
 #  include "keyevent.h"
 #endif
 
+// IRCv3 capabilities
+#include "irccap.h"
+
 CoreSessionEventProcessor::CoreSessionEventProcessor(CoreSession *session)
     : BasicHandler("handleCtcp", session),
     _coreSession(session)
@@ -94,14 +97,21 @@ void CoreSessionEventProcessor::processIrcEventNumeric(IrcEventNumeric *e)
     switch (e->number()) {
     // SASL authentication replies
     // See: http://ircv3.net/specs/extensions/sasl-3.1.html
+
+    //case 900:  // RPL_LOGGEDIN
+    //case 901:  // RPL_LOGGEDOUT
+    // Don't use 900 or 901 for updating the local hostmask.  Unreal 3.2 gives it as the IP address
+    // even when cloaked.
+    // Every other reply should result in moving on
     // TODO Handle errors to stop connection if appropriate
+    case 902:  // ERR_NICKLOCKED
     case 903:  // RPL_SASLSUCCESS
     case 904:  // ERR_SASLFAIL
     case 905:  // ERR_SASLTOOLONG
     case 906:  // ERR_SASLABORTED
     case 907:  // ERR_SASLALREADY
         // Move on to the next capability
-        sendNextCap(e->network());
+        coreNetwork(e)->sendNextCap();
         break;
 
     default:
@@ -140,24 +150,6 @@ void CoreSessionEventProcessor::processIrcEventAuthenticate(IrcEvent *e)
 #endif
 }
 
-void CoreSessionEventProcessor::sendNextCap(Network *net)
-{
-    CoreNetwork *coreNet = qobject_cast<CoreNetwork *>(net);
-    if (coreNet->capNegotiationInProgress()) {
-        // Request the next capability and remove it from the list
-        // Handle one at a time so one capability failing won't NAK all of 'em
-        coreNet->putRawLine(coreNet->serverEncode(QString("CAP REQ :%1").arg(coreNet->takeQueuedCap())));
-    } else {
-        // If SASL requested but not available, print a warning
-        if (coreNet->networkInfo().useSasl && !coreNet->useCapSASL())
-            emit newEvent(new MessageEvent(Message::Error, net, tr("SASL authentication not supported by server, continuing without"), QString(), QString(), Message::None, QDateTime::currentDateTimeUtc()));
-
-        // No pending desired capabilities, end negotiation
-        coreNet->putRawLine(coreNet->serverEncode(QString("CAP END")));
-        emit newEvent(new MessageEvent(Message::Server, net, tr("Capability negotiation finished"), QString(), QString(), Message::None, QDateTime::currentDateTimeUtc()));
-    }
-}
-
 void CoreSessionEventProcessor::processIrcEventCap(IrcEvent *e)
 {
     // Handle capability negotiation
@@ -165,7 +157,9 @@ void CoreSessionEventProcessor::processIrcEventCap(IrcEvent *e)
     // And: http://ircv3.net/specs/core/capability-negotiation-3.1.html
     if (e->params().count() >= 3) {
         CoreNetwork *coreNet = coreNetwork(e);
-        if (e->params().at(1).compare("LS", Qt::CaseInsensitive) == 0) {
+        QString capCommand = e->params().at(1).trimmed().toUpper();
+        if (capCommand == "LS" || capCommand == "NEW") {
+            // Either we've gotten a list of capabilities, or new capabilities we may want
             // Server: CAP * LS * :multi-prefix extended-join account-notify batch invite-notify tls
             // Server: CAP * LS * :cap-notify server-time example.org/dummy-cap=dummyvalue example.org/second-dummy-cap
             // Server: CAP * LS :userhost-in-names sasl=EXTERNAL,DH-AES,DH-BLOWFISH,ECDSA-NIST256P-CHALLENGE,PLAIN
@@ -180,78 +174,60 @@ void CoreSessionEventProcessor::processIrcEventCap(IrcEvent *e)
                 capListFinished = true;
                 availableCaps = e->params().at(2).split(' ');
             }
-            // We know what capabilities are available, request what we want.
+            // Store what capabilities are available
             QStringList availableCapPair;
-            bool queueCurrentCap;
             for (int i = 0; i < availableCaps.count(); ++i) {
                 // Capability may include values, e.g. CAP * LS :multi-prefix sasl=EXTERNAL
                 availableCapPair = availableCaps[i].trimmed().split('=');
-                queueCurrentCap = false;
-                if (availableCapPair.at(0).startsWith("sasl")) {
-                    // Only request SASL if it's enabled
-                    if (coreNet->networkInfo().useSasl)
-                        queueCurrentCap = true;
-                } else if (availableCapPair.at(0).startsWith("away-notify") ||
-                           availableCapPair.at(0).startsWith("account-notify") ||
-                           availableCapPair.at(0).startsWith("extended-join") ||
-                           availableCapPair.at(0).startsWith("userhost-in-names") ||
-                           availableCapPair.at(0).startsWith("multi-prefix")) {
-                    // Always request these capabilities if available
-                    queueCurrentCap = true;
-                }
-                if (queueCurrentCap) {
-                    if(availableCapPair.count() >= 2)
-                        coreNet->queuePendingCap(availableCapPair.at(0).trimmed(), availableCapPair.at(1).trimmed());
-                    else
-                        coreNet->queuePendingCap(availableCapPair.at(0).trimmed());
+                if(availableCapPair.count() >= 2) {
+                    coreNet->addCap(availableCapPair.at(0).trimmed().toLower(), availableCapPair.at(1).trimmed());
+                } else {
+                    coreNet->addCap(availableCapPair.at(0).trimmed().toLower());
                 }
             }
+
             // Begin capability requests when capability listing complete
-            if (capListFinished) {
-                emit newEvent(new MessageEvent(Message::Server, e->network(), tr("Negotiating capabilities..."), QString(), QString(), Message::None, e->timestamp()));
-                sendNextCap(coreNet);
-            }
-        } else if (e->params().at(1).compare("ACK", Qt::CaseInsensitive) == 0) {
+            if (capListFinished)
+                coreNet->beginCapNegotiation();
+        } else if (capCommand == "ACK") {
             // Server: CAP * ACK :multi-prefix sasl
-            // Got the capability we want, enable, handle as needed.
+            // Got the capability we want, handle as needed.
             // As only one capability is requested at a time, no need to split
-            // Lower-case the list to make later comparisons easier
-            // Capability may include values, e.g. CAP * LS :multi-prefix sasl=EXTERNAL
-            QStringList acceptedCap = e->params().at(2).trimmed().split('=');
+            QString acceptedCap = e->params().at(2).trimmed().toLower();
 
             // Mark this cap as accepted
-            if(acceptedCap.count() >= 2)
-                coreNet->addCap(acceptedCap.at(0), acceptedCap.at(1));
-            else
-                coreNet->addCap(acceptedCap.at(0));
+            coreNet->acknowledgeCap(acceptedCap);
 
-            // Handle special cases
-            if (acceptedCap.at(0).startsWith("sasl")) {
-                // Freenode (at least) sends "sasl " with a trailing space for some reason!
-                // if the current identity has a cert set, use SASL EXTERNAL
-                // FIXME use event
-                // TODO If value of sasl capability is not empty, limit to accepted
-#ifdef HAVE_SSL
-                if (!coreNet->identityPtr()->sslCert().isNull()) {
-                    coreNet->putRawLine(coreNet->serverEncode("AUTHENTICATE EXTERNAL"));
-                } else {
-#endif
-                    // Only working with PLAIN atm, blowfish later
-                    coreNet->putRawLine(coreNet->serverEncode("AUTHENTICATE PLAIN"));
-#ifdef HAVE_SSL
-                }
-#endif
-            } else {
-                // Special handling not needed, move on to next cap
-                sendNextCap(coreNet);
+            if (!coreNet->capsRequiringConfiguration.contains(acceptedCap)) {
+                // Some capabilities (e.g. SASL) require further messages to finish.  If so, do NOT
+                // send the next capability; it will be handled elsewhere in CoreNetwork.
+                // Otherwise, move on to the next capability
+                coreNet->sendNextCap();
             }
-        } else if (e->params().at(1).compare("NAK", Qt::CaseInsensitive) == 0) {
-            // Something went wrong with this capability, disable, go to next cap
-            // As only one capability is requested at a time, no need to split
-            // Lower-case the list to make later comparisons easier
-            QString deniedCap = e->params().at(2).trimmed();
-            coreNet->removeCap(deniedCap);
-            sendNextCap(coreNet);
+        } else if (capCommand == "NAK" || capCommand == "DEL") {
+            // Either something went wrong with this capability, or it is no longer supported
+            // > For CAP NAK
+            // Server: CAP * NAK :multi-prefix sasl
+            // > For CAP DEL
+            // Server: :irc.example.com CAP modernclient DEL :multi-prefix sasl
+            // CAP NAK and CAP DEL replies are always single-line
+
+            QStringList removedCaps;
+            removedCaps = e->params().at(2).split(' ');
+
+            // Store what capability was denied or removed
+            QString removedCap;
+            for (int i = 0; i < removedCaps.count(); ++i) {
+                removedCap = removedCaps[i].trimmed().toLower();
+                // Mark this cap as removed
+                coreNet->removeCap(removedCap);
+            }
+
+            if (capCommand == "NAK") {
+                // Continue negotiation when capability listing complete only if this is the result
+                // of a denied cap, not a removed cap
+                coreNet->sendNextCap();
+            }
         }
     }
 }
@@ -321,7 +297,7 @@ void CoreSessionEventProcessor::processIrcEventJoin(IrcEvent *e)
     QString channel = e->params()[0];
     IrcUser *ircuser = net->updateNickFromMask(e->prefix());
 
-    if (net->useCapExtendedJoin()) {
+    if (net->capEnabled(IrcCap::EXTENDED_JOIN)) {
         if (!checkParamCount(e, 3))
             return;
         // If logged in, :nick!user@host JOIN #channelname accountname :Real Name
@@ -341,8 +317,8 @@ void CoreSessionEventProcessor::processIrcEventJoin(IrcEvent *e)
 
     // If using away-notify, check new users.  Works around buggy IRC servers
     // forgetting to send :away messages for users who join channels when away.
-    if (coreNetwork(e)->useCapAwayNotify()) {
-        coreNetwork(e)->queueAutoWhoOneshot(ircuser->nick());
+    if (net->capEnabled(IrcCap::AWAY_NOTIFY)) {
+        net->queueAutoWhoOneshot(ircuser->nick());
     }
 
     if (!handledByNetsplit)
@@ -924,7 +900,7 @@ void CoreSessionEventProcessor::processIrcEvent352(IrcEvent *e)
         ircuser->setServer(e->params()[3]);
         ircuser->setRealName(e->params().last().section(" ", 1));
 
-        if (coreNetwork(e)->useCapMultiPrefix()) {
+        if (coreNetwork(e)->capEnabled(IrcCap::MULTI_PREFIX)) {
             // If multi-prefix is enabled, all modes will be sent in WHO replies.
             // :kenny.chatspike.net 352 guest #test grawity broken.symlink *.chatspike.net grawity H@%+ :0 Mantas M.
             // See: http://ircv3.net/specs/extensions/multi-prefix-3.1.html
@@ -990,7 +966,7 @@ void CoreSessionEventProcessor::processIrcEvent353(IrcEvent *e)
     QStringList modes;
 
     // Cache result of multi-prefix to avoid unneeded casts and lookups with each iteration.
-    bool _useCapMultiPrefix = coreNetwork(e)->useCapMultiPrefix();
+    bool _useCapMultiPrefix = coreNetwork(e)->capEnabled(IrcCap::MULTI_PREFIX);
 
     foreach(QString nick, e->params()[2].split(' ', QString::SkipEmptyParts)) {
         QString mode;

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -277,6 +277,23 @@ void CoreSessionEventProcessor::processIrcEventAway(IrcEvent *e)
     }
 }
 
+/* IRCv3 chghost - ":nick!user@host CHGHOST newuser new.host.goes.here" */
+void CoreSessionEventProcessor::processIrcEventChghost(IrcEvent *e)
+{
+    if (!checkParamCount(e, 2))
+        return;
+
+    IrcUser *ircuser = e->network()->updateNickFromMask(e->prefix());
+    if (ircuser) {
+        // Update with new user/hostname information.  setUser/setHost handles checking what
+        // actually changed.
+        ircuser->setUser(e->params().at(0));
+        ircuser->setHost(e->params().at(1));
+    } else {
+        qDebug() << "Received chghost data for unknown user" << e->prefix();
+    }
+}
+
 void CoreSessionEventProcessor::processIrcEventInvite(IrcEvent *e)
 {
     if (checkParamCount(e, 2)) {

--- a/src/core/coresessioneventprocessor.h
+++ b/src/core/coresessioneventprocessor.h
@@ -91,6 +91,7 @@ public:
     Q_INVOKABLE void processIrcEvent352(IrcEvent *event);          // RPL_WHOREPLY
     Q_INVOKABLE void processIrcEvent353(IrcEvent *event);          // RPL_NAMREPLY
     Q_INVOKABLE void processIrcEvent354(IrcEvent *event);          // RPL_WHOSPCRPL
+    Q_INVOKABLE void processIrcEvent403(IrcEventNumeric *event);   // ERR_NOSUCHCHANNEL
     Q_INVOKABLE void processIrcEvent432(IrcEventNumeric *event);   // ERR_ERRONEUSNICKNAME
     Q_INVOKABLE void processIrcEvent433(IrcEventNumeric *event);   // ERR_NICKNAMEINUSE
     Q_INVOKABLE void processIrcEvent437(IrcEventNumeric *event);   // ERR_UNAVAILRESOURCE

--- a/src/core/coresessioneventprocessor.h
+++ b/src/core/coresessioneventprocessor.h
@@ -154,17 +154,6 @@ private:
     // key: quit message
     // value: the corresponding netsplit object
     QHash<Network *, QHash<QString, Netsplit *> > _netsplits;
-
-    // IRCv3 capability negotiation
-    /**
-     * Sends the next capability from the queue.
-     *
-     * During nick registration if any capabilities remain queued, this will take the next and
-     * request it.  When no capabilities remain, capability negotiation is ended.
-     *
-     * @param[in,out] A network currently undergoing capability negotiation
-     */
-    void sendNextCap(Network *net);
 };
 
 

--- a/src/core/coresessioneventprocessor.h
+++ b/src/core/coresessioneventprocessor.h
@@ -85,10 +85,12 @@ public:
     Q_INVOKABLE void processIrcEvent322(IrcEvent *event);          // RPL_LIST
     Q_INVOKABLE void processIrcEvent323(IrcEvent *event);          // RPL_LISTEND
     Q_INVOKABLE void processIrcEvent324(IrcEvent *event);          // RPL_CHANNELMODEIS
+    Q_INVOKABLE void processIrcEvent330(IrcEvent *event);          // RPL_WHOISACCOUNT (quakenet/snircd/undernet)
     Q_INVOKABLE void processIrcEvent331(IrcEvent *event);          // RPL_NOTOPIC
     Q_INVOKABLE void processIrcEvent332(IrcEvent *event);          // RPL_TOPIC
     Q_INVOKABLE void processIrcEvent352(IrcEvent *event);          // RPL_WHOREPLY
     Q_INVOKABLE void processIrcEvent353(IrcEvent *event);          // RPL_NAMREPLY
+    Q_INVOKABLE void processIrcEvent354(IrcEvent *event);          // RPL_WHOSPCRPL
     Q_INVOKABLE void processIrcEvent432(IrcEventNumeric *event);   // ERR_ERRONEUSNICKNAME
     Q_INVOKABLE void processIrcEvent433(IrcEventNumeric *event);   // ERR_NICKNAMEINUSE
     Q_INVOKABLE void processIrcEvent437(IrcEventNumeric *event);   // ERR_UNAVAILRESOURCE
@@ -155,6 +157,25 @@ private:
     // key: quit message
     // value: the corresponding netsplit object
     QHash<Network *, QHash<QString, Netsplit *> > _netsplits;
+
+    /**
+     * Process given WHO reply information, updating user data, channel modes, etc as needed
+     *
+     * This takes information from WHO and WHOX replies, processing information that's common
+     * between them.
+     *
+     * @param[in] net                 Network object for the IRC server
+     * @param[in] targetChannel       Target channel, or * if unspecified
+     * @param[in] ircUser             IrcUser representing the desired nick
+     * @param[in] server              Nick server name
+     * @param[in] user                Nick username
+     * @param[in] host                Nick hostname
+     * @param[in] awayStateAndModes   Nick away-state and modes (e.g. G@)
+     * @param[in] realname            Nick realname
+     */
+    void processWhoInformation (Network *net, const QString &targetChannel, IrcUser *ircUser,
+                                const QString &server, const QString &user, const QString &host,
+                                const QString &awayStateAndModes, const QString &realname);
 };
 
 

--- a/src/core/coresessioneventprocessor.h
+++ b/src/core/coresessioneventprocessor.h
@@ -50,6 +50,7 @@ public:
     Q_INVOKABLE void processIrcEventCap(IrcEvent *event);          /// CAP framework negotiation
     Q_INVOKABLE void processIrcEventAccount(IrcEvent *event);      /// account-notify received
     Q_INVOKABLE void processIrcEventAway(IrcEvent *event);         /// away-notify received
+    Q_INVOKABLE void processIrcEventChghost(IrcEvent *event);      /// chghost received
     Q_INVOKABLE void processIrcEventInvite(IrcEvent *event);
     Q_INVOKABLE void processIrcEventJoin(IrcEvent *event);
     Q_INVOKABLE void lateProcessIrcEventKick(IrcEvent *event);

--- a/src/core/eventstringifier.cpp
+++ b/src/core/eventstringifier.cpp
@@ -205,15 +205,29 @@ void EventStringifier::processIrcEventNumeric(IrcEventNumeric *e)
     case 376:
         break;
 
-    // CAP stuff
-    case 900:
-    case 903:
-    case 904:
-    case 905:
-    case 906:
-    case 907:
+    // SASL authentication stuff
+    // See: http://ircv3.net/specs/extensions/sasl-3.1.html
+    case 900:  // RPL_LOGGEDIN
+    case 901:  // RPL_LOGGEDOUT
     {
-        displayMsg(e, Message::Info, "CAP: " + e->params().join(""));
+        // :server 900 <nick> <nick>!<ident>@<host> <account> :You are now logged in as <user>
+        // :server 901 <nick> <nick>!<ident>@<host> :You are now logged out
+        if (!checkParamCount(e, 3))
+            return;
+        displayMsg(e, Message::Server, "SASL: " + e->params().at(2));
+        break;
+    }
+    // Ignore SASL success, partially redundant with RPL_LOGGEDIN and RPL_LOGGEDOUT
+    case 903:  // RPL_SASLSUCCESS  :server 903 <nick> :SASL authentication successful
+        break;
+    case 902:  // ERR_NICKLOCKED   :server 902 <nick> :You must use a nick assigned to you
+    case 904:  // ERR_SASLFAIL     :server 904 <nick> :SASL authentication failed
+    case 905:  // ERR_SASLTOOLONG  :server 905 <nick> :SASL message too long
+    case 906:  // ERR_SASLABORTED  :server 906 <nick> :SASL authentication aborted
+    case 907:  // ERR_SASLALREADY  :server 907 <nick> :You have already authenticated using SASL
+    case 908:  // RPL_SASLMECHS    :server 908 <nick> <mechanisms> :are available SASL mechanisms
+    {
+        displayMsg(e, Message::Server, "SASL: " + e->params().join(""));
         break;
     }
 

--- a/src/core/eventstringifier.cpp
+++ b/src/core/eventstringifier.cpp
@@ -657,6 +657,16 @@ void EventStringifier::processIrcEvent352(IrcEvent *e)
 }
 
 
+/*  RPL_WHOSPCRPL: "<yournick> <num> #<channel> ~<ident> <host> <servname> <nick>
+                    ("H"/ "G") <account> :<realname>"
+Could be anything else, though.  User-specified fields.
+See http://faerion.sourceforge.net/doc/irc/whox.var */
+void EventStringifier::processIrcEvent354(IrcEvent *e)
+{
+    displayMsg(e, Message::Server, tr("[WhoX] %1").arg(e->params().join(" ")));
+}
+
+
 /*  RPL_ENDOFWHOWAS - "<nick> :End of WHOWAS" */
 void EventStringifier::processIrcEvent369(IrcEvent *e)
 {

--- a/src/core/eventstringifier.h
+++ b/src/core/eventstringifier.h
@@ -88,6 +88,7 @@ public:
     Q_INVOKABLE void processIrcEvent333(IrcEvent *event);    // RPL_??? (topic set by)
     Q_INVOKABLE void processIrcEvent341(IrcEvent *event);    // RPL_INVITING
     Q_INVOKABLE void processIrcEvent352(IrcEvent *event);    // RPL_WHOREPLY
+    Q_INVOKABLE void processIrcEvent354(IrcEvent *event);    // RPL_WHOSPCRPL
     Q_INVOKABLE void processIrcEvent369(IrcEvent *event);    // RPL_ENDOFWHOWAS
     Q_INVOKABLE void processIrcEvent432(IrcEvent *event);    // ERR_ERRONEUSNICKNAME
     Q_INVOKABLE void processIrcEvent433(IrcEvent *event);    // ERR_NICKNAMEINUSE

--- a/src/core/ircparser.cpp
+++ b/src/core/ircparser.cpp
@@ -280,10 +280,13 @@ void IrcParser::processNetworkIncoming(NetworkDataEvent *e)
 
     case EventManager::IrcEventAway:
         {
+            // Update hostmask info first.  This will create the nick if it doesn't exist, e.g.
+            // away-notify data being sent before JOIN messages.
+            net->updateNickFromMask(prefix);
+            // Separate nick in order to separate server and user decoding
             QString nick = nickFromMask(prefix);
             decParams << nick;
             decParams << (params.count() >= 1 ? net->userDecode(nick, params.at(0)) : QString());
-            net->updateNickFromMask(prefix);
         }
         break;
 


### PR DESCRIPTION
## In short
* Support ```CAP NEW``` and ```CAP DEL``` as [required by IRCv3 specs](http://ircv3.net/specs/extensions/cap-notify-3.2.html )
 * Needed to remain [listed as IRCv3.2 compliant](http://ircv3.net/software/clients.html ), used to handle services restarting, etc
* Synchronize IRCv3 capabilities between core and client
 * Backwards-compatible, allows for smarter client suggestions
* Synchronize nick services accounts (NickServ/SASL), part two of [```account-notify```](http://ircv3.net/specs/extensions/account-notify-3.1.html )
 * Now that [pull request #186](https://github.com/quassel/quassel/pull/186 ) is merged, display client-side when available
*  Add Feature flag ```CapNegotiation = 0x0020```
* Support [the ```CHGHOST``` capability](http://ircv3.net/specs/extensions/chghost-3.2.html )
* Polish and fixes

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | User-facing features, foundation for IRCv3 compliance and future
Risk | ★★☆ *2/3* | Difficult to test, many possible edge cases (*risk accepted in #180*)
Intrusiveness | ★★★ *3/3* | Modifies protocol, required for other improvements, may conflict PRs

## Rationale
The reason for ```CAP NEW``` and ```CAP DEL``` are well explained on [the IRCv3 specs page](http://ircv3.net/specs/extensions/cap-notify-3.2.html).  In relation to Quassel, it's necessary to implement in order to avoid breaking spec-compliant servers correctly assuming IRCv3.2-compliant clients support ```CAP NEW``` and ```CAP DEL```.

The approach in #180 of making IRCv3 invisible to clients works, but leaves room for improvement.  Right now, if the client knows what capabilities are supported by the server, it could guide users in setting up matters like account registration, suggesting SASL over NickServ if supported, and warning if ```PLAIN``` or ```EXTERNAL``` is not supported by a given server.

The ```CapNegotiation``` Feature flag technically isn't needed as newer clients can connect to older cores just fine.  However, it may be useful to know if the core supports cap negotiation or account-tracking in the future, e.g. distinguishing between account tracking being unsupported by the core, versus the IRC server simply not providing the needed information.  Most importantly, if 0.13 is released without this flag, there's no way to reliably determine if negotiation is supported.

## Implementation
* Support ```CAP NEW``` and ```CAP DEL``` as [required by IRCv3 specs](http://ircv3.net/specs/extensions/cap-notify-3.2.html )
 * Using a new signal/slot system, capabilities are added and removed the same with ```CAP LS```, ```CAP NEW```, and ```CAP NAK```, ```CAP DEL```, respectively.
 * If a capability is added, Quassel attempts to negotiate it, e.g. doing SASL authentication, and if it disappears, related functionality is disabled
* Synchronize IRCv3 capabilities between core and client
 * Add new functions mimicking ```ISUPPORT``` handling, reusing the same patterns without modifying existing protocol
 * Client could suggest ```SASL``` over ```NickServ```, indicate if SASL external isn't available, etc
* Synchronize nick services accounts (NickServ/SASL), part two of [```account-notify```](http://ircv3.net/specs/extensions/account-notify-3.1.html )
 * Helps keep track of users as they change nicks, from a user and computer perspective
 * Implement WHOX as mentioned in [the ```account-notify``` spec](http://ircv3.net/specs/extensions/account-notify-3.1.html )
 * **To display client-side, [pull request #186](https://github.com/quassel/quassel/pull/186 ) needs addressed, then a separate pull request can include account information in the tool-tips**
*  Add Feature flag ```CapNegotiation = 0x0020``` 
 * Clients can check if the core supports capability negotiation and account tracking
 * Not required for these changes, but useful in the future and cannot be retroactively added to Quassel 0.13 after release
* Support [the ```CHGHOST``` capability](http://ircv3.net/specs/extensions/chghost-3.2.html )
 * On supporting servers, get notified of changes to user/hostmask part of ```nick!user@hostmask```
 * More important since ```away-notify``` disables ```WHO``` polling, as [per IRCv3 specs](http://ircv3.net/specs/extensions/away-notify-3.1.html )
 * Good example of how to add support for simple IRCv3 capabilities
* Polishing and fixes
 * Show capabilities available, requested, and successful in the phases of negotiation
 * Fix one case of errant AutoWho replies
 * Add some missing files to ```CMakeLists.txt``` so they show up in Qt Creator

## Testing
*Using Ubuntu 14.04 LTS, Quasseldroid latest alpha version*
* New core ↔ new client
 * Works fine
* Old client ↔ new core
 * Client prints warnings to console but works
 * Complains of no matching slot for sync call.  Old client doesn't need the new information, though, so it shouldn't cause issues
* New client ↔ old core
 * Works as before, simply assuming no IRCv3
 * Quassel didn't support IRCv3 cap negotiation or account tracking before now, so that's a safe assumption to make
* New core ↔ Quasseldroid alpha
 * Works fine, warnings in debug log (```logcat```)

## Examples
### Capability negotiation
**New**
```
* Connecting to localhost:6667...
* Requesting capability list...
* Ready to negotiate (found: extended-join, away-notify, userhost-in-names, sasl, multi-prefix)
* Negotiating capabilities (requesting: sasl, multi-prefix, extended-join, away-notify, userhost-in-names)...
[localhost] BitlBee-IRCd initialized, please go on
* Capability negotiation finished (enabled: sasl, multi-prefix, extended-join, away-notify, userhost-in-names)
* Welcome to the BitlBee gateway, digitalcircuit
* Host localhost is running BitlBee 3.4.[…trimmed…]
* BitlBee <http://www.bitlbee.org/>
* localhost 3.4.[…trimmed…]
* PREFIX=(ohv)@%+ […trimmed…] FLOOD=0/9999 are supported by this server
* We don't need MOTDs.
*** Mode digitalcircuit +s by digitalcircuit
*** Mode digitalcircuit +R by digitalcircuit
* SASL: You are now logged in as digitalcircuit
```
**Old**
```
* Connecting to localhost:6667...
* Requesting capability list...
[localhost] BitlBee-IRCd initialized, please go on
* Negotiating capabilities...
* CAP: Password accepted
* Capability negotiation finished
* Welcome to the BitlBee gateway, digitalcircuit
* Host localhost is running BitlBee 3.4.[…trimmed…]
* BitlBee <http://www.bitlbee.org/>
* localhost 3.4.[…trimmed…]
* PREFIX=(ohv)@%+ […trimmed…] FLOOD=0/9999 are supported by this server
* We don't need MOTDs.
*** Mode digitalcircuit +s by digitalcircuit
*** Mode digitalcircuit +R by digitalcircuit
* CAP: digitalcircuit!quassel@localhostdigitalcircuitYou are now logged in as digitalcircuit
```
### Account tracking
**```account-notify``` supported, nick logged out**
![Nick tooltip showing Not logged in message](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/ircv3-polish/Nick%20tooltip%20-%20not%20logged%20in.png#v3 )
**```account-notify``` supported, nick logged in**
![Nick tooltip showing logged in account name](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/ircv3-polish/Nick%20tooltip%20-%20logged%20in.png#v3 )

## Critique, questions, and other feedback welcome!
*Given the protocol additions, @justjanne (Quasseldroid) and @magne4000 (Quassel Web Server) may want to take a look.*