### PR TITLE
Only load the `EnableSpellCheck` setting for KDE4 users.

### DIFF
--- a/src/qtui/inputwidget.cpp
+++ b/src/qtui/inputwidget.cpp
@@ -101,7 +101,7 @@ InputWidget::InputWidget(QWidget *parent)
 
     UiSettings s("InputWidget");
 
-#ifdef HAVE_KDE
+#ifdef HAVE_KDE4
     s.notify("EnableSpellCheck", this, SLOT(setEnableSpellCheck(QVariant)));
     setEnableSpellCheck(s.value("EnableSpellCheck", false));
 #endif


### PR DESCRIPTION
Others either have no spellchecking at all or use KF5 Sonnet with it's own settings / settingspage.

In [`inputwidgetsettingspage.cpp`](https://github.com/quassel/quassel/blob/master/src/qtui/settingspages/inputwidgetsettingspage.cpp#L28) we explicitly hide the `EnableSpellCheck` setting from everyone but KDE4 users. This is correct as others either have no spell checking at all or use KF5 Sonnet with it's own settings page.
Therefore we also should only load this setting for KDE4 users.