### PR TITLE
Fix Touch-Pads handled as Touch-Screen

### DIFF
--- a/src/qtui/chatview.cpp
+++ b/src/qtui/chatview.cpp
@@ -109,7 +109,11 @@ bool ChatView::event(QEvent *event)
         }
     }
 
-    if (event->type() == QEvent::TouchBegin) {
+#if QT_VERSION >= 0x050000
+    if (event->type() == QEvent::TouchBegin && ((QTouchEvent*)event)->device()->type()==QTouchDevice::TouchScreen) {
+#else
+    if (event->type() == QEvent::TouchBegin && ((QTouchEvent*)event)->deviceType()==QTouchEvent::TouchScreen) {
+#endif
         // Enable scrolling by draging, disable selecting/clicking content
         setDragMode(QGraphicsView::ScrollHandDrag);
         setInteractive(false);
@@ -145,8 +149,12 @@ bool ChatView::event(QEvent *event)
         }
         // Applying the movement happens automatically by the drag-mode
     }
-
-    if (event->type() == QEvent::Wheel || event->type() == QEvent::TouchBegin || event->type() == QEvent::TouchUpdate) {
+#if QT_VERSION >= 0x050000
+    if (event->type() == QEvent::Wheel || (event->type() == QEvent::TouchBegin && ((QTouchEvent*)event)->device()->type()==QTouchDevice::TouchScreen) || event->type() == QEvent::TouchUpdate) {
+#else
+    if (event->type() == QEvent::Wheel || (event->type() == QEvent::TouchBegin && ((QTouchEvent*)event)->deviceType()==QTouchEvent::TouchScreen) || event->type() == QEvent::TouchUpdate) {
+#endif
+    
         if (!verticalScrollBar()->isVisible()) {
             scene()->requestBacklog();
             return true;

--- a/src/uisupport/treeviewtouch.cpp
+++ b/src/uisupport/treeviewtouch.cpp
@@ -33,7 +33,11 @@ TreeViewTouch::TreeViewTouch(QWidget *parent)
 
 
 bool TreeViewTouch::event(QEvent *event) {
-    if (event->type() == QEvent::TouchBegin) {
+#if QT_VERSION >= 0x050000
+    if (event->type() == QEvent::TouchBegin && ((QTouchEvent*)event)->device()->type()==QTouchDevice::TouchScreen) {
+#else
+    if (event->type() == QEvent::TouchBegin && ((QTouchEvent*)event)->deviceType()==QTouchEvent::TouchScreen) {
+#endif
         // Register that we may be scrolling, set the scroll mode to scroll-per-pixel
         // and accept the event (return true) so that we will receive TouchUpdate and TouchEnd/TouchCancel
         _touchScrollInProgress = true;


### PR DESCRIPTION
Basic Touch Support (PR #187) broke (Multi) Touch Pad usage ... (e.g. on MacBooks)

This fixes it by checking the Touch-Device Type on TouchBegin Events.

(No check required on TouchUpdate and TouchEnd, because if TouchBegin is not accepted (return true) no following TouchUpdate/End Events get received)