### PR TITLE
EnableQt's high-DPI scaling introduced in Qt5.6

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -177,13 +177,19 @@ int main(int argc, char **argv)
     }
 #endif
 
-#  if defined BUILD_CORE
+#if defined BUILD_CORE
     CoreApplication app(argc, argv);
-#  elif defined BUILD_QTUI
+#elif defined BUILD_QTUI
+# if QT_VERSION >= 0x050600
+    QtUiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+# endif
     QtUiApplication app(argc, argv);
-#  elif defined BUILD_MONO
+#elif defined BUILD_MONO
+# if QT_VERSION >= 0x050600
+    MonolithicApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+# endif
     MonolithicApplication app(argc, argv);
-#  endif
+#endif
 
 #ifndef HAVE_KDE4
     // the non-KDE version parses after app has been instantiated


### PR DESCRIPTION
Just a simple QGuiApplication Attribute …
[http://doc.qt.io/qt-5.6/qtlabscontrols-highdpi.html](http://doc.qt.io/qt-5.6/qtlabscontrols-highdpi.html)

Fixes "too small font in Chat/Nick-List" on high-dpi screens.
Fixes "too big Buttons" and "too big font Chat-View" on non-high-dpi screen if high-dpi-screen is connected.

[![https://gyazo.com/ced7bf452e18eb09f8841230401c4819](https://i.gyazo.com/ced7bf452e18eb09f8841230401c4819.png)](https://gyazo.com/ced7bf452e18eb09f8841230401c4819)

[![https://gyazo.com/92cbfa41e7d705493345bc67e60fcf4c](https://i.gyazo.com/92cbfa41e7d705493345bc67e60fcf4c.png)](https://gyazo.com/92cbfa41e7d705493345bc67e60fcf4c)

(The Window-Title-Bar on the non-high-dpi screen is still a bit to big … if someone knows how to fix this …)