### PR TITLE
Fix sending quit messages on core shutdown

### DIFF
--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -161,6 +161,20 @@ bool Quassel::init()
 }
 
 
+void Quassel::beginQuittingApp()
+{
+    Q_ASSERT(!_instance);
+
+    // This should only ever be called when no instance exists
+    if (!_instance) {
+        return;
+    }
+
+    // By default, no extra processing is needed, just shut down immediately
+    _instance->quit();
+}
+
+
 void Quassel::quit()
 {
     QCoreApplication::quit();
@@ -316,11 +330,14 @@ void Quassel::handleSignal(int sig)
     switch (sig) {
     case SIGTERM:
     case SIGINT:
+        // Signal to quit received, begin cleanly shutting down application
         qWarning("%s", qPrintable(QString("Caught signal %1 - exiting.").arg(sig)));
-        if (_instance)
-            _instance->quit();
-        else
+        if (_instance) {
+            _instance->beginQuittingApp();
+        } else {
+            // No instance exists, quit without special cleanup
             QCoreApplication::quit();
+        }
         break;
     case SIGABRT:
     case SIGSEGV:

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -138,9 +138,23 @@ public:
 
     static void logFatalMessage(const char *msg);
 
+    static const int quitSessionsTimeout = 10; /// Max time (secs) to wait for session quit
+    // Maximum time in seconds that the core (RunMode is Monolithic or Core) will wait for networks
+    // to quit after sending a 'QUIT' command to all connected networks on every active session.
+    // In testing, 10 seconds seems like a reasonable balance - gives slow connections a chance to
+    // flush the QUIT from the socket, while shutdown won't be unduly delayed if things go wrong.
+
 protected:
     Quassel();
     virtual bool init();
+
+    /**
+     * Requests an orderly shutdown of the application, cleaning up active sessions as needed.
+     *
+     * Other classes should override as needed to implement further cleanup.
+     */
+    virtual void beginQuittingApp();
+
     virtual void quit();
 
     inline void setRunMode(RunMode mode);

--- a/src/core/coreapplication.h
+++ b/src/core/coreapplication.h
@@ -23,6 +23,9 @@
 
 #include <QCoreApplication>
 
+// Timeout for core session cleanup
+#include <QTimer>
+
 #include "quassel.h"
 
 /// Encapsulates CoreApplication's logic.
@@ -38,6 +41,15 @@ public:
 
     bool init();
 
+    /**
+     * Request all sessions disconnect from their active networks, and perform other cleanup.
+     *
+     * Returns immediately, raising a signal in Core when complete.
+     *
+     * @see Core::sessionsFinished()
+     */
+    void quitCoreSessions();
+
 private:
     bool _coreCreated;
 };
@@ -51,6 +63,20 @@ public:
     ~CoreApplication();
 
     bool init();
+
+protected:
+    /**
+     * Requests an orderly shutdown of the application, cleaning up active sessions as needed.
+     *
+     * @see Quassel::beginQuittingApp()
+     */
+    void beginQuittingApp();
+
+private slots:
+    /**
+     * Signifies all sessions have been disconnected and cleaned up, or timeout has reached.
+     */
+    void coreSessionsFinish();
 
 private:
     CoreApplicationInternal *_internal;

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -364,6 +364,10 @@ private:
     bool _quitRequested;
     QString _quitReason;
 
+    bool _disconnectExpected;  /// If true, connection is quitting, expect a socket close
+    // This avoids logging a spurious RemoteHostClosedError whenever disconnect is called without
+    // specifying a permanent (saved to core session) disconnect.
+
     bool _previousConnectionAttemptFailed;
     int _lastUsedServerIndex;
 

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -134,6 +134,14 @@ public slots:
     //! Marks us away (or unaway) on all networks
     void globalAway(const QString &msg = QString());
 
+    /**
+     * Disconnect and clean up all active networks.
+     *
+     * This includes sending a 'QUIT' to all connected networks.  Non-blocking call; connect to the
+     * CoreSession::globalDisconnected() signal to receive notice when cleanup is finished.
+     */
+    void globalDisconnect();
+
 signals:
     void initialized();
     void sessionState(const Protocol::SessionState &sessionState);
@@ -162,6 +170,11 @@ signals:
 
     void passwordChanged(PeerPtr peer, bool success);
 
+    /**
+     * Signifies that all active networks have finished disconnecting.
+     */
+    void globalDisconnected();
+
 protected:
     virtual void customEvent(QEvent *event);
 
@@ -181,6 +194,15 @@ private slots:
     void updateIdentityBySender();
 
     void saveSessionState() const;
+
+    /**
+     * Mark the network for the given NetworkId as disconnected.
+     *
+     * Disconnected networks have 'QUIT' and received the socket closed event.
+     *
+     * @param[in] networkId NetworkId for the disconnected CoreNetwork
+     */
+    void markNetworkDisconnected(const NetworkId &networkId);
 
 private:
     void processMessages();
@@ -219,6 +241,10 @@ private:
     QList<RawMessage> _messageQueue;
     bool _processMessages;
     CoreIgnoreListManager _ignoreListManager;
+
+    // Network disconnect and clean-up
+    bool _globalDisconnectActive;             /// If true, networks are being disconnected
+    QList<NetworkId> _disconnectingNetworks;  /// Networks still pending disconnect
 };
 
 

