### PR TITLE
Fix some instances of nicks shown as offline when actually online

### DIFF
--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -656,8 +656,22 @@ void QueryBufferItem::setIrcUser(IrcUser *ircUser)
 
 void QueryBufferItem::removeIrcUser()
 {
-    _ircUser = 0;
-    emit dataChanged();
+    if (_ircUser) {
+        // Disconnect the active IrcUser before removing it, otherwise it will fire removeIrcUser()
+        // a second time when the object's destroyed due to QueryBufferItem::setIrcUser() connecting
+        // SIGNAL destroyed(QObject*) to SLOT removeIrcUser().
+        // This fixes removing an active IrcUser if the user had quit then rejoined in a nonstandard
+        // manner (e.g. updateNickFromHost calling newIrcUser, triggered by an away-notify message).
+        disconnect(_ircUser, 0, this, 0);
+
+        // Clear IrcUser (only set to 0 if not already 0)
+        _ircUser = 0;
+
+        // Only emit dataChanged() if data actually changed.  This might serve as a small
+        // optimization, but it can be moved outside the if statement if other behavior depends on
+        // it always being called.
+        emit dataChanged();
+    }
 }
 
 


### PR DESCRIPTION
## In short
* Disconnect signals from the old ```_ircUser``` before deleting it in ```QueryBufferItem```
 * Prevents ```_ircUser``` from triggering ```removeIrcUser()``` again when it's destroyed out of scope
 * Fixes some cases of client showing nicks as offline when actually online
* Limit ```emit dataChanged()``` to when ```_ircUser``` is removed in ```removeIrcUser()```

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing fix for nick tracking for certain edge cases
Risk | ★☆☆ *1/3* | Could result in wrong nick being tracked in client query list
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other pull requests

## Example
Starting with Quassel connected to Bitlbee, an XMPP account active, and a query open with someone in your friend list, when they go offline, their nick quits as expected.  With this pull request, Quassel now shows the nickname as online but away when Bitlbee sends the follow-up ```away-notify``` message indicating the user's able to receive offline messages.

Specifically, receiving the following messages (*no delay between ```AWAY```s*):
```
:nick!name@gmail.com JOIN :&bitlbee
:nick!name@gmail.com AWAY :Away (Testing)
:nick!name@gmail.com QUIT :Leaving...
:nick!name@gmail.com AWAY :User is offline
```

Before, ```nick``` was wrongly shown as not available.  After, ```nick``` is shown as away with the message ```User is offline```.  (*Bitlbee does this as GTalk/XMPP allow for messaging offline users*)

This may also improve handling of nicks during netsplits or rapid quit and re-join.