### PR TITLE
Try to reconnect to the database multiple times when disconnected

### DIFF
--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -57,7 +57,19 @@ QSqlDatabase AbstractSqlStorage::logDb()
 
     if (!db.isOpen()) {
         qWarning() << "Database connection" << displayName() << "for thread" << QThread::currentThread() << "was lost, attempting to reconnect...";
-        dbConnect(db);
+
+        // We can't assume that the DB is immediately available,
+        // so we try waiting up to a minute
+        for (int i=0; i<10; i++) {
+            dbConnect(db);
+
+            if (db.isOpen()) {
+                break;
+            }
+
+            qWarning() << "Database still down, trying again in 6 seconds...";
+            QThread::sleep(6);
+        }
     }
 
     return db;


### PR DESCRIPTION
In case we lose contact with the database, e. g. when it is restarting
during an upgrade, we can't assume it is available immediately, so loop
for a minute trying to reconnect before giving up.

**Not tested much yet.** So should probably not be merged immediately.
