### PR TITLE
Fix ping timeouts when sending many messages at once (prioritize PING/PONG)

### DIFF
--- a/src/core/corebasichandler.cpp
+++ b/src/core/corebasichandler.cpp
@@ -30,14 +30,14 @@ CoreBasicHandler::CoreBasicHandler(CoreNetwork *parent)
     connect(this, SIGNAL(displayMsg(Message::Type, BufferInfo::Type, const QString &, const QString &, const QString &, Message::Flags)),
         network(), SLOT(displayMsg(Message::Type, BufferInfo::Type, const QString &, const QString &, const QString &, Message::Flags)));
 
-    connect(this, SIGNAL(putCmd(QString, const QList<QByteArray> &, const QByteArray &)),
-        network(), SLOT(putCmd(QString, const QList<QByteArray> &, const QByteArray &)));
+    connect(this, SIGNAL(putCmd(QString, const QList<QByteArray> &, const QByteArray &, const bool)),
+        network(), SLOT(putCmd(QString, const QList<QByteArray> &, const QByteArray &, const bool)));
 
-    connect(this, SIGNAL(putCmd(QString, const QList<QList<QByteArray>> &, const QByteArray &)),
-        network(), SLOT(putCmd(QString, const QList<QList<QByteArray>> &, const QByteArray &)));
+    connect(this, SIGNAL(putCmd(QString, const QList<QList<QByteArray>> &, const QByteArray &, const bool)),
+        network(), SLOT(putCmd(QString, const QList<QList<QByteArray>> &, const QByteArray &, const bool)));
 
-    connect(this, SIGNAL(putRawLine(const QByteArray &)),
-        network(), SLOT(putRawLine(const QByteArray &)));
+    connect(this, SIGNAL(putRawLine(const QByteArray &, const bool)),
+        network(), SLOT(putRawLine(const QByteArray &, const bool)));
 }
 
 
@@ -142,9 +142,9 @@ BufferInfo::Type CoreBasicHandler::typeByTarget(const QString &target) const
 }
 
 
-void CoreBasicHandler::putCmd(const QString &cmd, const QByteArray &param, const QByteArray &prefix)
+void CoreBasicHandler::putCmd(const QString &cmd, const QByteArray &param, const QByteArray &prefix, const bool prepend)
 {
     QList<QByteArray> list;
     list << param;
-    emit putCmd(cmd, list, prefix);
+    emit putCmd(cmd, list, prefix, prepend);
 }

--- a/src/core/corebasichandler.h
+++ b/src/core/corebasichandler.h
@@ -54,12 +54,43 @@ public:
 
 signals:
     void displayMsg(Message::Type, BufferInfo::Type, const QString &target, const QString &text, const QString &sender = "", Message::Flags flags = Message::None);
-    void putCmd(const QString &cmd, const QList<QByteArray> &params, const QByteArray &prefix = QByteArray());
-    void putCmd(const QString &cmd, const QList<QList<QByteArray>> &params, const QByteArray &prefix = QByteArray());
-    void putRawLine(const QByteArray &msg);
+
+    /**
+     * Sends the raw (encoded) line, adding to the queue if needed, optionally with higher priority.
+     *
+     * @see CoreNetwork::putRawLine()
+     */
+    void putRawLine(const QByteArray &msg, const bool prepend = false);
+
+    /**
+     * Sends the command with encoded parameters, with optional prefix or high priority.
+     *
+     * @see CoreNetwork::putCmd(const QString &cmd, const QList<QByteArray> &params, const QByteArray &prefix = QByteArray(), const bool prepend = false)
+     */
+    void putCmd(const QString &cmd, const QList<QByteArray> &params, const QByteArray &prefix = QByteArray(), const bool prepend = false);
+
+    /**
+     * Sends the command for each set of encoded parameters, with optional prefix or high priority.
+     *
+     * @see CoreNetwork::putCmd(const QString &cmd, const QList<QList<QByteArray>> &params, const QByteArray &prefix = QByteArray(), const bool prepend = false)
+     */
+    void putCmd(const QString &cmd, const QList<QList<QByteArray>> &params, const QByteArray &prefix = QByteArray(), const bool prepend = false);
 
 protected:
