### PR TITLE
Fix Crash if Topic has a CarriageReturn

### DIFF
--- a/src/qtui/topicwidget.cpp
+++ b/src/qtui/topicwidget.cpp
@@ -281,6 +281,9 @@ QString TopicWidget::sanitizeTopic(const QString& topic)
     // some unicode characters with a new line, which then triggers
     // a stack overflow later
     QString result(topic);
+#if QT_VERSION >= 0x050000
+    result.replace(QChar::CarriageReturn, " ");
+#endif
     result.replace(QChar::ParagraphSeparator, " ");
     result.replace(QChar::LineSeparator, " ");
 


### PR DESCRIPTION
Slack supports multiline Topics and sends them over the IRC Bridge too: [https://gyazo.com/ea5112f89ad919f7db96c252364248c3](url)

We already remove ParagraphSeparator and LineSeparator but not CarriageReturn which results in a crash…