### PR TITLE
Fix maybe-uninitialized compile warning for hashVersion

### DIFF
--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -193,7 +193,7 @@ UserId SqliteStorage::validateUser(const QString &user, const QString &password)
 {
     UserId userId;
     QString hashedPassword;
-    Storage::HashVersion hashVersion;
+    Storage::HashVersion hashVersion = Storage::HashVersion::Latest;
 
     {
         QSqlQuery query(logDb());


### PR DESCRIPTION
## In short
* Declare hashVersion as latest version before loading results from database
 * If database call failed, hashVersion could be uninitialized
* Resolves a compile warning when building inside Qt Creator 3.0.1

*As this is a very small change, I've skipped the usual breakdown and risk analysis*