-    void putCmd(const QString &cmd, const QByteArray &param, const QByteArray &prefix = QByteArray());
+    /**
+     * Sends the command with one parameter, with optional prefix or high priority.
+     *
+     * @param[in] cmd      Command to send, ignoring capitalization
+     * @param[in] param    Parameter for the command, encoded within a QByteArray
+     * @param[in] prefix   Optional command prefix
+     * @param[in] prepend
+     * @parmblock
+     * If true, the command is prepended into the start of the queue, otherwise, it's appended to
+     * the end.  This should be used sparingly, for if either the core or the IRC server cannot
+     * maintain PING/PONG replies, the other side will close the connection.
+     * @endparmblock
+     */
+    void putCmd(const QString &cmd, const QByteArray &param, const QByteArray &prefix = QByteArray(), const bool prepend = false);
 
     inline CoreNetwork *network() const { return _network; }
     inline CoreSession *coreSession() const { return _network->coreSession(); }

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -258,16 +258,21 @@ void CoreNetwork::userInput(BufferInfo buf, QString msg)
 }
 
 
-void CoreNetwork::putRawLine(QByteArray s)
+void CoreNetwork::putRawLine(const QByteArray s, const bool prepend)
 {
-    if (_tokenBucket > 0)
+    if (_tokenBucket > 0) {
         writeToSocket(s);
-    else
-        _msgQueue.append(s);
+    } else {
+        if (prepend) {
+            _msgQueue.prepend(s);
+        } else {
+            _msgQueue.append(s);
+        }
+    }
 }
 
 
-void CoreNetwork::putCmd(const QString &cmd, const QList<QByteArray> &params, const QByteArray &prefix)
+void CoreNetwork::putCmd(const QString &cmd, const QList<QByteArray> &params, const QByteArray &prefix, const bool prepend)
 {
     QByteArray msg;
 
@@ -284,16 +289,16 @@ void CoreNetwork::putCmd(const QString &cmd, const QList<QByteArray> &params, co
         msg += params[i];
     }
 
-    putRawLine(msg);
+    putRawLine(msg, prepend);
 }
 
 
-void CoreNetwork::putCmd(const QString &cmd, const QList<QList<QByteArray>> &params, const QByteArray &prefix)
+void CoreNetwork::putCmd(const QString &cmd, const QList<QList<QByteArray>> &params, const QByteArray &prefix, const bool prependAll)
 {
     QListIterator<QList<QByteArray>> i(params);
     while (i.hasNext()) {
         QList<QByteArray> msg = i.next();
-        putCmd(cmd, msg, prefix);
+        putCmd(cmd, msg, prefix, prependAll);
     }
 }
 

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -212,7 +212,8 @@ void CoreNetwork::connectToIrc(bool reconnecting)
 }
 
 
