### PR TITLE
Add support for self messages

### DIFF
--- a/src/common/irccap.h
+++ b/src/common/irccap.h
@@ -102,6 +102,24 @@ namespace IrcCap {
     const QString USERHOST_IN_NAMES = "userhost-in-names";
 
     /**
+     * Vendor-specific capabilities
+     */
+    namespace Vendor {
+
+        /**
+         * Self message support, as recognized by ZNC.
+         *
+         * Some servers (e.g. Bitlbee) assume self-message support; ZNC requires a capability
+         * instead.  As self-message is already implemented, there's little reason to not do this.
+         *
+         * More information in the IRCv3 commit that removed the 'self-message' capability.
+         *
+         * https://github.com/ircv3/ircv3-specifications/commit/1bfba47843c2526707c902034b3395af934713c8
+         */
+        const QString ZNC_SELF_MESSAGE = "znc.in/self-message";
+    }
+
+    /**
      * List of capabilities currently implemented and requested during capability negotiation.
      */
     const QStringList knownCaps = QStringList {
@@ -112,7 +130,8 @@ namespace IrcCap {
             EXTENDED_JOIN,
             MULTI_PREFIX,
             SASL,
-            USERHOST_IN_NAMES
+            USERHOST_IN_NAMES,
+            Vendor::ZNC_SELF_MESSAGE
     };
     // NOTE: If you modify the knownCaps list, update the constants above as needed.
 

--- a/src/core/ctcpparser.cpp
+++ b/src/core/ctcpparser.cpp
@@ -192,6 +192,11 @@ void CtcpParser::parse(IrcEventRawMessage *e, Message::Type messagetype)
         flags |= Message::StatusMsg;
     }
 
+    // For self-messages, pass the flag on to the message, too
+    if (e->testFlag(EventManager::Self)) {
+        flags |= Message::Self;
+    }
+
     if (coreSession()->networkConfig()->standardCtcp())
         parseStandard(e, messagetype, dequotedMessage, ctcptype, flags);
     else


### PR DESCRIPTION
## In short
* Check if incoming message sender is our nick; if so, treat
as if sent by the core
 * Message decryption is still tried in case the user manually set up identical keys on different clients,
but key negotiation isn't allowed with self-messages
 * Carry over "Self" flag from ```EventManager``` to ```Message```, so incoming
self-messages are processed as if sent by client
* Enable self message support with [ZNC](http://znc.in/)

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing, better support other chat systems, part of IRCv3 future
Risk | ★☆☆ *1/3* | Messages might possibly be wrongly interpreted as from self
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Rationale
Modern chat systems allow sending messages from multiple clients while keeping chat history in sync.  While Quassel handles this for messages sent via the Quassel core, it currently does *not* handle messages sent from elsewhere.

For example, [Bitlbee](https://www.bitlbee.org/ ) serves as a bridge between IRC and other chat services, and [with self message support](https://wiki.bitlbee.org/SelfMessages ) it can relay conversations held over Jabber, Skype, etc with other clients (*web, mobile, desktop*) back into Quassel.

[ZNC](http://wiki.znc.in/ZNC ) also supports self messages, but requires requesting the capability ```znc.in/self-message```.  (*Included now that [pull request #198](https://github.com/quassel/quassel/pull/198 ) is merged*)

Self message support is required for [IRCv3 ```echo-message```](http://ircv3.net/specs/extensions/echo-message-3.2.html ), which would allow Quassel to determine when messages are received by the server, and how the server decided to present them (*e.g. if color formatting was stripped or words were censored*).

## Example
If the core's nick is ```quasseluser```, then
```
:quasseluser!ex@example.com PRIVMSG dcircuit :hi
```
is handled as if ```quasseluser``` had sent ```hi``` to nick ```dcircuit```.