### PR TITLE
Do a full install by default

### DIFF
--- a/scripts/build/NullsoftInstaller.nsi
+++ b/scripts/build/NullsoftInstaller.nsi
@@ -33,7 +33,6 @@ Var StartMenuFolder
 !define MUI_STARTMENUPAGE_REGISTRY_KEY "${regkey}"
 !define MUI_STARTMENUPAGE_REGISTRY_VALUENAME "Start Menu Folder"
 
-InstType "Minimal"
 InstType "Full"
 ;--------------------------------
 
@@ -139,7 +138,7 @@ SectionEnd
 
 
 Section "Quassel"  QUASSEL_ALL_IN_ONE
-    SectionIn 1 2
+    SectionIn 1
     SetOutPath $INSTDIR
     StrCpy $ToBeRunned "$INSTDIR\quassel.exe"
     StrCpy $nameOfToBeRunend "Run Quassel"
@@ -149,8 +148,8 @@ Section "Quassel"  QUASSEL_ALL_IN_ONE
     !insertmacro MUI_STARTMENU_WRITE_END
 SectionEnd
 
-Section /o "QuasselClient"  QUASSEL_CLIENT
-    SectionIn 2
+Section "QuasselClient"  QUASSEL_CLIENT
+    SectionIn 1
     SetOutPath $INSTDIR
     ${If} $ToBeRunned == ""
         StrCpy $ToBeRunned "$INSTDIR\quasselclient.exe"
@@ -162,8 +161,8 @@ Section /o "QuasselClient"  QUASSEL_CLIENT
     !insertmacro MUI_STARTMENU_WRITE_END
 SectionEnd
 
-Section /o "QuasselCore"  QUASSEL_CORE
-    SectionIn 2
+Section "QuasselCore"  QUASSEL_CORE
+    SectionIn 1
     SetOutPath $INSTDIR
     ${If} $ToBeRunned == ""
         StrCpy $ToBeRunned "$INSTDIR\quasselcore.exe"


### PR DESCRIPTION
Nsis doesn't provide command line switches by default to change the selection.
To be able to provide automated installs install all components by default.
The previous behaviour was to only install quassel monolith by default.
