### PR TITLE
Snapcraft packaging for quasselcore

### DIFF
--- a/snap.wrapper
+++ b/snap.wrapper
@@ -1,0 +1,21 @@
+#!/bin/sh
+if [ "$SNAP_ARCH" = "amd64" ]; then
+    ARCH="x86_64-linux-gnu"
+elif [ "$SNAP_ARCH" = "armhf" ]; then
+    ARCH="arm-linux-gnueabihf"
+else
+    ARCH="$SNAP_ARCH-linux-gnu"
+fi
+export PATH="$SNAP/bin:$SNAP/usr/bin:$PATH"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH:$SNAP/usr/lib/$ARCH"
+export LD_LIBRARY_PATH="$SNAP/usr/lib/$ARCH:$LD_LIBRARY_PATH"
+
+LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+
+export QT_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/qt5/plugins
+
+export XDG_CONFIG_HOME=$HOME/.config
+CERT=$XDG_CONFIG_HOME/quassel-irc.org/quasselCert.pem
+test ! -f $CERT && openssl req -x509 -nodes -days 365 -newkey rsa:4096 -keyout $CERT -out $CERT -batch
+
+exec $@

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,34 @@
+name: quasselcore
+version: "0.12.4"
+summary: Modern, cross-platform IRC client (core)
+description: |
+ This is a modern, cross-platform, distributed IRC client. One
+ (or multiple) client(s) can attach to and detach from a central core. It's
+ much like the popular combination of screen and a text-based IRC client such
+ as WeeChat, but graphical.
+confinement: strict
+
+apps:
+    quasselcore:
+        command: wrap quasselcore
+        plugs: [network-bind]
+        daemon: simple
+
+parts:
+    quasselcore:
+        source: .
+        plugin: cmake
+        configflags: [-DUSE_QT5=1, -DWANT_MONO=0, -DWANT_QTCLIENT=0, -DCMAKE_BUILD_TYPE=Release]
+        build-packages:
+            - cmake
+            - g++
+            - zlib1g-dev
+            - qttools5-dev
+            - qtscript5-dev
+            - libqt5sql5-sqlite
+        stage-packages:
+            - libqt5sql5-sqlite
+    environment:
+        plugin: copy
+        files:
+            snap.wrapper: bin/wrap


### PR DESCRIPTION
These files enable "snapcraft cleanbuild" to create a snap for quasselcore (no client).