### PR TITLE
Use case-insensitive filtering for buffer search

### DIFF
--- a/src/uisupport/bufferviewfilter.cpp
+++ b/src/uisupport/bufferviewfilter.cpp
@@ -357,7 +357,7 @@ bool BufferViewFilter::filterAcceptBuffer(const QModelIndex &source_bufferIndex)
     if (!_filterString.isEmpty()) {
         const BufferInfo info = qvariant_cast<BufferInfo>(Client::bufferModel()->data(source_bufferIndex, NetworkModel::BufferInfoRole));
         QString name = info.bufferName();
-        if (name.contains(_filterString)) {
+        if (name.contains(_filterString, Qt::CaseInsensitive)) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
## In short
* When filtering buffers via the quick search bar (*```Ctrl-S```*), use case-insensitive matching
 * Allows typing lowercase to find proper names
 * Mimics the default behavior of the ```Ctrl-F``` find bar

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | User-facing, consistent with find text bar of Quassel and other apps
Risk | ★☆☆ *1/3* | Finding specifically-capitalized buffers may be less-easy
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Example
### Before - case-sensitive search
![PM list showing a search for 'all' with no match](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/ft-buffer-search-nocase/Before%20-%20case-sensitive%20search.png#v1 )
### After - case-insensitive search
![PM list showing a search for 'all' with one match for 'AllanJude'](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/ft-buffer-search-nocase/After%20-%20case-insensitive%20search.png#v2 )