### PR TITLE
Disable high DPI scaling on everything but Windows

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -186,7 +186,7 @@ int main(int argc, char **argv)
 #if defined BUILD_CORE
     CoreApplication app(argc, argv);
 #elif defined BUILD_QTUI
-# if QT_VERSION >= 0x050600
+# if QT_VERSION >= 0x050600 && defined(Q_OS_WIN)
     QtUiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 # if QT_VERSION >= 0x050700
@@ -194,7 +194,7 @@ int main(int argc, char **argv)
 # endif
     QtUiApplication app(argc, argv);
 #elif defined BUILD_MONO
-# if QT_VERSION >= 0x050600
+# if QT_VERSION >= 0x050600 && defined(Q_OS_WIN)
     MonolithicApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 # if QT_VERSION >= 0x050700


### PR DESCRIPTION
The automatic scaling only works well on Windows.

See e. g. e33532e048fa12ee32429ca83ee31aa8f065147d in qttools,
QTBUG-50698 and QTBUG-52318.