### PR TITLE
Fix Mac Deploy scripts for newer Xcode and git

### DIFF
--- a/cmake/QuasselCompileSettings.cmake
+++ b/cmake/QuasselCompileSettings.cmake
@@ -80,6 +80,6 @@ endif()
 # Mac build stuff
 if (APPLE AND DEPLOY)
     set(CMAKE_OSX_ARCHITECTURES "x86_64")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.8")
-    set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.9")
+    set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk")
 endif()

--- a/scripts/build/macosx_DeployApp.py
+++ b/scripts/build/macosx_DeployApp.py
@@ -189,6 +189,7 @@ class InstallQt(object):
             else:
                 newlibname = "@executable_path/%s%s" % (frameworkname, libpath)
             # print 'install_name_tool -id "%s" "%s"' % (newlibname, lib)
+            os.system('chmod +w "%s"' % (lib))
             os.system('install_name_tool -id "%s" "%s"' % (newlibname, lib))
 
             self.resolveDependancies(lib)
@@ -210,6 +211,8 @@ class InstallQt(object):
             newlibname = "@executable_path/Frameworks/%s" % newlibname
 
         # print 'install_name_tool -change "%s" "%s" "%s"' % (lib, newlibname, obj)
+        os.system('chmod +w "%s"' % (lib))
+        os.system('chmod +w "%s"' % (obj))
         os.system('install_name_tool -change "%s" "%s" "%s"' % (lib, newlibname, obj))
 
 if __name__ == "__main__":

--- a/scripts/build/macosx_makePackage.sh
+++ b/scripts/build/macosx_makePackage.sh
@@ -41,7 +41,7 @@ if [ ! -f "$mypath" ]; then
 fi
 
 SCRIPTDIR=$(dirname $mypath)
-QUASSEL_VERSION=$(git-describe)
+QUASSEL_VERSION=$(git describe)
 BUILDTYPE=$1
 
 # check the working dir

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,7 +90,7 @@ if(APPLE)
                        COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makePackage.sh Client ..)
     add_custom_command(TARGET quasselcore POST_BUILD
                        COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makePackage.sh Core ..)
-    add_custom_command(TARGET quasselcore POST_BUILD
+    add_custom_command(TARGET quassel POST_BUILD
                        COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makePackage.sh Mono ..)
   endif(DEPLOY)
 endif(APPLE)


### PR DESCRIPTION
(Split away from PRs #227 / #228 )

In order to be able to generate dmg files with git and Xcode version on my MacBook (and on Travis) I needed to modify the Mac Deploy scripts:

- Current Xcode does not contain 10.8 SDK's anymore
- use "git describe" instead of "git-describe" for dmg-name
- make sure files to be modified by install_name_tool allow write  
(some files get copied with read-only attribute)
- make sure Quassel (Mono) gets packaged after quassel (mono) build (not quasselcore)  
(did you ship old artifacts earlier?)

~~**There is still something wrong with the Deploy Script:**~~ (It was not the Deploy-Script's fault)
~~If Built with the Deploy-Script, generated Clients set for some reason MainWindowHidden to true on close (except if closed with the red x) …~~  
~~This results to a Hidden Quassel Client on the next start and you need to Right-click→Restore on the Tray-Icon.~~

~~This does not happen if built without Deploy Script which generates .app which rely on Qt Libraries installed on the system...~~

~~Tested with Qt 5.6.1-1 (locally and on travis) … I will test other qt versions later …~~

~~Changes in the Deploy-Script in PR #210 don't fix this …~~ (Fixed in PR #230)