### PR TITLE
Make reloadCerts also handle the IPv6 server

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -431,8 +431,13 @@ bool Core::sslSupported()
 bool Core::reloadCerts()
 {
 #ifdef HAVE_SSL
-    SslServer *sslServer = qobject_cast<SslServer *>(&instance()->_server);
-    return sslServer->reloadCerts();
+    SslServer *sslServerv4 = qobject_cast<SslServer *>(&instance()->_server);
+    bool retv4 = sslServerv4->reloadCerts();
+
+    SslServer *sslServerv6 = qobject_cast<SslServer *>(&instance()->_v6server);
+    bool retv6 = sslServerv6->reloadCerts();
+
+    return retv4 && retv6;
 #else
     // SSL not supported, don't mark configuration reload as failed
     return true;


### PR DESCRIPTION
`Core::reloadCerts` (from #208) was only calling `reloadCerts` on `_server`, instead of on both `_server` and `_v6server`.