### PR TITLE
Prevent the spelling highlighter from disabling itself

### DIFF
--- a/src/qtui/inputwidget.cpp
+++ b/src/qtui/inputwidget.cpp
@@ -504,12 +504,6 @@ void InputWidget::onTextEntered(const QString &text)
     fmt.clearForeground();
     fmt.clearBackground();
     inputLine()->setCurrentCharFormat(fmt);
-
-#ifdef HAVE_KDE
-    // Set highlighter back to active in case it was deactivated by too many errors.
-    if (ui.inputEdit->highlighter())
-        ui.inputEdit->highlighter()->setActive(true);
-#endif
 }
 
 

--- a/src/uisupport/multilineedit.cpp
+++ b/src/uisupport/multilineedit.cpp
@@ -90,6 +90,14 @@ MultiLineEdit::~MultiLineEdit()
 {
 }
 
+#if defined HAVE_KF5 || defined HAVE_KDE4
+void MultiLineEdit::createHighlighter()
+{
+    KTextEdit::createHighlighter();
+    if (highlighter())
+        highlighter()->setAutomatic(false);
+}
+#endif
 
 void MultiLineEdit::setCustomFont(const QFont &font)
 {

--- a/src/uisupport/multilineedit.h
+++ b/src/uisupport/multilineedit.h
@@ -74,6 +74,9 @@ public:
     inline bool emacsMode() const { return _emacsMode; }
 
     void addCompletionSpace();
+#if defined HAVE_KF5 || defined HAVE_KDE4
+    virtual void createHighlighter() override;
+#endif
 
 public slots:
     void setMode(Mode mode);


### PR DESCRIPTION
* Prevent the spelling highlighter from disabling itself, if there are too many spelling mistakes (KDE).
[Sonnet::Highlighter::setAutomatic(bool)](https://api.kde.org/frameworks/sonnet/html/classSonnet_1_1Highlighter.html#abfa334a6fafbefb78dab715b2ed3da94)
* Also enables spell checking by default if it is not configured.

----

Is the `#ifdef HAVE_KDE` in `qtui/inputwidget.cpp` really necessary?
If we have KDE, Sonnet normally loads the default values. 
Furthermore in my case `s.value("EnableSpellCheck", false)` always returns `false` (But [sonnet] spell checking is set to enabled by default).

----
This PR Should work for KF5 and KDE4, the API is the same, but I could only test it on KF5.