### PR TITLE
Fix highlights on formatted (bold, colored) messages

### DIFF
--- a/src/qtui/qtuimessageprocessor.cpp
+++ b/src/qtui/qtuimessageprocessor.cpp
@@ -130,7 +130,7 @@ void QtUiMessageProcessor::checkForHighlight(Message &msg)
         }
         foreach(QString nickname, nickList) {
             QRegExp nickRegExp("(^|\\W)" + QRegExp::escape(nickname) + "(\\W|$)", _nicksCaseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
-            if (nickRegExp.indexIn(msg.contents()) >= 0) {
+            if (nickRegExp.indexIn(stripFormatCodes(msg.contents())) >= 0) {
                 msg.setFlags(msg.flags() | Message::Highlight);
                 return;
             }
@@ -161,7 +161,7 @@ void QtUiMessageProcessor::checkForHighlight(Message &msg)
             else {
                 rx = QRegExp("(^|\\W)" + QRegExp::escape(rule.name) + "(\\W|$)", rule.caseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
             }
-            bool match = (rx.indexIn(msg.contents()) >= 0);
+            bool match = (rx.indexIn(stripFormatCodes(msg.contents())) >= 0);
             if (match) {
                 msg.setFlags(msg.flags() | Message::Highlight);
                 return;


### PR DESCRIPTION
## In short
* Strip format codes from message content when checking for highlights
 * Fixes color-coded messages not triggering highlights
 * Test-case - messages from the ```qAnnounce``` bot in ```#quassel```

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing, more consistent highlighting
Risk | ★★☆ *2/3* | Some might expect formatted messages to be ignored
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Example
### Before - highlights ignore formatted messages
![Highlighting broken](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/fix-highlight-formatted/highlight%20broken%20-%20missed%20messages.png#v1 )
### After - highlights detect formatted messages
![Highlighting fixed](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/fix-highlight-formatted/highlight%20fixed%20-%20no%20missed%20messages.png#v1 )