-void CoreNetwork::disconnectFromIrc(bool requested, const QString &reason, bool withReconnect)
+void CoreNetwork::disconnectFromIrc(bool requested, const QString &reason, bool withReconnect,
+                                    bool forceImmediate)
 {
     _quitRequested = requested; // see socketDisconnected();
     if (!withReconnect) {
@@ -240,7 +241,7 @@ void CoreNetwork::disconnectFromIrc(bool requested, const QString &reason, bool 
         socketDisconnected();
     } else {
         if (socket.state() == QAbstractSocket::ConnectedState) {
-            userInputHandler()->issueQuit(_quitReason);
+            userInputHandler()->issueQuit(_quitReason, forceImmediate);
         } else {
             socket.close();
         }

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -202,7 +202,18 @@ public slots:
     void setPingInterval(int interval);
 
     void connectToIrc(bool reconnecting = false);
-    void disconnectFromIrc(bool requested = true, const QString &reason = QString(), bool withReconnect = false);
+    /**
+     * Disconnect from the IRC server.
+     *
+     * Begin disconnecting from the IRC server, including optionally reconnecting.
+     *
+     * @param requested       If true, user requested this disconnect; don't try to reconnect
+     * @param reason          Reason for quitting, defaulting to the user-configured quit reason
+     * @param withReconnect   Reconnect to the network after disconnecting (e.g. ping timeout)
+     * @param forceImmediate  Immediately disconnect from network, skipping queue of other commands
+     */
+    void disconnectFromIrc(bool requested = true, const QString &reason = QString(),
+                           bool withReconnect = false, bool forceImmediate = false);
 
     void userInput(BufferInfo bufferInfo, QString msg);
 

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -205,9 +205,53 @@ public slots:
     void disconnectFromIrc(bool requested = true, const QString &reason = QString(), bool withReconnect = false);
 
     void userInput(BufferInfo bufferInfo, QString msg);
-    void putRawLine(QByteArray input);
-    void putCmd(const QString &cmd, const QList<QByteArray> &params, const QByteArray &prefix = QByteArray());
-    void putCmd(const QString &cmd, const QList<QList<QByteArray>> &params, const QByteArray &prefix = QByteArray());
+
+    /**
+     * Sends the raw (encoded) line, adding to the queue if needed, optionally with higher priority.
+     *
+     * @param[in] input   QByteArray of encoded characters
+     * @param[in] prepend
+     * @parmblock
+     * If true, the line is prepended into the start of the queue, otherwise, it's appended to the
+     * end.  This should be used sparingly, for if either the core or the IRC server cannot maintain
+     * PING/PONG replies, the other side will close the connection.
+     * @endparmblock
+     */
+    void putRawLine(const QByteArray input, const bool prepend = false);
+
+    /**
+     * Sends the command with encoded parameters, with optional prefix or high priority.
+     *
+     * @param[in] cmd      Command to send, ignoring capitalization
+     * @param[in] params   Parameters for the command, encoded within a QByteArray
+     * @param[in] prefix   Optional command prefix
+     * @param[in] prepend
+     * @parmblock
+     * If true, the command is prepended into the start of the queue, otherwise, it's appended to
+     * the end.  This should be used sparingly, for if either the core or the IRC server cannot
+     * maintain PING/PONG replies, the other side will close the connection.
+     * @endparmblock
+     */
+    void putCmd(const QString &cmd, const QList<QByteArray> &params, const QByteArray &prefix = QByteArray(), const bool prepend = false);
+
+    /**
+     * Sends the command for each set of encoded parameters, with optional prefix or high priority.
+     *
+     * @param[in] cmd         Command to send, ignoring capitalization
+     * @param[in] params
+     * @parmblock
+     * List of parameter lists for the command, encoded within a QByteArray.  The command will be
+     * sent multiple times, once for each set of params stored within the outer list.
+     * @endparmblock
+     * @param[in] prefix      Optional command prefix
+     * @param[in] prependAll
+     * @parmblock
+     * If true, ALL of the commands are prepended into the start of the queue, otherwise, they're
+     * appended to the end.  This should be used sparingly, for if either the core or the IRC server
+     * cannot maintain PING/PONG replies, the other side will close the connection.
+     * @endparmblock
+     */
+    void putCmd(const QString &cmd, const QList<QList<QByteArray>> &params, const QByteArray &prefix = QByteArray(), const bool prependAll = false);
 
     void setChannelJoined(const QString &channel);
     void setChannelParted(const QString &channel);

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -523,7 +523,8 @@ void CoreSessionEventProcessor::processIrcEventPing(IrcEvent *e)
 {
     QString param = e->params().count() ? e->params().first() : QString();
     // FIXME use events
-    coreNetwork(e)->putRawLine("PONG " + coreNetwork(e)->serverEncode(param));
+    // Take priority so this won't get stuck behind other queued messages.
+    coreNetwork(e)->putRawLine("PONG " + coreNetwork(e)->serverEncode(param), true);
 }
 
 

--- a/src/core/coreuserinputhandler.cpp
+++ b/src/core/coreuserinputhandler.cpp
@@ -545,7 +545,8 @@ void CoreUserInputHandler::handlePing(const BufferInfo &bufferInfo, const QStrin
     if (param.isEmpty())
         param = QTime::currentTime().toString("hh:mm:ss.zzz");
 
-    putCmd("PING", serverEncode(param));
+    // Take priority so this won't get stuck behind other queued messages.
+    putCmd("PING", serverEncode(param), QByteArray(), true);
 }
 
 

--- a/src/core/coreuserinputhandler.cpp
+++ b/src/core/coreuserinputhandler.cpp
@@ -581,9 +581,10 @@ void CoreUserInputHandler::handleQuit(const BufferInfo &bufferInfo, const QStrin
 }
 
 
-void CoreUserInputHandler::issueQuit(const QString &reason)
+void CoreUserInputHandler::issueQuit(const QString &reason, bool forceImmediate)
 {
-    emit putCmd("QUIT", serverEncode(reason));
+    // If needing an immediate QUIT (e.g. core shutdown), prepend this to the queue
+    emit putCmd("QUIT", serverEncode(reason), QByteArray(), forceImmediate);
 }
 
 

--- a/src/core/coreuserinputhandler.h
+++ b/src/core/coreuserinputhandler.h
@@ -79,7 +79,13 @@ public slots:
 
     void defaultHandler(QString cmd, const BufferInfo &bufferInfo, const QString &text);
 
-    void issueQuit(const QString &reason);
+    /**
+     * Send a QUIT to the IRC server, optionally skipping the command queue.
+     *
+     * @param reason          Reason for quitting, often displayed to other IRC clients
+     * @param forceImmediate  Immediately quit, skipping queue of other commands
+     */
+    void issueQuit(const QString &reason, bool forceImmediate = false);
     void issueAway(const QString &msg, bool autoCheck = true);
 
 protected:


### PR DESCRIPTION
## In short
* Add optional flag to ```putRawLine``` and ```putCmd``` to put any given lines or commands to the front of the queue (prepend instead of append)
* Enable queue prepend for sending ```PING```s and ```PONG``` replies
 * Fixes ping-timeout when trying to send huge messages (*e.g. 40 lines at once*), or multiple commands
 * Unfortunately, some IRC servers don't behave properly so Quassel may still get disconnected.  Hopefully other servers will get fixed soon.
* Allow ```QUIT``` to take priority, useful for [pull request #207](https://github.com/quassel/quassel/pull/207 )
* Add more documentation, of course.  Document all the things!

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Infrequent, frustrating edge case, priority system useful elsewhere
Risk | ★☆☆ *1/3* | Modifies command queuing, may expose ```PING```/```PONG``` bugs
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

Thanks to @mamarley for their initial help in solving this!

## Example
*Many lines of lorem ipsum pasted into a temporary channel on Freenode, and Quassel kept going...*
*The ```PING``` was Quassel checking that Freenode was still alive.  It properly jumped the queue.*
```
2016-05-31 20:48:19 Debug: << "PRIVMSG ##temp_chan :~~ BEGIN ~~"
2016-05-31 20:48:19 Debug: << "PRIVMSG ##temp_chan :Lorem ipsum dolor sit amet, consectetur[...trimmed]"
[...much lorem ipsum trimmed...]
2016-05-31 20:52:22 Debug: << "PRIVMSG ##temp_chan :efficitur, consequat ultrices nulla. Maecenas[...trimmed]"
2016-05-31 20:52:24 Debug: << "PRIVMSG ##temp_chan :Proin in lectus in dolor rutrum pulvinar[...trimmed]"
2016-05-31 20:52:26 Debug: << "PING 20:52:25.111"
2016-05-31 20:52:26 Debug: >> ":wilhelm.freenode.net PONG wilhelm.freenode.net :20:52:25.111"
2016-05-31 20:52:28 Debug: << "PRIVMSG ##temp_chan :lacinia, ante eu pretium consequat, tellus[...trimmed]"
2016-05-31 20:52:30 Debug: << "PRIVMSG ##temp_chan :In vitae blandit libero. Aenean fringilla [...trimmed]"
[...and more lorem ipsum trimmed...]
2016-05-31 20:53:39 Debug: << "PRIVMSG ##temp_chan : Mauris id lorem in magna luctus vestibulum[...trimmed]"
2016-05-31 20:53:41 Debug: << "PRIVMSG ##temp_chan :~~ END ~~"
```