### PR TITLE
Travis OSX Builds dmg deployment on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,25 @@ script: |-
     make
   elif [ "$TRAVIS_OS_NAME" == "osx" ]
   then
-    cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DUSE_QT5=ON -DWANT_CORE=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
+    if [[ "$TRAVIS_TAG" != "" && "$GH_TOKEN" != "" ]]
+    then
+      PATH=$PATH:/usr/local/opt/qt5/bin
+      cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DUSE_QT5=ON -DWANT_CORE=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DDEPLOY=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
+    else
+      cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DUSE_QT5=ON -DWANT_CORE=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
+    fi
     ninja install
   fi
+
+deploy:
+  provider: releases
+  api_key: "${GH_TOKEN}"
+  file_glob: true
+  file:
+    - "QuasselClient_MacOSX-x86_64_*.dmg"
+    - "QuasselCore_MacOSX-x86_64_*.dmg"
+    - "QuasselMono_MacOSX-x86_64_*.dmg"
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: "$TRAVIS_OS_NAME == 'osx' && $GH_TOKEN != ''"


### PR DESCRIPTION
(Split away from PR #227 which was already partially merged)

When building a git tag and if a GitHub access token is set in the Travis account .dmg files will be generated and uploaded to GitHub releases.
(~~Travis~~ GitHub supports that only for tags ... some workaround hacks exist. Alternatively upload to e.g. Amazon S3 would be possible for each commit)

In a similar way it would be possible to upload .deb files to GitHub ...

**NOTICE: For the Deploy-Script to be working PR #229 needs to be merged too**

**Here is how to give Travis permission to upload to GitHub:**
- go to GitHub Account Settings -> Personal access tokens -> generate new token 
- (Enter Description & ) check "public_repo" -> Generate Token
- copy token (and save it somewhere safe)
- go to Travis Project Settings -> Add an Envoirement Variable:
  - Name: GH_TOKEN
  - Value: token from above
  - Display value in build log: off