### PR TITLE
Reload SSL certificates on signal SIGHUP

### DIFF
--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -72,6 +72,11 @@ Quassel::Quassel()
     // We catch SIGTERM and SIGINT (caused by Ctrl+C) to graceful shutdown Quassel.
     signal(SIGTERM, handleSignal);
     signal(SIGINT, handleSignal);
+#ifndef Q_OS_WIN
+    // SIGHUP is used to reload configuration (i.e. SSL certificates)
+    // Windows does not support SIGHUP
+    signal(SIGHUP, handleSignal);
+#endif
 }
 
 
@@ -323,6 +328,20 @@ void Quassel::handleSignal(int sig)
         else
             QCoreApplication::quit();
         break;
+#ifndef Q_OS_WIN
+// Windows does not support SIGHUP
+    case SIGHUP:
+        // Most applications use this as the 'configuration reload' command, e.g. nginx uses it for
+        // graceful reloading of processes.
+        if (_instance) {
+            // If the instance exists, reload the configuration
+            quInfo() << "Caught signal" << SIGHUP <<"- reloading configuration";
+            if (_instance->reloadConfig()) {
+                quInfo() << "Successfully reloaded configuration";
+            }
+        }
+        break;
+#endif
     case SIGABRT:
     case SIGSEGV:
 #ifndef Q_OS_WIN

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -143,6 +143,16 @@ protected:
     virtual bool init();
     virtual void quit();
 
+    /**
+     * Requests a reload of relevant runtime configuration.
+     *
+     * Does not reload all configuration, but could catch things such as SSL certificates.  Unless
+     * overridden, simply does nothing.
+     *
+     * @return True if configuration reload successful, otherwise false
+     */
+    virtual bool reloadConfig() { return true; }
+
     inline void setRunMode(RunMode mode);
     inline void setDataDirPaths(const QStringList &paths);
     QStringList findDataDirPaths() const;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -428,6 +428,18 @@ bool Core::sslSupported()
 }
 
 
+bool Core::reloadCerts()
+{
+#ifdef HAVE_SSL
+    SslServer *sslServer = qobject_cast<SslServer *>(&instance()->_server);
+    return sslServer->reloadCerts();
+#else
+    // SSL not supported, don't mark configuration reload as failed
+    return true;
+#endif
+}
+
+
 bool Core::startListening()
 {
     // in mono mode we only start a local port if a port is specified in the cli call

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -494,6 +494,14 @@ public:
     static inline QDateTime startTime() { return instance()->_startTime; }
     static inline bool isConfigured() { return instance()->_configured; }
     static bool sslSupported();
+
+    /**
+     * Reloads SSL certificates used for connection with clients
+     *
+     * @return True if certificates reloaded successfully, otherwise false.
+     */
+    static bool reloadCerts();
+
     static QVariantList backendInfo();
 
     static QString setup(const QString &adminUser, const QString &adminPassword, const QString &backend, const QVariantMap &setupData);

--- a/src/core/coreapplication.cpp
+++ b/src/core/coreapplication.cpp
@@ -62,6 +62,17 @@ bool CoreApplicationInternal::init()
 }
 
 
+bool CoreApplicationInternal::reloadConfig()
+{
+    if (_coreCreated) {
+        // Currently, only reloading SSL certificates is supported
+        return Core::reloadCerts();
+    } else {
+        return false;
+    }
+}
+
+
 /*****************************************************************************/
 
 CoreApplication::CoreApplication(int &argc, char **argv)
@@ -93,4 +104,14 @@ bool CoreApplication::init()
         return true;
     }
     return false;
+}
+
+
+bool CoreApplication::reloadConfig()
+{
+    if (_internal) {
+        return _internal->reloadConfig();
+    } else {
+        return false;
+    }
 }

--- a/src/core/coreapplication.h
+++ b/src/core/coreapplication.h
@@ -38,6 +38,15 @@ public:
 
     bool init();
 
+    /**
+     * Requests a reload of relevant runtime configuration.
+     *
+     * In particular, signals to the Core to reload SSL certificates.
+     *
+     * @return True if configuration reload successful, otherwise false
+     */
+    bool reloadConfig();
+
 private:
     bool _coreCreated;
 };
@@ -51,6 +60,15 @@ public:
     ~CoreApplication();
 
     bool init();
+
+    /**
+     * Requests a reload of relevant runtime configuration.
+     *
+     * @see Quassel::reloadConfig()
+     *
+     * @return True if configuration reload successful, otherwise false
+     */
+    bool reloadConfig();
 
 private:
     CoreApplicationInternal *_internal;

--- a/src/core/sslserver.h
+++ b/src/core/sslserver.h
@@ -42,6 +42,16 @@ public:
     virtual inline const QSslKey &key() const { return _key; }
     virtual inline bool isCertValid() const { return _isCertValid; }
 
+    /**
+     * Reloads SSL certificates used for connections
+     *
+     * If this command fails, it will try to maintain the most recent working certificate.  Error
+     * conditions are automatically written to the log.
+     *
+     * @return True if certificates reloaded successfully, otherwise false.
+     */
+    bool reloadCerts();
+
 protected:
 #if QT_VERSION >= 0x050000
     virtual void incomingConnection(qintptr socketDescriptor);
@@ -52,11 +62,25 @@ protected:
     virtual bool setCertificate(const QString &path, const QString &keyPath);
 
 private:
+    /**
+     * Loads SSL certificates used for connections
+     *
+     * If this command fails, it will try to maintain the most recent working certificate.  Will log
+     * specific failure points, but does not offer verbose guidance.
+     *
+     * @return True if certificates loaded successfully, otherwise false.
+     */
+    bool loadCerts();
+
     QLinkedList<QTcpSocket *> _pendingConnections;
     QSslCertificate _cert;
     QSslKey _key;
     QList<QSslCertificate> _ca;
     bool _isCertValid;
+
+    // Used when reloading certificates later
+    QString _sslCertPath; /// Path to the certificate file
+    QString _sslKeyPath;  /// Path to the private key file (may be in same file as above)
 };
 
 

--- a/src/qtui/monoapplication.cpp
+++ b/src/qtui/monoapplication.cpp
@@ -73,3 +73,13 @@ void MonolithicApplication::startInternalCore()
     connect(connection, SIGNAL(connectToInternalCore(InternalPeer*)), core, SLOT(setupInternalClientSession(InternalPeer*)));
     connect(core, SIGNAL(sessionState(Protocol::SessionState)), connection, SLOT(internalSessionStateReceived(Protocol::SessionState)));
 }
+
+
+bool MonolithicApplication::reloadConfig()
+{
+    if (_internal) {
+        return _internal->reloadConfig();
+    } else {
+        return false;
+    }
+}

--- a/src/qtui/monoapplication.h
+++ b/src/qtui/monoapplication.h
@@ -34,6 +34,15 @@ public:
 
     bool init();
 
+    /**
+     * Requests a reload of relevant runtime configuration.
+     *
+     * @see Quassel::reloadConfig()
+     *
+     * @return True if configuration reload successful, otherwise false
+     */
+    bool reloadConfig();
+
 private slots:
     void startInternalCore();
 


### PR DESCRIPTION
## In brief
* Catch SIGHUP, use it to reload configuration (SSL certs)
 * Similar to how [```nginx```](https://www.nginx.com/resources/wiki/start/topics/tutorials/commandline/ ) and other server programs handle it
 * Allows easy automation of reloading certificates, important with services such as
Let's Encrypt
* If reloading certificates fails, keep old certificates to not disrupt new connections

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Less prominent feature, helps uptime for high-availability cores
Risk | ★☆☆ *1/3* | Edge-cases might interfere with loading certificates
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Rationale
[Let's Encrypt](https://letsencrypt.org/), a free, automated certificate authority, issues certificates that last for up to 90 days.  To make use of their certificates, Quassel must either restart, or have a manner to reload.

Ability to swap out certificates on the fly may also help in environments where uptime more of a concern, such as hosting for tens or hundreds of users.

## Examples
*Command or input by me* ```> this```
*Otherwise, Quassel log output*
```
> ./quasselcore
2016-06-08 16:00:01 Info: Restoring previous core state... 
> killall -SIGHUP quasselcore
2016-06-08 16:00:12 Info: Caught signal 1 - reloading configuration 
2016-06-08 16:00:12 Info: Successfully reloaded configuration 
> mv quasselCert.pem quasselCert-notvisible.pem
> killall -SIGHUP quasselcore
2016-06-08 16:00:22 Info: Caught signal 1 - reloading configuration 
2016-06-08 16:00:22 Warning: SslServer: Certificate file /PATH/quasselCert.pem does not exist 
2016-06-08 16:00:22 Warning: SslServer: Unable to reload certificate file, reverting
           Quassel Core will use the previous key to provide SSL for client connections.
           Please see http://quassel-irc.org/faq/cert to learn how to enable SSL support. 
> mv quasselCert-notvisible.pem quasselCert.pem
> killall -SIGHUP quasselcore
2016-06-08 16:00:31 Info: Caught signal 1 - reloading configuration 
2016-06-08 16:00:31 Info: Successfully reloaded configuration 
> [Ctrl]-[C]
2016-06-08 16:00:33 Warning: Caught signal 2 - exiting. 
> mv quasselCert.pem quasselCert-notvisible.pem
> ./quasselcore
2016-06-08 16:00:36 Warning: SslServer: Certificate file /PATH/quasselCert.pem does not exist 
2016-06-08 16:00:36 Warning: SslServer: Unable to set certificate file
           Quassel Core will still work, but cannot provide SSL for client connections.
           Please see http://quassel-irc.org/faq/cert to learn how to enable SSL support. 
2016-06-08 16:00:36 Warning: SslServer: Certificate file /PATH/quasselCert.pem does not exist 
2016-06-08 16:00:36 Info: Restoring previous core state... 
> killall -SIGHUP quasselcore
2016-06-08 16:00:39 Info: Caught signal 1 - reloading configuration 
2016-06-08 16:00:39 Warning: SslServer: Certificate file /PATH/quasselCert.pem does not exist 
2016-06-08 16:00:39 Warning: SslServer: Unable to reload certificate file
           Quassel Core will still work, but cannot provide SSL for client connections.
           Please see http://quassel-irc.org/faq/cert to learn how to enable SSL support. 
> mv quasselCert-notvisible.pem quasselCert.pem
> killall -SIGHUP quasselcore
2016-06-08 16:00:43 Info: Caught signal 1 - reloading configuration 
2016-06-08 16:00:43 Info: Successfully reloaded configuration 
2016-06-08 16:01:03 Warning: Caught signal 2 - exiting. 
```