### PR TITLE
Hide network tooltip info when disconnected, simplify markup

### DIFF
--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -76,7 +76,7 @@ QVariant NetworkItem::data(int column, int role) const
 
 QString NetworkItem::escapeHTML(const QString &string, bool useNonbreakingSpaces)
 {
-    // QString.replace() doesn't guarentee the source string will remain constant.
+    // QString.replace() doesn't guarantee the source string will remain constant.
     // Use a local variable to avoid compiler errors.
 #if QT_VERSION < 0x050000
     QString formattedString = Qt::escape(string);
@@ -522,8 +522,7 @@ QString QueryBufferItem::toolTip(int column) const
     Q_UNUSED(column);
     QString strTooltip;
     QTextStream tooltip( &strTooltip, QIODevice::WriteOnly );
-    tooltip << "<qt><style>.bold { font-weight: bold; }</style>"
-            << "<style>.italic { font-style: italic; }</style>";
+    tooltip << "<qt><style>.bold { font-weight: bold; } .italic { font-style: italic; }</style>";
 
     // Keep track of whether or not information has been added
     bool infoAdded = false;
@@ -552,11 +551,13 @@ QString QueryBufferItem::toolTip(int column) const
 
         tooltip << "<table cellspacing='5' cellpadding='0'>";
         if (_ircUser->isAway()) {
-            QString awayMessage(tr("(unknown)"));
-            if(!_ircUser->awayMessage().isEmpty()) {
-                awayMessage = _ircUser->awayMessage();
+            QString awayMessageHTML = QString("<p class='italic'>%1</p>").arg(tr("Unknown"));
+
+            // If away message is known, replace with the escaped message.
+            if (!_ircUser->awayMessage().isEmpty()) {
+                awayMessageHTML = NetworkItem::escapeHTML(_ircUser->awayMessage());
             }
-            addRow(NetworkItem::escapeHTML(tr("Away message"), true), NetworkItem::escapeHTML(awayMessage), true);
+            addRow(NetworkItem::escapeHTML(tr("Away message"), true), awayMessageHTML, true);
         }
         addRow(tr("Realname"),
                NetworkItem::escapeHTML(_ircUser->realName()),
@@ -608,7 +609,7 @@ QString QueryBufferItem::toolTip(int column) const
 
     // If no further information found, offer an explanatory message
     if (!infoAdded)
-        tooltip << "<p class='italic'>" << tr("No information available") << "</p>";
+        tooltip << "<p class='italic' align='center'>" << tr("No information available") << "</p>";
 
     tooltip << "</qt>";
     return strTooltip;
@@ -669,8 +670,7 @@ QString ChannelBufferItem::toolTip(int column) const
     Q_UNUSED(column);
     QString strTooltip;
     QTextStream tooltip( &strTooltip, QIODevice::WriteOnly );
-    tooltip << "<qt><style>.bold { font-weight: bold; }</style>"
-            << "<qt><style>.italic { font-style: italic; }</style>";
+    tooltip << "<qt><style>.bold { font-weight: bold; } .italic { font-style: italic; }</style>";
 
     // Function to add a row to the tooltip table
     auto addRow = [&](const QString& key, const QString& value, bool condition) {
@@ -705,7 +705,7 @@ QString ChannelBufferItem::toolTip(int column) const
 
         tooltip << "</table>";
     } else {
-        tooltip << "<p class='italic'>" << tr("Not active, double-click to join") << "</p>";
+        tooltip << "<p class='italic' align='center'>" << tr("Not active, double-click to join") << "</p>";
     }
 
     tooltip << "</qt>";
@@ -1055,8 +1055,7 @@ QString IrcUserItem::toolTip(int column) const
     Q_UNUSED(column);
     QString strTooltip;
     QTextStream tooltip( &strTooltip, QIODevice::WriteOnly );
-    tooltip << "<qt><style>.bold { font-weight: bold; }</style>"
-            << "<style>.italic { font-style: italic; }</style>";
+    tooltip << "<qt><style>.bold { font-weight: bold; } .italic { font-style: italic; }</style>";
 
     // Keep track of whether or not information has been added
     bool infoAdded = false;
@@ -1082,11 +1081,13 @@ QString IrcUserItem::toolTip(int column) const
            NetworkItem::escapeHTML(channelModes()),
            !channelModes().isEmpty());
     if (_ircUser->isAway()) {
-        QString awayMessage(tr("(unknown)"));
-        if(!_ircUser->awayMessage().isEmpty()) {
-            awayMessage = _ircUser->awayMessage();
+        QString awayMessageHTML = QString("<p class='italic'>%1</p>").arg(tr("Unknown"));
+
+        // If away message is known, replace with the escaped message.
+        if (!_ircUser->awayMessage().isEmpty()) {
+            awayMessageHTML = NetworkItem::escapeHTML(_ircUser->awayMessage());
         }
-        addRow(NetworkItem::escapeHTML(tr("Away message"), true), NetworkItem::escapeHTML(awayMessage), true);
+        addRow(NetworkItem::escapeHTML(tr("Away message"), true), awayMessageHTML, true);
     }
     addRow(tr("Realname"),
            NetworkItem::escapeHTML(_ircUser->realName()),
@@ -1138,7 +1139,7 @@ QString IrcUserItem::toolTip(int column) const
 
     // If no further information found, offer an explanatory message
     if (!infoAdded)
-        tooltip << "<p class='italic'>" << tr("No information available") << "</p>";
+        tooltip << "<p class='italic' align='center'>" << tr("No information available") << "</p>";
 
     tooltip << "</qt>";
     return strTooltip;

--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -224,7 +224,7 @@ QString NetworkItem::toolTip(int column) const
     Q_UNUSED(column);
     QString strTooltip;
     QTextStream tooltip( &strTooltip, QIODevice::WriteOnly );
-    tooltip << "<qt><style>.bold { font-weight: bold; }</style>";
+    tooltip << "<qt><style>.bold { font-weight: bold; } .italic { font-style: italic; }</style>";
 
     // Function to add a row to the tooltip table
     auto addRow = [&](const QString& key, const QString& value, bool condition) {
@@ -234,15 +234,18 @@ QString NetworkItem::toolTip(int column) const
     };
 
     tooltip << "<p class='bold' align='center'>" << NetworkItem::escapeHTML(networkName(), true) << "</p>";
-    tooltip << "<table cellspacing='5' cellpadding='0'>";
-    addRow(tr("Server"), NetworkItem::escapeHTML(currentServer(), true), true);
+    if (isActive()) {
+        tooltip << "<table cellspacing='5' cellpadding='0'>";
+        addRow(tr("Server"), NetworkItem::escapeHTML(currentServer(), true), !currentServer().isEmpty());
+        addRow(tr("Users"), QString::number(nickCount()), true);
+        if (_network)
+            addRow(tr("Lag"), NetworkItem::escapeHTML(tr("%1 msecs").arg(_network->latency()), true), true);
 
-    addRow(tr("Users"), QString::number(nickCount()), true);
-
-    if (_network)
-        addRow(tr("Lag"), NetworkItem::escapeHTML(tr("%1 msecs").arg(_network->latency()), true), true);
-
-    tooltip << "</table></qt>";
+        tooltip << "</table>";
+    } else {
+        tooltip << "<p class='italic' align='center'>" << tr("Not connected") << "</p>";
+    }
+    tooltip << "</qt>";
     return strTooltip;
 }
 


### PR DESCRIPTION
## In short
* Remove network information from tooltip when disconnected; show *Not connected* instead
 * Fixes confusing state where tooltip implies network's connected when it's not
* Don't show the server name if empty
* Simplify QML markup
 * Clean up style declaration, redundant ```<qt>``` tags
 * Use *italics* for when away message is unknown, distinguishing from literally being ```(unknown)```

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | User-facing interface polish
Risk | ★☆☆ *1/3* | Might possibly show less information while connecting to a network
Intrusiveness | ★☆☆ *1/3* | New translation string, shouldn't interfere with other pull requests

## Examples
### Network tooltips
**Before: additional, confusing information**
![Network tooltip showing confusing empty server](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/fix-tooltips-server/Server%20tooltip%20-%20with%20extra%20info.png#v1 )
**After: simple "Not connected" message**
![Network tooltip showing simple Not connected message](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/fix-tooltips-server/Server%20tooltip%20-%20with%20cleaner%20message.png#v1 )
### Nick tooltips
**Before: indistinguishable from normal away messages**
![Nick tooltip showing regular unknown message](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/fix-tooltips-server/Nick%20tooltip%20-%20regular%20unknown.png#v1 )
**After: italics used to signify unknown**
![Nick tooltip showing italicized unknown message](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/fix-tooltips-server/Nick%20tooltip%20-%20italic%20unknown.png#v1 )