### PR TITLE
Build with Qt5 by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,17 +45,17 @@ script: |-
   cd build
   if [ "$TRAVIS_OS_NAME" == "linux" ]
   then
-    if [ "$QT_VERSION" = "qt4" ]; then cmake ..; fi
-    if [ "$QT_VERSION" = "qt5" ]; then cmake -DUSE_QT5=ON ..; fi
+    if [ "$QT_VERSION" = "qt4" ]; then cmake -DUSE_QT4=ON ..; fi
+    if [ "$QT_VERSION" = "qt5" ]; then cmake ..; fi
     make
   elif [ "$TRAVIS_OS_NAME" == "osx" ]
   then
     if [[ "$TRAVIS_TAG" != "" && "$GH_TOKEN" != "" ]]
     then
       PATH=$PATH:/usr/local/opt/qt5/bin
-      cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DUSE_QT5=ON -DWANT_CORE=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DDEPLOY=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
+      cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DWANT_CORE=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DDEPLOY=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
     else
-      cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DUSE_QT5=ON -DWANT_CORE=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
+      cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DWANT_CORE=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
     fi
     ninja install
   fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,13 +40,13 @@ include(QuasselMacros)
 # Options and variables that can be set on the command line
 #####################################################################
 
-# First, choose a Qt version. We support USE_QT4 and USE_QT5; if neither is set, prefer Qt4 for now
-option(USE_QT5 "Enable support for Qt5 (disables KDE integration)" OFF)
-if (USE_QT4) # takes precedence
-    set(USE_QT5 OFF)
+# First, choose a Qt version. We support USE_QT5 and USE_QT4; if neither is set, Qt5 will be used
+option(USE_QT5 "Enable support for Qt5" OFF)
+if (USE_QT5) # takes precedence
+    set(USE_QT4 OFF)
 else()
-    if (NOT USE_QT5)
-        set(USE_QT4 ON)
+    if (NOT USE_QT4)
+        set(USE_QT5 ON)
     endif()
 endif()
 


### PR DESCRIPTION
This basically reverses the old default behavior.  Now, Qt5 is used
by default if neither USE_QT4 nor USE_QT5 is set or if they are
both set.