### PR TITLE
Enable Mac OSX builds on Travis inclusive dmg deployment on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,25 @@
+os:
+  - osx
+  - linux
+
 sudo: required
 dist: trusty
 
-install:
-  - sudo apt-get -qy install libqt5webkit5-dev qttools5-dev qtscript5-dev 
-  - sudo apt-get -qy install libdbusmenu-qt-dev libdbusmenu-qt5-dev
-  - sudo apt-get -qy install libphonon-dev libphonon4qt5-dev
-  - sudo apt-get -qy install libqca2-dev
-  - sudo apt-get -qy install qt4-dev-tools qttools5-dev-tools
-  - sudo apt-get -qy install libphonon4qt5experimental4 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=805096
+install: |- 
+  if [ "$TRAVIS_OS_NAME" == "osx" ]
+  then
+    brew update
+    brew install ninja qt5
+  fi
+  if [ "$TRAVIS_OS_NAME" == "linux" ]
+  then
+    sudo apt-get -qy install libqt5webkit5-dev qttools5-dev qtscript5-dev 
+    sudo apt-get -qy install libdbusmenu-qt-dev libdbusmenu-qt5-dev
+    sudo apt-get -qy install libphonon-dev libphonon4qt5-dev
+    sudo apt-get -qy install libqca2-dev
+    sudo apt-get -qy install qt4-dev-tools qttools5-dev-tools
+    sudo apt-get -qy install libphonon4qt5experimental4 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=805096
+  fi
 
 language: cpp
 cache: ccache
@@ -20,14 +32,26 @@ env:
   - QT_VERSION=qt4
   - QT_VERSION=qt5
 
-script:
-  - mkdir build
-  - cd build
-  - if [ "$QT_VERSION" = "qt4" ]; then cmake ..; fi
-  - if [ "$QT_VERSION" = "qt5" ]; then cmake -DUSE_QT5=ON ..; fi
-  - make
+script: |-
+  mkdir build
+  cd build
+  if [ "$TRAVIS_OS_NAME" == "osx" ]
+  then
+    cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DUSE_QT5=ON -DWANT_CORE=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
+    ninja install
+  fi
+  if [ "$TRAVIS_OS_NAME" == "linux" ]
+  then
+    if [ "$QT_VERSION" = "qt4" ]; then cmake ..; fi
+    if [ "$QT_VERSION" = "qt5" ]; then cmake -DUSE_QT5=ON ..; fi
+    make
+  fi
 
 matrix:
   exclude:
     - compiler: clang
+      env: QT_VERSION=qt4
+    - os: osx
+      compiler: clang
+    - os: osx
       env: QT_VERSION=qt4

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,13 @@ script: |-
   cd build
   if [ "$TRAVIS_OS_NAME" == "osx" ]
   then
-    cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DUSE_QT5=ON -DWANT_CORE=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
+    if [[ "$TRAVIS_TAG" != "" && "$GH_TOKEN" != "" ]]
+    then
+      PATH=$PATH:/usr/local/opt/qt5/bin
+      cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DUSE_QT5=ON -DWANT_CORE=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DDEPLOY=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
+    else
+      cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DUSE_QT5=ON -DWANT_CORE=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
+    fi
     ninja install
   fi
   if [ "$TRAVIS_OS_NAME" == "linux" ]
@@ -68,10 +74,14 @@ matrix:
 deploy:
   provider: releases
   api_key: "${GH_TOKEN}"
+  file_glob: true
   file:
     - "Quassel.zip"
     - "QuasselClient.zip"
     - "quasselcore"
+    - "QuasselClient_MacOSX-x86_64_*.dmg"
+    - "QuasselCore_MacOSX-x86_64_*.dmg"
+    - "QuasselMono_MacOSX-x86_64_*.dmg"
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,15 @@ script: |-
     make
   fi
 
+before_deploy: |-
+  if [ "$TRAVIS_OS_NAME" == "osx" ]
+  then
+    mkdir releases
+    zip -r Quassel.zip Quassel.app
+    zip -r QuasselClient.zip Quassel\ Client.app
+    zip -r quasselcore.zip quasselcore
+  fi
+
 matrix:
   exclude:
     - compiler: clang
