### PR TITLE
Allow merging channel buffers

### DIFF
--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -668,6 +668,7 @@ ChannelBufferItem::ChannelBufferItem(const BufferInfo &bufferInfo, AbstractTreeI
     : BufferItem(bufferInfo, parent),
     _ircChannel(0)
 {
+    setFlags(flags() | Qt::ItemIsDropEnabled);
 }
 
 

--- a/src/core/corebuffersyncer.cpp
+++ b/src/core/corebuffersyncer.cpp
@@ -129,12 +129,12 @@ void CoreBufferSyncer::mergeBuffersPermanently(BufferId bufferId1, BufferId buff
     BufferInfo bufferInfo1 = Core::getBufferInfo(_coreSession->user(), bufferId1);
     BufferInfo bufferInfo2 = Core::getBufferInfo(_coreSession->user(), bufferId2);
     if (!bufferInfo1.isValid() || !bufferInfo2.isValid()) {
-        qWarning() << "CoreBufferSyncer::mergeBufferPermanently(): invalid BufferIds:" << bufferId1 << bufferId2 << "for User:" << _coreSession->user();
+        qWarning() << "CoreBufferSyncer::mergeBuffersPermanently(): invalid BufferIds:" << bufferId1 << bufferId2 << "for User:" << _coreSession->user();
         return;
     }
 
-    if (bufferInfo1.type() != BufferInfo::QueryBuffer || bufferInfo2.type() != BufferInfo::QueryBuffer) {
-        qWarning() << "CoreBufferSyncer::mergeBufferPermanently(): only QueryBuffers can be merged!" << bufferId1 << bufferId2;
+    if((bufferInfo1.type() != BufferInfo::QueryBuffer && bufferInfo1.type() != BufferInfo::ChannelBuffer) || (bufferInfo2.type() != BufferInfo::QueryBuffer && bufferInfo2.type() != BufferInfo::ChannelBuffer)) {
+        qWarning() << "CoreBufferSyncer::mergeBuffersPermanently(): only QueryBuffers and/or ChannelBuffers can be merged!" << bufferId1 << bufferId2;
         return;
     }
 

--- a/src/uisupport/bufferview.cpp
+++ b/src/uisupport/bufferview.cpp
@@ -229,27 +229,44 @@ void BufferView::dropEvent(QDropEvent *event)
     QPoint cursorPos = event->pos();
 
     // check if we're really _on_ the item and not indicating a move to just above or below the item
+    // Magic margin number for this is from QAbstractItemViewPrivate::position()
     const int margin = 2;
     if (cursorPos.y() - indexRect.top() < margin
         || indexRect.bottom() - cursorPos.y() < margin)
         return TreeViewTouch::dropEvent(event);
 
+    // If more than one buffer was being dragged, treat this as a rearrangement instead of a merge request
     QList<QPair<NetworkId, BufferId> > bufferList = Client::networkModel()->mimeDataToBufferList(event->mimeData());
     if (bufferList.count() != 1)
         return TreeViewTouch::dropEvent(event);
 
+    // Get the Buffer ID of the buffer that was being dragged
     BufferId bufferId2 = bufferList[0].second;
 
-    if (index.data(NetworkModel::ItemTypeRole) != NetworkModel::BufferItemType)
-        return TreeViewTouch::dropEvent(event);
-
-    if (index.data(NetworkModel::BufferTypeRole) != BufferInfo::QueryBuffer)
-        return TreeViewTouch::dropEvent(event);
-
+    // Get the Buffer ID of the target buffer
     BufferId bufferId1 = index.data(NetworkModel::BufferIdRole).value<BufferId>();
+
+    // If the source and target are the same buffer, this was an aborted rearrangement
     if (bufferId1 == bufferId2)
         return TreeViewTouch::dropEvent(event);
 
+    // Get index of buffer that was being dragged
+    QModelIndex index2 = Client::networkModel()->bufferIndex(bufferId2);
+
+    // If the buffer being dragged is a channel and we're still joined to it, treat this as a rearrangement
+    // This prevents us from being joined to a channel with no associated UI elements
+    if(index2.data(NetworkModel::BufferTypeRole) == BufferInfo::ChannelBuffer && index2.data(NetworkModel::ItemActiveRole) == true)
+        return TreeViewTouch::dropEvent(event);
+
+    //If the source buffer is not mergeable(AKA not a Channel and not a Query), try rearranging instead
+    if(index2.data(NetworkModel::BufferTypeRole) != BufferInfo::ChannelBuffer && index2.data(NetworkModel::BufferTypeRole) != BufferInfo::QueryBuffer)
+        return TreeViewTouch::dropEvent(event);
+
+    // If the target buffer is not mergeable(AKA not a Channel and not a Query), try rearranging instead
+    if(index.data(NetworkModel::BufferTypeRole) != BufferInfo::ChannelBuffer && index.data(NetworkModel::BufferTypeRole) != BufferInfo::QueryBuffer)
+        return TreeViewTouch::dropEvent(event);
+
+    // Confirm that the user really wants to merge the buffers before doing so
     int res = QMessageBox::question(0, tr("Merge buffers permanently?"),
         tr("Do you want to merge the buffer \"%1\" permanently into buffer \"%2\"?\n This cannot be reversed!").arg(Client::networkModel()->bufferName(bufferId2)).arg(Client::networkModel()->bufferName(bufferId1)),
         QMessageBox::Yes|QMessageBox::No, QMessageBox::No);

--- a/src/uisupport/bufferviewfilter.cpp
+++ b/src/uisupport/bufferviewfilter.cpp
@@ -175,22 +175,22 @@ Qt::ItemFlags BufferViewFilter::flags(const QModelIndex &index) const
     QModelIndex source_index = mapToSource(index);
     Qt::ItemFlags flags = sourceModel()->flags(source_index);
     if (config()) {
-        NetworkModel::ItemType itemType = (NetworkModel::ItemType)sourceModel()->data(source_index, NetworkModel::ItemTypeRole).toInt();
         BufferInfo::Type bufferType = (BufferInfo::Type)sourceModel()->data(source_index, NetworkModel::BufferTypeRole).toInt();
-        if (source_index == QModelIndex() || itemType == NetworkModel::NetworkItemType) {
-            flags |= Qt::ItemIsDropEnabled;
-        }
-        else if (_editMode) {
-            flags |= Qt::ItemIsUserCheckable | Qt::ItemIsTristate;
+
+        // We need Status Buffers to be a drop target, to allow for rearranging buffers.
+        // The Status Buffer "owns" the space between Channel/Query buffers in the tree.
+        // This DOES mean that it looks like you can merge a buffer into the Status buffer, but that is restricted in BufferView::dropEvent().
+        if(bufferType == BufferInfo::StatusBuffer) {
+            // But only if the layout isn't locked!
+            ClientBufferViewConfig *clientConf = qobject_cast<ClientBufferViewConfig *>(config());
+            if(clientConf && !clientConf->isLocked()) {
+                flags |= Qt::ItemIsDropEnabled;
+            }
         }
 
-        // prohibit dragging of most items. and most drop places
-        // only query to query is allowed for merging
-        if (bufferType != BufferInfo::QueryBuffer) {
-            ClientBufferViewConfig *clientConf = qobject_cast<ClientBufferViewConfig *>(config());
-            if (clientConf && clientConf->isLocked()) {
-                flags &= ~(Qt::ItemIsDropEnabled | Qt::ItemIsDragEnabled);
-            }
+        // If we're in Edit Mode, everything except Status Buffers should be hideable.
+        if(_editMode && bufferType != BufferInfo::StatusBuffer) {
+            flags |= Qt::ItemIsUserCheckable | Qt::ItemIsTristate;
         }
     }
     return flags;


### PR DESCRIPTION
Allow Channel buffers to be merged in addition to Query buffers, and clean up the associated functions to be clearer and have comments.

A Channel buffer is not allowed to be the "source" of a merge if that channel is currently joined, to prevent UI confusion from being present in a channel and not having a buffer associated with it.

# Known issues:
* When the layout is not locked and the buffer list is not sorted alphabetically, it appears like you will be able to merge a channel/query buffer into a status buffer. This is only a graphical error, however, and it still fails to merge silently and treats it as if you were rearranging the buffers. This is also not new, it is present in 0.12.4.
 * This is caused by the network's Status buffer "owning" the space between Channel/Query buffers in the tree. I'm not sure how to fix this.
* Even though you can't have a currently-joined channel as a merge source, it still appears like you can merge it. This is only a graphical error, and it fails silently and treats it as if you were rearranging the buffers.
 * I think this could be fixed by implementing BufferView::onDragEnter() to look at the source/destination buffers while still dragging. I did not do this as I figure for now, at least, it's consistently inconsistent. Once the Status buffer weirdness is fixed, this could be implemented for all types of buffers for dynamic droppable/not-droppable goodness.