--- a/src/core/sessionthread.h
+++ b/src/core/sessionthread.h
@@ -44,11 +44,26 @@ public:
     CoreSession *session();
     UserId user();
 
+    /**
+     * Request the session disconnect and clean-up.
+     *
+     * This handles any tasks that require the event-loop.  Non-blocking call; connect to the
+     * SessionThread::threadedSessionFinished() signal to receive notice when cleanup is finished.
+     */
+    void finishThreadedSession();
+
 public slots:
     void addClient(QObject *peer);
 
 private slots:
     void setSessionInitialized();
+
+    /**
+     * Signifies that the session hosted by this thread instance has finished cleaning up.
+     *
+     * Generic event used internally to be able to include UserId in the public signal.
+     */
+    void sessionFinished();
 
 signals:
     void initialized();
@@ -56,6 +71,20 @@ signals:
 
     void addRemoteClient(RemotePeer *peer);
     void addInternalClient(InternalPeer *peer);
+
+    /**
+     * Request the session disconnect and clean-up.
+     *
+     * Generic event used internally for easier cross-thread safety.
+     */
+    void finishSession();
+
+    /**
+     * Signifies that the session hosted by this thread instance has finished cleaning up.
+     *
+     * @param[out] user UserId of the finished session
+     */
+    void threadedSessionFinished(const UserId user);
 
 private:
     CoreSession *_session;

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -291,7 +291,13 @@ void MainWin::quit()
     QtUiSettings s;
     saveStateToSettings(s);
     saveLayout();
-    QApplication::quit();
+    if (QtUiApplication::runMode() == QtUiApplication::RunMode::Monolithic) {
+        // For monolithic with built-in core, attempt to clean up in the background before quitting
+        emit coreQuitRequested();
+    } else {
+        // Not monolithic, just shutdown the UI immediately
+        QApplication::quit();
+    }
 }
 
 

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -169,6 +169,13 @@ signals:
     void connectToCore(const QVariantMap &connInfo);
     void disconnectFromCore();
 
+    /**
+     * Signifies the internal core should be shutdown as the application is quitting.
+     *
+     * This signal is not raised if QtUiApplication::runMode() != RunMode::Monolithic
+     */
+    void coreQuitRequested();
+
 private:
 #ifdef HAVE_KDE
     KHelpMenu *_kHelpMenu;

--- a/src/qtui/monoapplication.h
+++ b/src/qtui/monoapplication.h
@@ -23,6 +23,9 @@
 
 #include "qtuiapplication.h"
 
+// Timeout for core session cleanup
+#include <QTimer>
+
 class CoreApplicationInternal;
 
 class MonolithicApplication : public QtUiApplication
@@ -34,8 +37,30 @@ public:
 
     bool init();
 
+protected:
+    /**
+     * Requests an orderly shutdown of the application, cleaning up active sessions as needed.
+     *
+     * @see Quassel::beginQuittingApp()
+     */
+    virtual void beginQuittingApp();
+
 private slots:
     void startInternalCore();
+
+    /**
+     * Requests an orderly shutdown of the application, cleaning up active sessions as needed.
+     *
+     * Implementation as a slot allows connecting signals from QtUiApplication.
+     *
+     * @see MonolithicApplication::beginQuittingApp()
+     */
+    void shutdownInternalCore();
+
+    /**
+     * Signifies all sessions have been disconnected and cleaned up, or timeout has reached.
+     */
+    void coreSessionsFinish();
 
 private:
     CoreApplicationInternal *_internal;

--- a/src/qtui/qtuiapplication.cpp
+++ b/src/qtui/qtuiapplication.cpp
@@ -161,6 +161,8 @@ bool QtUiApplication::init()
         // QTimer::singleShot(0, gui, SLOT(init()));
         gui->init();
         resumeSessionIfPossible();
