### PR TITLE
Port ignore rules to QRegularExpression

### DIFF
--- a/src/client/clientignorelistmanager.cpp
+++ b/src/client/clientignorelistmanager.cpp
@@ -50,8 +50,8 @@ QMap<QString, bool> ClientIgnoreListManager::matchingRulesForHostmask(const QStr
     QMap<QString, bool> result;
     foreach(IgnoreListItem item, ignoreList()) {
         if (item.type == SenderIgnore && pureMatch(item, hostmask)
-            && ((network.isEmpty() && channel.isEmpty()) || item.scope == GlobalScope || (item.scope == NetworkScope && scopeMatch(item.scopeRule, network))
-                || (item.scope == ChannelScope && scopeMatch(item.scopeRule, channel)))) {
+            && ((network.isEmpty() && channel.isEmpty()) || item.scope == GlobalScope || (item.scope == NetworkScope && scopeMatch(item.scopeRegex, network))
+                || (item.scope == ChannelScope && scopeMatch(item.scopeRegex, channel)))) {
             result[item.ignoreRule] = item.isActive;
 //      qDebug() << "matchingRulesForHostmask found: " << item.ignoreRule << "is active: " << item.isActive;
         }

--- a/src/common/ignorelistmanager.h
+++ b/src/common/ignorelistmanager.h
@@ -101,7 +101,9 @@ public:
             if (!regEx.isValid()) {
                 qWarning() << "Ignore rule" << ignoreRule << "is invalid!";
             } else {
+#if QT_VERSION >= 0x050400
                 regEx.optimize();
+#endif
             }
 
             // Set up scope regex
@@ -112,7 +114,9 @@ public:
             if (!scopeRegex.isValid()) {
                 qWarning() << "Scope rule" << scopeRule_ << "is invalid!";
             } else {
+#if QT_VERSION >= 0x050400
                 scopeRegex.optimize();
+#endif
             }
         }
         bool operator!=(const IgnoreListItem &other)


### PR DESCRIPTION
Also moves more of the creation of regex objects to initialization to improve performance a bit.
