### PR TITLE
Fix disconnected networks not collapsing on login with Qt5

### DIFF
--- a/src/uisupport/bufferview.cpp
+++ b/src/uisupport/bufferview.cpp
@@ -68,7 +68,7 @@ void BufferView::init()
     hideColumn(2);
     setIndentation(10);
 
-    expandAll();
+    // New entries will be expanded automatically when added; no need to call expandAll()
 
     header()->hide(); // nobody seems to use this anyway
 


### PR DESCRIPTION
## In short
* Fix disconnected networks not collapsing when logging in to core
 * Remove call to ```expandAll()``` when initializing ```BufferView```
 * Regression from Qt4 to Qt5, once again collapsing disconnected networks by default

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing interface polish, fixes Qt4 → Qt5 regression
Risk | ★☆☆ *1/3* | Might possibly not auto-expand networks when connected
Intrusiveness | ★☆☆ *1/3* | Single line changed, shouldn't interfere with other pull requests

## Testing
* Ubuntu 16.04 LTS
 * Qt4 build works as before
 * Qt5 build now works properly
* Windows 7
 * Qt5 build now works properly

## Example
### Before: disconnected networks expanded on login
![Network list showing expanded disconnected networks](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/fix-qt5-collapse-disconnected/Network%20list%20-%20expanded.png#v1 )

### After: disconnected networks collapsed on login
![Network list showing collapsed disconnected networks](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/fix-qt5-collapse-disconnected/Network%20list%20-%20collapsed.png#v1 )