+        // Pass along the main window's request for shutdown to the backend __Application instance
+        connect(QtUi::mainWindow(), SIGNAL(coreQuitRequested()), this, SIGNAL(quitRequested()));
         return true;
     }
     return false;

--- a/src/qtui/qtuiapplication.h
+++ b/src/qtui/qtuiapplication.h
@@ -60,6 +60,14 @@ public:
     void saveState(QSessionManager &manager);
 #endif
 
+signals:
+    /**
+     * Signifies the main application is closing and intends to shutdown the internal core.
+     *
+     * This signal is not raised if QtUiApplication::runMode() != RunMode::Monolithic
+     */
+    void quitRequested();
+
 protected:
     virtual void quit();
 


### PR DESCRIPTION
## In short
* When shutting down the core, disconnect all sessions' networks first
 * Signal sent via core, session threads, to networks, calling disconnect on each
 * When sockets closed, signal sent back up to ```[Core|Mono]Application``` as appropriate
* Modify monolithic to gracefully shutdown when main window calls quit
 * Disconnect happens in background, window still disappears nearly instantly
* If disconnect not finished within 10 seconds, Quassel immediately quits
 * Same behavior as before, should reduce risk of getting stuck

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing polish, visible to other clients
Risk | ★★☆ *2/3* | Edge-cases might block normal shutdown
Intrusiveness | ★★☆ *2/3* | Many files, but shouldn't interfere with other pull requests

```
> From this:
<-- dcircuit_dev (quasseldev@hostmask.IP) has quit (Input/output error)
> To this:
<-- dcircuit_dev (quasseldev@hostmask.IP) has quit (Quit: My Message!)
```

## Rationale
This addresses two small matters of polish.

First, Quassel should send a ```QUIT``` when shutting down to make use of the "Quit Reason" in the identity settings.  Having the core shutdown may be one of the most common methods of quitting, whether via closing the monolithic client or ```upstart```, ```systemd```, ```sysvinit```, etc managing the ```quasselcore``` service.  Simply dropping the socket as done now seems somewhat haphazard.

Second, by properly waiting to ```QUIT``` and disconnect, Quassel now logs disconnects in the chat history.  This reduces confusion over what happened, and simplifies distinguishing between a controlled shutdown and a power outage or crash.

## Implementation
* Send ```QUIT``` when core is shutting down, treating it as a non-requested
disconnect (*core will reconnect on next launch*)
 * If sockets aren't closed within 10 seconds, Quassel quits immediately like before
* Add the necessary ```SLOT``` and ```SIGNAL``` calls throughout the chain of ```[Core|Mono]Application``` ↔ ```CoreApplicationInternal``` ↔ ```Core``` ↔ ```SessionThread``` ↔ ```CoreSession``` ↔ ```CoreNetwork```
 * Lets networks be centrally disconnected, then the status signaled back
* Redirect ```SIGTERM``` and ```SIGINT``` to a virtual function in ```quassel.h```, so
CoreApplication and MonolithicApplication can implement custom
clean-up, i.e. calling Core::quitSessions().
* Modify ```mainwin``` in monolithic mode to emit a signal to request quit
 * Window will hide while core shuts down in background
 * Classic client immediately quits as before

*Other approaches are possible; constructive criticism is welcome!*

## Testing
### Test results

**Success** (*properly sends ```QUIT```*)
* ```Ctrl-C``` ```quasselcore``` in terminal
* ```Upstart```/```systemd``` shutting down ```quasselcore```
* Closing monolithic client with ```Ctrl-Q```/close button/etc (*Win/Linux*)

**Failure** (*behaves as before, dropping socket*)
* Shutting down desktop session (*Win/Linux*) with monolithic client without first closing the window
* Shutting down standalone core on Windows

### Examples
**Unreal 3.2**
```
> Before
<-- dcircuit_dev (quasseldev@hostmask.IP) has quit (Input/output error)
> After
<-- dcircuit_dev (quasseldev@hostmask.IP) has quit (Quit: My Message!)
```
**Freenode**
```
> Before
<-- dcircuit_dev (~quasselde@hostmask) has quit (Remote host closed the connection)
> After
<-- dcircuit_dev (~quasselde@hostmask) has quit (Quit: My Message!)
```

Where "My Message!" is specified in Configure Quassel → IRC → Identities → Advanced → Quit Reason

*Note: Freenode hides quit messages from clients that disconnect soon after connecting.  Stay connected ~10 minutes before testing quit.*