### PR TITLE
Fix AppVeyor builds (use Visual Studio 2015, Qt 5.6)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -116,12 +116,12 @@ build_script:
     NsisDeployImage $env:APPVEYOR_BUILD_FOLDER\scripts\build\NullsoftInstaller.nsi
 
 environment:
-    QT_VER: 5.5
+    QT_VER: 5.6
 
     matrix:
     #msvc
-    - COMPILER: msvc2013_64
-    - COMPILER: msvc2013
+    - COMPILER: msvc2015_64
+    - COMPILER: msvc2015
     #mingw
     - COMPILER: mingw492_32
 


### PR DESCRIPTION
## In brief
* Fix Windows builds due to newer C++ features
 * Bumps requirements to Visual Studio 2015, Qt 5.6
 * [AppVeyor requires Qt 5.6 due to them not installing ```msvc2015``` support for older versions](http://www.appveyor.com/docs/installed-software#qt )

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | Fixes Quassel building on Windows, including future pull requests
Risk | ★☆☆ *1/3* | Qt 5.6 on Windows might change or break other functionality
Intrusiveness | ★☆☆ *1/3* | Changes appveyor.yml, shouldn't interfere with other pull requests

*This template may be overkill, but it's followed for consistency, and a little bit of silliness* :)