### PR TITLE
Fix sasl authentication to fail on servers which don't support sasl

### DIFF
--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -144,19 +144,25 @@ void CoreSessionEventProcessor::processIrcEventCap(IrcEvent *e)
     // additional CAP messages (ls, multi-prefix, et cetera).
 
     if (e->params().count() == 3) {
-        if (e->params().at(2).startsWith("sasl")) { // Freenode (at least) sends "sasl " with a trailing space for some reason!
-            // FIXME use event
-            // if the current identity has a cert set, use SASL EXTERNAL
+        if (e->params().at(1) == "NAK") {
+            // CAP REQ sasl was denied
+            coreNetwork(e)->putRawLine("CAP END");
+        }
+        else if (e->params().at(1) == "ACK") {
+            if (e->params().at(2).startsWith("sasl")) { // Freenode (at least) sends "sasl " with a trailing space for some reason!
+                // FIXME use event
+                // if the current identity has a cert set, use SASL EXTERNAL
 #ifdef HAVE_SSL
-            if (!coreNetwork(e)->identityPtr()->sslCert().isNull()) {
-                coreNetwork(e)->putRawLine(coreNetwork(e)->serverEncode("AUTHENTICATE EXTERNAL"));
-            } else {
+                if (!coreNetwork(e)->identityPtr()->sslCert().isNull()) {
+                    coreNetwork(e)->putRawLine(coreNetwork(e)->serverEncode("AUTHENTICATE EXTERNAL"));
+                } else {
 #endif
-                // Only working with PLAIN atm, blowfish later
-                coreNetwork(e)->putRawLine(coreNetwork(e)->serverEncode("AUTHENTICATE PLAIN"));
+                    // Only working with PLAIN atm, blowfish later
+                    coreNetwork(e)->putRawLine(coreNetwork(e)->serverEncode("AUTHENTICATE PLAIN"));
 #ifdef HAVE_SSL
+                }
+#endif
             }
-#endif
         }
     }
 }


### PR DESCRIPTION
If you connect quassel to a server which doesn't support sasl, but with sasl enabled on the client, you get this:

```
-> :adam.home NOTICE * :*** Looking up your hostname...
-> :adam.home NOTICE * :*** Checking Ident
-> :adam.home NOTICE * :*** No Ident response
-> :adam.home NOTICE * :*** Couldn't look up your hostname
<- CAP REQ :sasl
-> :adam.home CAP * NAK :sasl
<- NICK Adam
<- USER quassel 8 * :Adam
<- AUTHENTICATE PLAIN
(~30 second wait)
-> ERROR :Closing Link: 192.168.1.16 (Registration timed out)
```

You can see this by trying to connect to irc.rizon.net.

This behavior of not requesting CAP LS first to see if sasl is even available (and it isn't) is very bad.

It looks to me like this has all be rewritten in master to be correct, so I've just hacked in a check for CAP NAK coming back into 0.12. I think it should be fixed in 0.12 despite master being fixed because it is preventing users from connecting and is a clearly broken behavior.

Thanks