### PR TITLE
Default to sqlite backend in core creation wizard

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -669,6 +669,7 @@ QVariantList Core::backendInfo()
         v["Description"] = backend->description();
         v["SetupKeys"] = backend->setupKeys();
         v["SetupDefaults"] = backend->setupDefaults();
+        v["IsDefault"] = isStorageBackendDefault(backend);
         backends.append(v);
     }
     return backends;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -504,6 +504,19 @@ public:
 
     static QVariantList backendInfo();
 
+    /**
+     * Checks if a storage backend is the default storage backend. This
+     * hardcodes this information into the core (not the client).
+     *
+     * \param backend    The backend to check.
+     *
+     * @return True if storage backend is default, false otherwise.
+     */
+    static inline bool isStorageBackendDefault(const Storage *backend)
+    {
+        return (backend->displayName() == "SQLite") ? true : false;
+    }
+
     static QString setup(const QString &adminUser, const QString &adminPassword, const QString &backend, const QVariantMap &setupData);
 
     static inline QTimer &syncTimer() { return instance()->_storageSyncTimer; }

--- a/src/qtui/coreconfigwizard.cpp
+++ b/src/qtui/coreconfigwizard.cpp
@@ -201,9 +201,15 @@ StorageSelectionPage::StorageSelectionPage(const QHash<QString, QVariant> &backe
 
     registerField("storage.backend", ui.backendList);
 
+    int defaultIndex = 0;
     foreach(QString key, _backends.keys()) {
         ui.backendList->addItem(_backends[key].toMap()["DisplayName"].toString(), key);
+        if (_backends[key].toMap()["IsDefault"].toBool()) {
+            defaultIndex = ui.backendList->count() - 1;
+        }
     }
+
+    ui.backendList->setCurrentIndex(defaultIndex);
 
     on_backendList_currentIndexChanged();
 }


### PR DESCRIPTION
This introduces the notion of a "default" storage backend into the core by adding a function (Core::isStorageBackendDefault), which returns true if a given Storage object is 'default' and false if not. This information is then added to the BackendInfo dictionary passed through the protocol to the user interface, which ensures the backend that is default will always be the one displayed by default.

This change was prompted by conversation in IRC with [Saint] and @digitalcircuit about making core creation slightly more intuitive.

This allows us to, potentially, change the default storage backend shown at core creation time should at some point another backend be introduced, without having to modify the interface. (It also allows other things, at some point, to know what the "default" storage backend is, should it ever become relevant).

It is a little weird having "isDefault" be an attribute of *each* storage backend, but this was the simplest way to do it without modifying the handshake. (Whichever is the last storage backend to claim to be the default will win).

(As an aside, should this be merged and should #170 be merged I'll implement something similar for authenticators in a separate PR).

I tested that this works as is, and also that if I modify core/core.h to change "SQLite" to "PostgreSQL", the PostgreSQL storage backend is shown as default instead. I also tested that this is backwards compatible with older cores, too.