### PR TITLE
Use unread backlog fetching by default if not changed

### DIFF
--- a/src/client/backlogsettings.h
+++ b/src/client/backlogsettings.h
@@ -23,11 +23,16 @@
 
 #include "clientsettings.h"
 
+// For backlog requester types
+#include "backlogrequester.h"
+
 class BacklogSettings : public ClientSettings
 {
 public:
     BacklogSettings() : ClientSettings("Backlog") {}
-    inline int requesterType() { return localValue("RequesterType", 1).toInt(); }
+    inline int requesterType() { return localValue("RequesterType", BacklogRequester::PerBufferUnread).toInt(); }
+    // Default to PerBufferUnread to help work around performance problems on connect when there's
+    // many buffers that don't have much activity.
     inline void setRequesterType(int requesterType) { setLocalValue("RequesterType", requesterType); }
 
     inline int dynamicBacklogAmount() { return localValue("DynamicBacklogAmount", 200).toInt(); }

--- a/src/qtui/settingspages/backlogsettingspage.cpp
+++ b/src/qtui/settingspages/backlogsettingspage.cpp
@@ -23,6 +23,9 @@
 #include "qtui.h"
 #include "backlogsettings.h"
 
+// For backlog requester types
+#include "backlogrequester.h"
+
 BacklogSettingsPage::BacklogSettingsPage(QWidget *parent)
     : SettingsPage(tr("Interface"), tr("Backlog Fetching"), parent)
 {
@@ -45,7 +48,7 @@ bool BacklogSettingsPage::hasDefaults() const
 
 void BacklogSettingsPage::defaults()
 {
-    ui.requesterType->setCurrentIndex(0);
+    ui.requesterType->setCurrentIndex(BacklogRequester::PerBufferUnread - 1);
 
     SettingsPage::defaults();
 }


### PR DESCRIPTION
## In short
* Use ```PerBufferUnread``` by default for backlog fetching rather than ```PerBufferFixed```
  * With slow channels or multiple PMs, reduces backlog fetched on connect by ignoring old chat
  * Modifies new installs and existing configurations if prior default wasn't changed
  * In most cases, should speed up connecting and show more missed highlights

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing, faster connects and highlights slightly more reliable
Risk | ★★☆ *2/3* | Can request more messages than fixed, complex SQL, risks timeouts
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Rationale
Quassel prioritizes recent over past, like other modern chat systems.  However, when connecting to the Quassel core, by default the client currently requests 500 messages of the past for all channels and private messages, regardless of age.

Quassel should instead use the ```Unread messages per chat``` backlog requester, reducing bandwidth spent on unneeded past while requesting more chat history for unread channels and private messages that the user generally cares about more.  This also allows highlights to work slightly more reliably, and additional backlog remains available via scrolling up as before.

As this should provide improvements or at least generally cause no trouble, Quassel should also change the default for existing setups where backlog fetching hasn't been configured.

*If this causes issues, the version upgrade system could be used to preserve old defaults for existing installs*

## Example
### Before - fixed backlog requester as default
![Settings -> Configure Quassel... -> Interface: Backlog Fetching -> Backlog request method, old default of Fixed](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/ft-default-unread-backlog/Backlog%20requester%20-%20old%20default%20of%20fixed.png#v1 )
### After - unread backlog requester as default
![Settings -> Configure Quassel... -> Interface: Backlog Fetching -> Backlog request method, new default of Unread](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/ft-default-unread-backlog/Backlog%20requester%20-%20new%20default%20of%20unread.png#v1 )