### PR TITLE
Add AppData metadata for quassel, quasselclient

### DIFF
--- a/data/quassel.appdata.xml
+++ b/data/quassel.appdata.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2016 Quassel Project <devel@quassel-irc.org> -->
+<component type="desktop">
+	<id>quassel.desktop</id>
+	<metadata_license>CC0-1.0</metadata_license>
+	<project_license>GPL-2.0 or GPL-3.0</project_license>
+	<name>Quassel</name>
+	<summary>Modern IRC client</summary>
+	<description>
+		<p>
+Quassel IRC is a modern, cross-platform, distributed IRC client, meaning that
+one (or multiple) client(s) can attach to and detach from a central core: much
+like the popular combination of screen and a text-based IRC client such as
+WeeChat, but graphical. In addition to this unique feature, we aim to bring a
+pleasurable, comfortable chatting experience to all major platforms, making
+communication with your peers not only convenient, but also available everywhere.
+		</p>
+		<p>
+And the best of all: It's free - as in beer and as in speech.
+		</p>
+		<p>
+This application is the "monolithic" build of Quassel; it can be used on its own
+without setting up a core.
+		</p>
+	</description>
+	<screenshots>
+		<screenshot type="default">
+			<image>http://quassel-irc.org/files/images/20080914-011743-quasselkde4.preview.png</image>
+			<caption>Quassel, with a dark theme enabled</caption>
+		</screenshot>
+		<screenshot type="default">
+			<image>http://quassel-irc.org/files/images/quassel_win7.preview.png</image>
+			<caption>
+The default quassel white theme. Quassel runs on all major desktop platforms,
+and many smartphones as well.
+			</caption>
+		</screenshot>
+	</screenshots>
+
+</component>
+

--- a/data/quasselclient.appdata.xml
+++ b/data/quasselclient.appdata.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2016 Quassel Project <devel@quassel-irc.org> -->
+<component type="desktop">
+	<id>quasselclient.desktop</id>
+	<metadata_license>CC0-1.0</metadata_license>
+	<project_license>GPL-2.0 or GPL-3.0</project_license>
+	<name>Quassel Client</name>
+	<summary>Modern distributed IRC client</summary>
+	<description>
+		<p>
+Quassel IRC is a modern, cross-platform, distributed IRC client, meaning that
+one (or multiple) client(s) can attach to and detach from a central core: much
+like the popular combination of screen and a text-based IRC client such as
+WeeChat, but graphical. In addition to this unique feature, we aim to bring a
+pleasurable, comfortable chatting experience to all major platforms, making
+communication with your peers not only convenient, but also available everywhere.
+		</p>
+		<p>
+And the best of all: It's free - as in beer and as in speech.
+		</p>
+		<p>
+This application is the client-only version of Quassel. You must first set up
+(or have been given an account on) the quassel core before using this.
+		</p>
+	</description>
+	<screenshots>
+		<screenshot type="default">
+			<image>http://quassel-irc.org/files/images/20080914-011743-quasselkde4.preview.png</image>
+			<caption>Quassel, with a dark theme enabled</caption>
+		</screenshot>
+		<screenshot type="default">
+			<image>http://quassel-irc.org/files/images/quassel_win7.preview.png</image>
+			<caption>
+The default quassel white theme. Quassel runs on all major desktop platforms,
+and many smartphones as well.
+			</caption>
+		</screenshot>
+	</screenshots>
+
+</component>
+


### PR DESCRIPTION
The freedesktop.org AppData standard defines metadata for GUI applications that wish to show up in various graphical software centers, such as GNOME Software. See the specification for more details: https://people.freedesktop.org/~hughsient/appdata/

Applications without metadata will not show up in GNOME Software, and possibly other graphical package managers. As GNOME Software is the recommended way on Fedora Workstation to install software, this means that without these files users won't be able to find quassel or quasselclient.

This was a first pass at writing this metadata for inclusion in the downstream Fedora packages; let me know if something is not correct or should be modified!