@@ -55,3 +64,15 @@ matrix:
       compiler: clang
     - os: osx
       env: QT_VERSION=qt4
+
+deploy:
+  provider: releases
+  api_key: "${GH_TOKEN}"
+  file:
+    - "Quassel.zip"
+    - "QuasselClient.zip"
+    - "quasselcore"
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: "$TRAVIS_OS_NAME == 'osx' && $GH_TOKEN != ''"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,21 +45,11 @@ script: |-
       cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DUSE_QT5=ON -DWANT_CORE=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
     fi
     ninja install
-  fi
-  if [ "$TRAVIS_OS_NAME" == "linux" ]
+  elif [ "$TRAVIS_OS_NAME" == "linux" ]
   then
     if [ "$QT_VERSION" = "qt4" ]; then cmake ..; fi
     if [ "$QT_VERSION" = "qt5" ]; then cmake -DUSE_QT5=ON ..; fi
     make
-  fi
-
-before_deploy: |-
-  if [ "$TRAVIS_OS_NAME" == "osx" ]
-  then
-    mkdir releases
-    zip -r Quassel.zip Quassel.app
-    zip -r QuasselClient.zip Quassel\ Client.app
-    zip -r quasselcore.zip quasselcore
   fi
 
 matrix:
@@ -76,9 +66,6 @@ deploy:
   api_key: "${GH_TOKEN}"
   file_glob: true
   file:
-    - "Quassel.zip"
-    - "QuasselClient.zip"
-    - "quasselcore"
     - "QuasselClient_MacOSX-x86_64_*.dmg"
     - "QuasselCore_MacOSX-x86_64_*.dmg"
     - "QuasselMono_MacOSX-x86_64_*.dmg"

--- a/cmake/QuasselCompileSettings.cmake
+++ b/cmake/QuasselCompileSettings.cmake
@@ -80,6 +80,6 @@ endif()
 # Mac build stuff
 if (APPLE AND DEPLOY)
     set(CMAKE_OSX_ARCHITECTURES "x86_64")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.8")
-    set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.9")
+    set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk")
 endif()

--- a/scripts/build/macosx_makePackage.sh
+++ b/scripts/build/macosx_makePackage.sh
@@ -41,7 +41,7 @@ if [ ! -f "$mypath" ]; then
 fi
 
 SCRIPTDIR=$(dirname $mypath)
-QUASSEL_VERSION=$(git-describe)
+QUASSEL_VERSION=$(git describe)
 BUILDTYPE=$1
 
 # check the working dir

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,7 +90,7 @@ if(APPLE)
                        COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makePackage.sh Client ..)
     add_custom_command(TARGET quasselcore POST_BUILD
                        COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makePackage.sh Core ..)
-    add_custom_command(TARGET quasselcore POST_BUILD
+    add_custom_command(TARGET quassel POST_BUILD
                        COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makePackage.sh Mono ..)
   endif(DEPLOY)
 endif(APPLE)


### PR DESCRIPTION
Enables building Mac OSX builds on Travis...
When building a git tag and if a GitHub access token is set in the Travis account .dmg files will be generated and uploaded to GitHub releases.
(~~Travis~~ GitHub supports that only for tags ... some workaround hacks exist. Alternatively upload to e.g. Amazon S3 would be possible for each commit)

In a similar way it would be possible to upload .deb files to GitHub ...

**Noteworthy**
In order to be able to generate dmg files with git and Xcode version on my macbook and on Travis i needed to modify the Mac Deploy scripts


**Please Test**
Can someone who hasn't Qt5.6 installed on his Mac please test these generated dmg files if they work?
[romibi/quassel tagdeploytest12](https://github.com/romibi/quassel/releases/tag/tagdeploytest12) (mono package empty)
or [romibi custom build 2016-07-04](https://github.com/romibi/quassel/releases/tag/rmb-0.12.4.plus.16.07.04)


**Here is how to give Travis permission to upload to GitHub:**
- go to GitHub Account Settings -> Personal access tokens -> generate new token 
- (Enter Description & ) check "public_repo" -> Generate Token
- copy token (and save it somewhere safe)
- go to Travis Project Settings -> Add an Envoirement Variable:
  - Name: GH_TOKEN
  - Value: token from above
  - Display value in build log: off