### PR TITLE
Fix sending quit messages on core shutdown (simpler)

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -39,6 +39,7 @@ CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
     _userInputHandler(new CoreUserInputHandler(this)),
     _autoReconnectCount(0),
     _quitRequested(false),
+    _disconnectExpected(false),
 
     _previousConnectionAttemptFailed(false),
     _lastUsedServerIndex(0),
@@ -225,6 +226,8 @@ void CoreNetwork::connectToIrc(bool reconnecting)
 void CoreNetwork::disconnectFromIrc(bool requested, const QString &reason, bool withReconnect,
                                     bool forceImmediate)
 {
+    // Disconnecting from the network, should expect a socket close or error
+    _disconnectExpected = true;
     _quitRequested = requested; // see socketDisconnected();
     if (!withReconnect) {
         _autoReconnectTimer.stop();
@@ -455,8 +458,10 @@ void CoreNetwork::socketHasData()
 
 void CoreNetwork::socketError(QAbstractSocket::SocketError error)
 {
-    if (_quitRequested && error == QAbstractSocket::RemoteHostClosedError)
+    // Ignore socket closed errors if expected
+    if (_disconnectExpected && error == QAbstractSocket::RemoteHostClosedError) {
         return;
+    }
 
     _previousConnectionAttemptFailed = true;
     qWarning() << qPrintable(tr("Could not connect to %1 (%2)").arg(networkName(), socket.errorString()));
@@ -547,6 +552,8 @@ void CoreNetwork::socketDisconnected()
     setConnected(false);
     emit disconnected(networkId());
     emit socketDisconnected(identityPtr(), localAddress(), localPort(), peerAddress(), peerPort());
+    // Reset disconnect expectations
+    _disconnectExpected = false;
     if (_quitRequested) {
         _quitRequested = false;
         setConnectionState(Network::Disconnected);
@@ -591,6 +598,7 @@ void CoreNetwork::networkInitialized()
 {
     setConnectionState(Network::Initialized);
     setConnected(true);
+    _disconnectExpected = false;
     _quitRequested = false;
 
     if (useAutoReconnect()) {

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -99,10 +99,36 @@ CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
 
 CoreNetwork::~CoreNetwork()
 {
-    if (connectionState() != Disconnected && connectionState() != Network::Reconnecting)
-        disconnectFromIrc(false);  // clean up, but this does not count as requested disconnect!
+    // Request a proper disconnect, but don't count as user-requested disconnect
+    if (socketConnected()) {
+        // Only try if the socket's fully connected (not initializing or disconnecting).
+        // Force an immediate disconnect, jumping the command queue.  Ensures the proper QUIT is
+        // shown even if other messages are queued.
+        disconnectFromIrc(false, QString(), false, true);
+        // Process the putCmd events that trigger the quit.  Without this, shutting down the core
+        // results in abrubtly closing the socket rather than sending the QUIT as expected.
+        QCoreApplication::processEvents();
+        // Wait briefly for each network to disconnect.  Sometimes it takes a little while to send.
+        if (!forceDisconnect()) {
+            qWarning() << "Timed out quitting network" << networkName() <<
+                          "(user ID " << userId() << ")";
+        }
+    }
     disconnect(&socket, 0, this, 0); // this keeps the socket from triggering events during clean up
     delete _userInputHandler;
+}
+
+
+bool CoreNetwork::forceDisconnect(int msecs)
+{
+    if (socket.state() == QAbstractSocket::UnconnectedState) {
+        // Socket already disconnected.
+        return true;
+    }
+    // Request a socket-level disconnect if not already happened
+    socket.disconnectFromHost();
+    // Return the result of waiting for disconnect; true if successful, otherwise false
+    return socket.waitForDisconnected(msecs);
 }
 
 

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -169,6 +169,17 @@ public slots:
     void disconnectFromIrc(bool requested = true, const QString &reason = QString(),
                            bool withReconnect = false, bool forceImmediate = false);
 
+    /**
+     * Forcibly close the IRC server socket, waiting for it to close.
+     *
+     * Call CoreNetwork::disconnectFromIrc() first, allow the event loop to run, then if you need to
+     * be sure the network's disconencted (e.g. clean-up), call this.
+     *
+     * @param msecs  Maximum time to wait for socket to close, in milliseconds.
+     * @return True if socket closes successfully; false if error occurs or timeout reached
+     */
+    bool forceDisconnect(int msecs = 1000);
+
     void userInput(BufferInfo bufferInfo, QString msg);
 
     /**

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -372,6 +372,10 @@ private:
     bool _quitRequested;
     QString _quitReason;
 
+    bool _disconnectExpected;  /// If true, connection is quitting, expect a socket close
+    // This avoids logging a spurious RemoteHostClosedError whenever disconnect is called without
+    // specifying a permanent (saved to core session) disconnect.
+
     bool _previousConnectionAttemptFailed;
     int _lastUsedServerIndex;
 

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -137,7 +137,47 @@ CoreSession::CoreSession(UserId uid, bool restoreState, QObject *parent)
 CoreSession::~CoreSession()
 {
     saveSessionState();
+
+    /* Why partially duplicate CoreNetwork destructor?  When each CoreNetwork quits in the
+     * destructor, disconnections are processed in sequence for each object.  For many IRC servers
+     * on a slow network, this could significantly delay core shutdown [msecs wait * network count].
+     *
+     * Here, CoreSession first calls disconnect on all networks, letting them all start
+     * disconnecting before beginning to sequentially wait for each network.  Ideally, after the
+     * first network is disconnected, the other networks will have already closed.  Worst-case may
+     * still wait [msecs wait time * num. of networks], but the risk should be much lower.
+     *
+     * CoreNetwork should still do cleanup in its own destructor in case a network is deleted
+     * outside of deleting the whole CoreSession.
+     *
+     * If this proves to be problematic in the future, there's an alternative Qt signal-based system
+     * implemented in another pull request that guarentees a maximum amount of time to disconnect,
+     * but at the cost of more complex code.
+     *
+     * See https://github.com/quassel/quassel/pull/203
+     */
+
     foreach(CoreNetwork *net, _networks.values()) {
+        // Request each network properly disconnect, but don't count as user-requested disconnect
+        if (net->socketConnected()) {
+            // Only try if the socket's fully connected (not initializing or disconnecting).
+            // Force an immediate disconnect, jumping the command queue.  Ensures the proper QUIT is
+            // shown even if other messages are queued.
+            net->disconnectFromIrc(false, QString(), false, true);
+        }
+    }
+
+    // Process the putCmd events that trigger the quit.  Without this, shutting down the core
+    // results in abrubtly closing the socket rather than sending the QUIT as expected.
+    QCoreApplication::processEvents();
+
+    foreach(CoreNetwork *net, _networks.values()) {
+        // Wait briefly for each network to disconnect.  Sometimes it takes a little while to send.
+        if (!net->forceDisconnect()) {
+            qWarning() << "Timed out quitting network" << net->networkName() <<
+                          "(user ID " << net->userId() << ")";
+        }
+        // Delete the network now that it's closed
         delete net;
     }
 }


### PR DESCRIPTION
## In short
* When shutting down the core, disconnect all sessions' networks first
 * Call happens via ```CoreSession``` destructor, waiting up to 1 second
 * *Pending [pull request #201](https://github.com/quassel/quassel/pull/201 )*, prioritize ```QUIT``` over queued messages to ensure a graceful disconnect

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing polish, visible to other clients
Risk | ★★☆ *2/3* | Slightly slower shutdown, edge-cases might block normal quit
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

```
From this:
<-- dcircuit_dev (quasseldev@hostmask.IP) has quit (Input/output error)
To this:
<-- dcircuit_dev (quasseldev@hostmask.IP) has quit (Quit: My Message!)
```

*Previously submitted as [pull request #203](https://github.com/quassel/quassel/pull/203 ) using a more complex signals/slots layout.  Thanks to @seezer for the suggestions!*

**Depends upon [pull request #201](https://github.com/quassel/quassel/pull/201 ) to work more reliably.  If the former is merged, this will need updated.**

## Rationale
This addresses two small matters of polish.

First, Quassel should send a ```QUIT``` when shutting down to make use of the "Quit Reason" in the identity settings.  Having the core shutdown may be one of the most common methods of quitting, whether via closing the monolithic client or ```upstart```, ```systemd```, ```sysvinit```, etc managing the ```quasselcore``` service.  Simply dropping the socket as done now seems somewhat haphazard.

Second, by properly waiting to ```QUIT``` and disconnect, Quassel now logs disconnects in the chat history.  This reduces confusion over what happened, and simplifies distinguishing between a controlled shutdown and a power outage or crash.

## Implementation
* Send ```QUIT``` when core is shutting down, treating it as a non-requested
disconnect (*core will reconnect on next launch*)
 * Happens inside ```~CoreSession()```, called during ```___Application::quit()```
 * If sockets aren't closed within 1 second, Quassel quits immediately like before

*Other approaches are possible; constructive criticism is welcome!*

## Testing
### Test results

**Success** (*properly sends ```QUIT```*)
* ```Ctrl-C``` ```quasselcore``` in terminal
* ```Upstart```/```systemd``` shutting down ```quasselcore```
* Closing monolithic client with ```Ctrl-Q```/close button/etc (*Win/Linux*)
* Shutting down Linux desktop session with monolithic client without first closing the window

**Failure** (*behaves as before, dropping socket*)
* Shutting down Windows desktop session with monolithic client without first closing the window
* Shutting down standalone core on Windows

### Examples
**Unreal 3.2**
```
> Before
<-- dcircuit_dev (quasseldev@hostmask.IP) has quit (Input/output error)
> After
<-- dcircuit_dev (quasseldev@hostmask.IP) has quit (Quit: My Message!)
```
**Freenode**
```
> Before
<-- dcircuit_dev (~quasselde@hostmask) has quit (Remote host closed the connection)
> After
<-- dcircuit_dev (~quasselde@hostmask) has quit (Quit: My Message!)
```

Where "My Message!" is specified in Configure Quassel → IRC → Identities → Advanced → Quit Reason

*Note: Freenode hides quit messages from clients that disconnect soon after connecting.  Stay connected ~10 minutes before testing quit.*