### PR TITLE
Enable per-chat history and line wrap by default

### DIFF
--- a/src/qtui/inputwidget.cpp
+++ b/src/qtui/inputwidget.cpp
@@ -116,7 +116,7 @@ InputWidget::InputWidget(QWidget *parent)
     setShowStyleButtons(s.value("ShowStyleButtons", true));
 
     s.notify("EnablePerChatHistory", this, SLOT(setEnablePerChatHistory(QVariant)));
-    setEnablePerChatHistory(s.value("EnablePerChatHistory", false));
+    setEnablePerChatHistory(s.value("EnablePerChatHistory", true));
 
     s.notify("MaxNumLines", this, SLOT(setMaxLines(QVariant)));
     setMaxLines(s.value("MaxNumLines", 5));
@@ -125,7 +125,7 @@ InputWidget::InputWidget(QWidget *parent)
     setScrollBarsEnabled(s.value("EnableScrollBars", true));
 
     s.notify("EnableLineWrap", this, SLOT(setLineWrapEnabled(QVariant)));
-    setLineWrapEnabled(s.value("EnableLineWrap", false));
+    setLineWrapEnabled(s.value("EnableLineWrap", true));
 
     s.notify("EnableMultiLine", this, SLOT(setMultiLineEnabled(QVariant)));
     setMultiLineEnabled(s.value("EnableMultiLine", true));

--- a/src/qtui/qtuiapplication.cpp
+++ b/src/qtui/qtuiapplication.cpp
@@ -210,7 +210,7 @@ bool QtUiApplication::migrateSettings()
     // --------
     // Check minor settings version, handling upgrades/downgrades as needed
     // Current minor version
-    const uint VERSION_MINOR_CURRENT = 2;
+    const uint VERSION_MINOR_CURRENT = 3;
     // Stored minor version
     uint versionMinor = s.versionMinor();
 
@@ -269,10 +269,33 @@ bool QtUiApplication::applySettingsMigration(QtUiSettings settings, const uint n
     // oldest version.  Ignore those, start from 2 and higher.
     // Each missed version will be called in sequence.  E.g. to upgrade from '1' to '3', this
     // function will be called with '2', then '3'.
+    // Use explicit scope via { ... } to avoid cross-initialization
+    case 3:
+    {
+        // New default changes: per-chat history and line wrapping enabled by default.  Preserve
+        // the older default values for keys that haven't been saved.
+
+        // --------
+        // InputWidget settings
+        UiSettings settingsInputWidget("InputWidget");
+        const QString enableInputPerChatId = "EnablePerChatHistory";
+        if (!settingsInputWidget.valueExists(enableInputPerChatId)) {
+            // New default value is true, preserve previous behavior by setting to false
+            settingsInputWidget.setValue(enableInputPerChatId, false);
+        }
+
+        const QString enableInputLinewrap = "EnableLineWrap";
+        if (!settingsInputWidget.valueExists(enableInputLinewrap)) {
+            // New default value is true, preserve previous behavior by setting to false
+            settingsInputWidget.setValue(enableInputLinewrap, false);
+        }
+        // --------
+
+        // Migration complete!
+        return true;
+    }
     case 2:
     {
-        // Use explicit scope via { ... } to avoid cross-initialization
-
         // New default changes: sender <nick> brackets disabled, sender colors and sender CTCP
         // colors enabled.  Preserve the older default values for keys that haven't been saved.
 

--- a/src/qtui/settingspages/inputwidgetsettingspage.ui
+++ b/src/qtui/settingspages/inputwidgetsettingspage.ui
@@ -69,7 +69,7 @@
       <string notr="true">EnablePerChatHistory</string>
      </property>
      <property name="defaultValue" stdset="0">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -133,7 +133,7 @@
       <string notr="true">EnableLineWrap</string>
      </property>
      <property name="defaultValue" stdset="0">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## In short
* Enable per-chat history and line wrapping by default
 * Mimics [Quassel Web](https://github.com/magne4000/quassel-webserver ), [Quasseldroid-NG](https://github.com/justjanne/QuasselDroid-ng ), SMS apps, [HexChat](https://hexchat.github.io/ ) (*does per-chat by default, no line wrap*)
 * Makes writing long messages easier, offers clue when message is longer than expected
 * Preserve old defaults for upgrades, bumped config minor version to ```3```

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing flexibility and consistency with some other chat services
Risk | ★☆☆ *1/3* | Protest of new defaults, forgetting draft messages when switching chats
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Rationale
Composing long messages with line wrapping allows showing more on screen without scrolling.  Likewise, per-chat history (*or the equivalent, such as email and SMS drafts*) allows for better multi-tasking, letting one switch between multiple conversations without having to manually copy-paste drafts of their words somewhere else.

Quassel should enable per-chat history and line wrapping by default to offer greater flexibility with composing messages on IRC and offer consistency with several other chat clients and services.

As this is a subjective change, Quassel should keep the old defaults when upgrading existing setups.

## Examples
### Line wrapping (default for new installs)
*Sender brackets hidden, sender colors enabled and nicks colored in action messages*
![Line wrapping enabled, showing multiple line-wrapped lines of BuzzwordIpsum](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/ft-default-perchat-input/Quassel%20-%20line%20wrap%20on.png#v1 )

### No line wrapping (default for upgrades)
*Sender brackets shown, sender colors disabled and nicks not colored in action messages*
![Line wrapping disabled, showing a single line of BuzzwordIpsum](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/ft-default-perchat-input/Quassel%20-%20line%20wrap%20off.png#v1 )

### Quassel Web (for comparison)
*Quassel Web does not have an equivalent to the nick selector.*
![Quassel web showing line wrapping of BuzzwordIpsum](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/ft-default-perchat-input/Quassel%20web%20-%20line%20wrap%20on.png#v1 )

### Quasseldroid-NG (for comparison)
*Quasseldroid-NG enables line wrapping with a swipe up on the input widget.*
![Quasseldroid-NG showing line wrapping of BuzzwordIpsum](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/ft-default-perchat-input/Quasseldroid-NG%20-%20line%20wrap%20on.png#v1 )

### Android Messaging app (for comparison)
![Android Messaging app showing line wrapping of BuzzwordIpsum](https://dl.dropbox.com/u/839888/Hosting/Utilities/Quassel/Development/pr/ft-default-perchat-input/Android%20Messaging%20-%20line%20wrap%20on.png#v2 )