### PR TITLE
Show IRC server error messages when not expected

### DIFF
--- a/src/common/eventmanager.h
+++ b/src/common/eventmanager.h
@@ -104,6 +104,7 @@ public :
         IrcEventPrivmsg,
         IrcEventQuit,
         IrcEventTopic,
+        IrcEventError,        /// ERROR message from server
         IrcEventWallops,
         IrcEventRawPrivmsg, ///< Undecoded privmsg (still needs CTCP parsing)
         IrcEventRawNotice, ///< Undecoded notice (still needs CTCP parsing)

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -101,6 +101,15 @@ public:
     inline quint16 localPort() const { return socket.localPort(); }
     inline quint16 peerPort() const { return socket.peerPort(); }
 
+    /**
+     * Gets whether or not a disconnect was expected.
+     *
+     * Distinguishes desired quits from unexpected disconnections such as socket errors or timeouts.
+     *
+     * @return True if disconnect was requested, otherwise false.
+     */
+    inline bool disconnectExpected() const { return _disconnectExpected; }
+
     QList<QList<QByteArray>> splitMessage(const QString &cmd, const QString &message, std::function<QList<QByteArray>(QString &)> cmdGenerator);
 
     // IRCv3 capability negotiation

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -591,6 +591,21 @@ void CoreSessionEventProcessor::processIrcEventTopic(IrcEvent *e)
     }
 }
 
+/* ERROR - "ERROR :reason"
+Example:  ERROR :Closing Link: nickname[xxx.xxx.xxx.xxx] (Large base64 image paste.)
+See https://tools.ietf.org/html/rfc2812#section-3.7.4 */
+void CoreSessionEventProcessor::processIrcEventError(IrcEvent *e)
+{
+    if (!checkParamCount(e, 1))
+        return;
+
+    if (coreNetwork(e)->disconnectExpected()) {
+        // During QUIT, the server should send an error (often, but not always, "Closing Link"). As
+        // we're expecting it, don't show this to the user.
+        e->setFlag(EventManager::Silent);
+    }
+}
+
 
 #ifdef HAVE_QCA2
 void CoreSessionEventProcessor::processKeyEvent(KeyEvent *e)

--- a/src/core/coresessioneventprocessor.h
+++ b/src/core/coresessioneventprocessor.h
@@ -62,6 +62,7 @@ public:
     Q_INVOKABLE void processIrcEventQuit(IrcEvent *event);
     Q_INVOKABLE void lateProcessIrcEventQuit(IrcEvent *event);
     Q_INVOKABLE void processIrcEventTopic(IrcEvent *event);
+    Q_INVOKABLE void processIrcEventError(IrcEvent *event);       /// ERROR message from server
 #ifdef HAVE_QCA2
     Q_INVOKABLE void processKeyEvent(KeyEvent *event);
 #endif

--- a/src/core/eventstringifier.cpp
+++ b/src/core/eventstringifier.cpp
@@ -356,6 +356,15 @@ void EventStringifier::processIrcEventTopic(IrcEvent *e)
         .arg(e->nick(), e->params().at(0), e->params().at(1)), QString(), e->params().at(0));
 }
 
+void EventStringifier::processIrcEventError(IrcEvent *e)
+{
+    // Need an error reason
+    if (!checkParamCount(e, 1))
+        return;
+
+    displayMsg(e, Message::Server, tr("Error from server: ") + e->params().join(""));
+}
+
 void EventStringifier::processIrcEventWallops(IrcEvent *e)
 {
     displayMsg(e, Message::Server, tr("[Operwall] %1: %2").arg(e->nick(), e->params().join(" ")));

--- a/src/core/eventstringifier.h
+++ b/src/core/eventstringifier.h
@@ -64,6 +64,7 @@ public:
     Q_INVOKABLE void processIrcEventPong(IrcEvent *event);
     Q_INVOKABLE void processIrcEventQuit(IrcEvent *event);
     Q_INVOKABLE void processIrcEventTopic(IrcEvent *event);
+    Q_INVOKABLE void processIrcEventError(IrcEvent *event);    /// ERROR message from server
     Q_INVOKABLE void processIrcEventWallops(IrcEvent *event);
 
     Q_INVOKABLE void processIrcEvent005(IrcEvent *event);    // RPL_ISUPPORT


### PR DESCRIPTION
## In short
* Handle client-facing [```ERROR``` replies from IRC servers](https://tools.ietf.org/html/rfc2812#section-3.7.4 )
 * Display error messages in status buffer
 * Add ```disconnectExpected()``` to ```CoreNetwork``` to hide expected error message when issuing ```QUIT```
 * Fixes users getting disconnected by the server without any way to find out why

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing, explains server disconnects (*kill, maintenance, etc*)
Risk | ★☆☆ *1/3* | Error messages may be logged when not needed
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

*As [pull request #207](https://github.com/quassel/quassel/pull/207 ) is merged, this has been updated to use ```_disconnectExpected``` instead of ```_quitRequested```.*

## Rationale
Quassel should display server ```ERROR``` responses to avoid confusing users (*why was I disconnected?*) and to ease the burden on IRC network operators with explaining unexpected downtime and other issues.

## Example
### Before: connection killed, no explanation
```
[6:29:53 pm] [bough.example.com] *** You are connected to bough.example.com with [...]
[6:29:53 pm] * Received CTCP-VERSION request by StatServ!stats@irc.example.com
[Disconnect by server]
[6:30:13 pm] * Connection failure: The TLS/SSL connection has been closed
[6:30:13 pm] * Connection failure: The remote host closed the connection
[6:30:13 pm] * Connection failed. Cycling to next Server
[6:30:13 pm] * Connecting to irc.example.com:6697...
[6:30:13 pm] * Requesting capability list...
[...]
```

### After: connection killed, reason shown
```
[6:46:49 pm] * Received CTCP-VERSION request by StatServ!stats@irc.example.com
[6:46:49 pm] [bough.example.com] *** You are connected to bough.example.com with [...]
[Disconnect by server]
[6:47:02 pm] * Error from server: Closing Link: digitalcircuit[xxx.xxx.xxx.xxx] (Large base64 image paste. Check your paste buffer and reconnect.)
[6:47:02 pm] * Connection failure: The TLS/SSL connection has been closed
[6:47:02 pm] * Connection failure: The remote host closed the connection
[6:47:02 pm] * Connection failed. Cycling to next Server
[6:47:02 pm] * Connecting to irc.example.com:6697...
[6:47:03 pm] * Requesting capability list...
[...]
```

### Regular ```/quit```
*Handled same as before*
```
[6:49:03 pm] * Received CTCP-VERSION request by StatServ!stats@irc.example.com
[6:49:03 pm] [bough.example.com] *** You are connected to bough.example.com with [...]
[QUIT issued by client]
[6:49:47 pm] * Disconnecting. (My custom quit reason)
```