### PR TITLE
Encourage SASL over NickServ when available, tidy up

### DIFF
--- a/src/common/irccap.h
+++ b/src/common/irccap.h
@@ -141,22 +141,6 @@ namespace IrcCap {
      * http://ircv3.net/specs/extensions/sasl-3.1.html
      */
     namespace SaslMech {
-
-        /**
-         * Check if the given authentication mechanism is likely to be supported.
-         *
-         * @param[in] saslCapValue   QString of SASL capability value, e.g. capValue(IrcCap::SASL)
-         * @param[in] saslMechanism  Desired SASL mechanism
-         * @return True if mechanism supported or unknown, otherwise false
-         */
-        inline bool maybeSupported(const QString &saslCapValue, const QString &saslMechanism) { return
-                    ((saslCapValue.length() == 0) || (saslCapValue.contains(saslMechanism, Qt::CaseInsensitive))); }
-        // SASL mechanisms are only specified in capability values as part of SASL 3.2.  In
-        // SASL 3.1, it's handled differently.  If we don't know via capability value, assume it's
-        // supported to reduce the risk of breaking existing setups.
-        // See: http://ircv3.net/specs/extensions/sasl-3.1.html
-        // And: http://ircv3.net/specs/extensions/sasl-3.2.html
-
         /**
          * PLAIN authentication, e.g. hashed password
          */

--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -243,6 +243,14 @@ QString Network::support(const QString &param) const
 
 bool Network::saslMaybeSupports(const QString &saslMechanism) const
 {
+    if (!capAvailable(IrcCap::SASL)) {
+        // If SASL's not advertised at all, it's likely the mechanism isn't supported, as per specs.
+        // Unfortunately, we don't know for sure, but Quassel won't request SASL without it being
+        // advertised, anyways.
+        // This may also occur if the network's disconnected or negotiation hasn't yet happened.
+        return false;
+    }
+
     // Get the SASL capability value
     QString saslCapValue = capValue(IrcCap::SASL);
     // SASL mechanisms are only specified in capability values as part of SASL 3.2.  In SASL 3.1,

--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -241,6 +241,20 @@ QString Network::support(const QString &param) const
 }
 
 
+bool Network::saslMaybeSupports(const QString &saslMechanism) const
+{
+    // Get the SASL capability value
+    QString saslCapValue = capValue(IrcCap::SASL);
+    // SASL mechanisms are only specified in capability values as part of SASL 3.2.  In SASL 3.1,
+    // it's handled differently.  If we don't know via capability value, assume it's supported to
+    // reduce the risk of breaking existing setups.
+    // See: http://ircv3.net/specs/extensions/sasl-3.1.html
+    // And: http://ircv3.net/specs/extensions/sasl-3.2.html
+    return (saslCapValue.length() == 0)
+            || (saslCapValue.contains(saslMechanism, Qt::CaseInsensitive));
+}
+
+
 IrcUser *Network::newIrcUser(const QString &hostmask, const QVariantMap &initData)
 {
     QString nick(nickFromMask(hostmask).toLower());

--- a/src/common/network.h
+++ b/src/common/network.h
@@ -39,6 +39,9 @@
 #include "ircuser.h"
 #include "ircchannel.h"
 
+// IRCv3 capabilities
+#include "irccap.h"
+
 // defined below!
 struct NetworkInfo;
 
@@ -279,6 +282,17 @@ public :
     // IRCv3 specs all use lowercase capability names
     // QHash returns the default constructed value if not found, in this case, empty string
     // See:  https://doc.qt.io/qt-4.8/qhash.html#value
+
+    /**
+     * Check if the given authentication mechanism is likely to be supported.
+     *
+     * This depends on the server advertising SASL support and either declaring available mechanisms
+     * (SASL 3.2), or just indicating something is supported (SASL 3.1).
+     *
+     * @param[in] saslMechanism  Desired SASL mechanism
+     * @return True if mechanism supported or unknown, otherwise false
+     */
+    bool saslMaybeSupports(const QString &saslMechanism) const;
 
     IrcUser *newIrcUser(const QString &hostmask, const QVariantMap &initData = QVariantMap());
     inline IrcUser *newIrcUser(const QByteArray &hostmask) { return newIrcUser(decodeServerString(hostmask)); }

--- a/src/common/network.h
+++ b/src/common/network.h
@@ -264,6 +264,19 @@ public :
     QString support(const QString &param) const;
 
     /**
+     * Checks if a given capability is advertised by the server.
+     *
+     * These results aren't valid if the network is disconnected or capability negotiation hasn't
+     * happened, and some servers might not correctly advertise capabilities.  Don't treat this as
+     * a guarentee.
+     *
+     * @param[in] capability Name of capability
+     * @returns True if connected and advertised by the server, otherwise false
+     */
+    inline bool capAvailable(const QString &capability) const { return _caps.contains(capability.toLower()); }
+    // IRCv3 specs all use lowercase capability names
+
+    /**
      * Checks if a given capability is acknowledged and active.
      *
      * @param[in] capability Name of capability

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -1053,7 +1053,7 @@ void CoreNetwork::serverCapAcknowledged(const QString &capability)
         // FIXME use event
 #ifdef HAVE_SSL
         if (!identityPtr()->sslCert().isNull()) {
-            if (IrcCap::SaslMech::maybeSupported(capValue(IrcCap::SASL), IrcCap::SaslMech::EXTERNAL)) {
+            if (saslMaybeSupports(IrcCap::SaslMech::EXTERNAL)) {
                 // EXTERNAL authentication supported, send request
                 putRawLine(serverEncode("AUTHENTICATE EXTERNAL"));
             } else {
@@ -1063,7 +1063,7 @@ void CoreNetwork::serverCapAcknowledged(const QString &capability)
             }
         } else {
 #endif
-            if (IrcCap::SaslMech::maybeSupported(capValue(IrcCap::SASL), IrcCap::SaslMech::PLAIN)) {
+            if (saslMaybeSupports(IrcCap::SaslMech::PLAIN)) {
                 // PLAIN authentication supported, send request
                 // Only working with PLAIN atm, blowfish later
                 putRawLine(serverEncode("AUTHENTICATE PLAIN"));

--- a/src/qtui/settingspages/networkssettingspage.cpp
+++ b/src/qtui/settingspages/networkssettingspage.cpp
@@ -746,16 +746,21 @@ void NetworksSettingsPage::setSASLStatus(const CapSupportStatus saslStatus)
 void NetworksSettingsPage::sslUpdated()
 {
     if (_cid && !_cid->sslKey().isNull()) {
-        ui.saslAccount->setDisabled(true);
-        ui.saslAccountLabel->setDisabled(true);
-        ui.saslPassword->setDisabled(true);
-        ui.saslPasswordLabel->setDisabled(true);
+        ui.saslContents->setDisabled(true);
         ui.saslExtInfo->setHidden(false);
     } else {
-        ui.saslAccount->setDisabled(false);
-        ui.saslAccountLabel->setDisabled(false);
-        ui.saslPassword->setDisabled(false);
-        ui.saslPasswordLabel->setDisabled(false);
+        ui.saslContents->setDisabled(false);
+        // Directly re-enabling causes the widgets to ignore the parent "Use SASL Authentication"
+        // state to indicate whether or not it's disabled.  To workaround this, keep track of
+        // whether or not "Use SASL Authentication" is enabled, then quickly uncheck/recheck the
+        // group box.
+        if (!ui.sasl->isChecked()) {
+            // SASL is not enabled, uncheck/recheck the group box to re-disable saslContents.
+            // Leaving saslContents disabled doesn't work as that prevents it from re-enabling if
+            // sasl is later checked.
+            ui.sasl->setChecked(true);
+            ui.sasl->setChecked(false);
+        }
         ui.saslExtInfo->setHidden(true);
     }
 }

--- a/src/qtui/settingspages/networkssettingspage.cpp
+++ b/src/qtui/settingspages/networkssettingspage.cpp
@@ -194,6 +194,12 @@ void NetworksSettingsPage::load()
                                           "modify message rate limits.")));
     }
 
+#ifdef HAVE_SSL
+    // Hide the SASL EXTERNAL notice until a network's shown.  Stops it from showing while loading
+    // backlog from the core.
+    sslUpdated();
+#endif
+
     foreach(NetworkId netid, Client::networkIds()) {
         clientNetworkAdded(netid);
     }

--- a/src/qtui/settingspages/networkssettingspage.h
+++ b/src/qtui/settingspages/networkssettingspage.h
@@ -100,7 +100,23 @@ private slots:
     void on_upServer_clicked();
     void on_downServer_clicked();
 
+    /**
+     * Event handler for SASL status Details button
+     */
+    void on_saslStatusDetails_clicked();
+
 private:
+    /**
+     * Status of capability support
+     */
+    enum CapSupportStatus {
+        Unknown,           ///< Old core, or otherwise unknown, can't make assumptions
+        Disconnected,      ///< Disconnected from network, can't determine
+        MaybeUnsupported,  ///< Server does not advertise support at this moment
+        MaybeSupported     ///< Server advertises support at this moment
+    };
+    // Keep in mind networks can add, change, and remove capabilities at any time.
+
     Ui::NetworksSettingsPage ui;
 
     NetworkId currentId;
@@ -112,6 +128,11 @@ private:
 
     QIcon connectedIcon, connectingIcon, disconnectedIcon;
 
+    // Status icons
+    QIcon infoIcon, warningIcon;
+
+    CapSupportStatus _saslStatusSelected;  /// Status of SASL support for currently-selected network
+
     void reset();
     bool testHasChanged();
     QListWidgetItem *insertNetwork(NetworkId);
@@ -119,6 +140,13 @@ private:
     QListWidgetItem *networkItem(NetworkId) const;
     void saveToNetworkInfo(NetworkInfo &);
     IdentityId defaultIdentity() const;
+
+    /**
+     * Update the SASL settings interface according to the given SASL state
+     *
+     * @param[in] saslStatus Current status of SASL support.
+     */
+    void setSASLStatus(const CapSupportStatus saslStatus);
 };
 
 

--- a/src/qtui/settingspages/networkssettingspage.h
+++ b/src/qtui/settingspages/networkssettingspage.h
@@ -58,6 +58,16 @@ private slots:
     void displayNetwork(NetworkId);
     void setItemState(NetworkId, QListWidgetItem *item = 0);
 
+    /**
+     * Update the capability-dependent settings according to what the server supports
+     *
+     * For example, this updates the SASL text for when the server advertises support.  This should
+     * only be called on the currently displayed network.
+     *
+     * @param[in] id  NetworkId referencing network used to update settings user interface.
+     */
+    void setNetworkCapStates(NetworkId id);
+
     void clientNetworkAdded(NetworkId);
     void clientNetworkRemoved(NetworkId);
     void clientNetworkUpdated();
@@ -65,6 +75,11 @@ private slots:
     void clientIdentityAdded(IdentityId);
     void clientIdentityRemoved(IdentityId);
     void clientIdentityUpdated();
+
+    /**
+     * Update the settings user interface according to capabilities advertised by the IRC server
+     */
+    void clientNetworkCapsUpdated();
 
 #ifdef HAVE_SSL
     void sslUpdated();

--- a/src/qtui/settingspages/networkssettingspage.ui
+++ b/src/qtui/settingspages/networkssettingspage.ui
@@ -664,64 +664,12 @@ Note that Quassel IRC automatically rejoins channels, so /join will rarely be ne
          </attribute>
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
-           <widget class="QGroupBox" name="autoIdentify">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="title">
-             <string>Auto Identify</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-            <layout class="QGridLayout" name="gridLayout">
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="autoIdentifyService">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="text">
-                <string>NickServ</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QLineEdit" name="autoIdentifyPassword">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="echoMode">
-                <enum>QLineEdit::Password</enum>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_2">
-               <property name="text">
-                <string>Service:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_3">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="text">
-                <string>Password:</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
            <widget class="QGroupBox" name="sasl">
             <property name="enabled">
              <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Authenticate using your nickname and password before joining any channels</string>
             </property>
             <property name="title">
              <string>Use SASL Authentication</string>
@@ -733,20 +681,13 @@ Note that Quassel IRC automatically rejoins channels, so /join will rarely be ne
              <bool>true</bool>
             </property>
             <layout class="QGridLayout" name="gridLayout_2">
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="saslAccount">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
              <item row="1" column="1">
               <widget class="QLineEdit" name="saslPassword">
                <property name="enabled">
                 <bool>true</bool>
+               </property>
+               <property name="toolTip">
+                <string>Account password</string>
                </property>
                <property name="echoMode">
                 <enum>QLineEdit::Password</enum>
@@ -773,6 +714,19 @@ Note that Quassel IRC automatically rejoins channels, so /join will rarely be ne
                </property>
               </widget>
              </item>
+             <item row="0" column="1">
+              <widget class="QLineEdit" name="saslAccount">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="toolTip">
+                <string>Account name, often the same as your nickname</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>
@@ -787,6 +741,70 @@ Note that Quassel IRC automatically rejoins channels, so /join will rarely be ne
            </widget>
           </item>
           <item>
+           <widget class="QGroupBox" name="autoIdentify">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Authenticate to services using your password.  Use SASL instead to identify before joining channels.</string>
+            </property>
+            <property name="title">
+             <string>Auto Identify</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+            <layout class="QGridLayout" name="gridLayout">
+             <item row="0" column="1">
+              <widget class="QLineEdit" name="autoIdentifyService">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="toolTip">
+                <string>Service user to send your password to, usually NickServ</string>
+               </property>
+               <property name="text">
+                <string>NickServ</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLineEdit" name="autoIdentifyPassword">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="toolTip">
+                <string>Account password</string>
+               </property>
+               <property name="echoMode">
+                <enum>QLineEdit::Password</enum>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="identifyServiceLabel">
+               <property name="text">
+                <string>Service:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="identifyPasswordLabel">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="text">
+                <string>Password:</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
            <spacer name="verticalSpacer_2">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -794,7 +812,7 @@ Note that Quassel IRC automatically rejoins channels, so /join will rarely be ne
             <property name="sizeHint" stdset="0">
              <size>
               <width>20</width>
-              <height>40</height>
+              <height>10</height>
              </size>
             </property>
            </spacer>
@@ -961,12 +979,12 @@ Unless you *really* know what you do, leave this as ISO-8859-1!</string>
   <tabstop>messageRateBurstSize</tabstop>
   <tabstop>unlimitedMessageRate</tabstop>
   <tabstop>messageRateDelay</tabstop>
-  <tabstop>autoIdentify</tabstop>
-  <tabstop>autoIdentifyService</tabstop>
-  <tabstop>autoIdentifyPassword</tabstop>
   <tabstop>sasl</tabstop>
   <tabstop>saslAccount</tabstop>
   <tabstop>saslPassword</tabstop>
+  <tabstop>autoIdentify</tabstop>
+  <tabstop>autoIdentifyService</tabstop>
+  <tabstop>autoIdentifyPassword</tabstop>
   <tabstop>useCustomEncodings</tabstop>
   <tabstop>sendEncoding</tabstop>
   <tabstop>recvEncoding</tabstop>

--- a/src/qtui/settingspages/networkssettingspage.ui
+++ b/src/qtui/settingspages/networkssettingspage.ui
@@ -680,52 +680,87 @@ Note that Quassel IRC automatically rejoins channels, so /join will rarely be ne
             <property name="checked">
              <bool>true</bool>
             </property>
-            <layout class="QGridLayout" name="gridLayout_2">
-             <item row="1" column="1">
-              <widget class="QLineEdit" name="saslPassword">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="toolTip">
-                <string>Account password</string>
-               </property>
-               <property name="echoMode">
-                <enum>QLineEdit::Password</enum>
-               </property>
-              </widget>
+            <layout class="QVBoxLayout" name="verticalLayout_11">
+             <item>
+              <layout class="QGridLayout" name="gridLayout_2">
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="saslAccount">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="toolTip">
+                  <string>Account name, often the same as your nickname</string>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="saslAccountLabel">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="text">
+                  <string>Account:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLineEdit" name="saslPassword">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="toolTip">
+                  <string>Account password</string>
+                 </property>
+                 <property name="echoMode">
+                  <enum>QLineEdit::Password</enum>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="saslPasswordLabel">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="text">
+                  <string>Password:</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="saslPasswordLabel">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="text">
-                <string>Password:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="saslAccountLabel">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="text">
-                <string>Account:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="saslAccount">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="toolTip">
-                <string>Account name, often the same as your nickname</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_7">
+               <item>
+                <widget class="QLabel" name="saslStatusIcon">
+                 <property name="text">
+                  <string notr="true">[icon]</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="saslStatusLabel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Could not detect if supported by server</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="saslStatusDetails">
+                 <property name="text">
+                  <string>Details...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
             </layout>
            </widget>
@@ -982,6 +1017,7 @@ Unless you *really* know what you do, leave this as ISO-8859-1!</string>
   <tabstop>sasl</tabstop>
   <tabstop>saslAccount</tabstop>
   <tabstop>saslPassword</tabstop>
+  <tabstop>saslStatusDetails</tabstop>
   <tabstop>autoIdentify</tabstop>
   <tabstop>autoIdentifyService</tabstop>
   <tabstop>autoIdentifyPassword</tabstop>

--- a/src/qtui/settingspages/networkssettingspage.ui
+++ b/src/qtui/settingspages/networkssettingspage.ui
@@ -682,85 +682,112 @@ Note that Quassel IRC automatically rejoins channels, so /join will rarely be ne
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_11">
              <item>
-              <layout class="QGridLayout" name="gridLayout_2">
-               <item row="0" column="1">
-                <widget class="QLineEdit" name="saslAccount">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="toolTip">
-                  <string>Account name, often the same as your nickname</string>
-                 </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="saslAccountLabel">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="text">
-                  <string>Account:</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QLineEdit" name="saslPassword">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="toolTip">
-                  <string>Account password</string>
-                 </property>
-                 <property name="echoMode">
-                  <enum>QLineEdit::Password</enum>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="saslPasswordLabel">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="text">
-                  <string>Password:</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_7">
-               <item>
-                <widget class="QLabel" name="saslStatusIcon">
-                 <property name="text">
-                  <string notr="true">[icon]</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="saslStatusLabel">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Could not detect if supported by server</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="saslStatusDetails">
-                 <property name="text">
-                  <string>Details...</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+              <widget class="QFrame" name="saslContents">
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <property name="frameShadow">
+                <enum>QFrame::Plain</enum>
+               </property>
+               <property name="lineWidth">
+                <number>0</number>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_12">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <layout class="QGridLayout" name="gridLayout_2">
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="saslAccount">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                    <property name="toolTip">
+                     <string>Account name, often the same as your nickname</string>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="saslAccountLabel">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                    <property name="text">
+                     <string>Account:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QLineEdit" name="saslPassword">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                    <property name="toolTip">
+                     <string>Account password</string>
+                    </property>
+                    <property name="echoMode">
+                     <enum>QLineEdit::Password</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="saslPasswordLabel">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                    <property name="text">
+                     <string>Password:</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout_7">
+                  <item>
+                   <widget class="QLabel" name="saslStatusIcon">
+                    <property name="text">
+                     <string notr="true">[icon]</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="saslStatusLabel">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Could not detect if supported by server</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="saslStatusDetails">
+                    <property name="text">
+                     <string>Details...</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </widget>
              </item>
             </layout>
            </widget>


### PR DESCRIPTION
## In short
* Suggest SASL in place of NickServ
  * Place ```Use SASL Authentication``` above ```Auto Identify```
  * Mark SASL as ```Supported by network``` when connected and server supports it
  * Add ```Details...``` button to explain why SASL is or is not supported
  * Add explanations in tooltips
  * All combinations still allowed, just a visual design change
* Tidy up capability handling code
* Fix SASL appearing active when ```Use SASL Authentication``` was unchecked

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing, clarifies, answers "How do I identify before joining?"
Risk | ★★☆ *2/3* | Misleading wording if server capabilities aren't detected correctly
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Rationale
In most cases, SASL authentication offers a better experience than NickServ identification.  As authentication happens before joining channels, channels requiring registration won't block attempts and hostmask cloaking will apply to ```JOIN``` messages.  Unfortunately, not all servers support SASL.

Quassel should make use of the IRCv3 capability list sent from the core to client in [pull request #198](https://github.com/quassel/quassel/pull/198 ) to check if SASL is available or not, then update the settings interface accordingly.

As networks may be disconnected or not accurately specify support for SASL (*e.g. temporary unavailability*), Quassel should not force configuring SASL one way or the other.

## Implementation
* Suggest SASL in place of NickServ
  * Rearrange the Network ```Auto Identify``` tab to place ```Use SASL Authentication``` at the top.  People tend to prioritize items shown first.
  * Add new row with icon and label saying ```Supported by network```, ```Not currently supported by network``` (*uses warning icon*), ```Cannot check if supported when disconnected```, or ```Could not check if supported by network```
  * Add new button ```Details...``` to explain each of the above states, including suggestions
  * Add tooltips to authentication options, including recommending SASL if you need to identify before joining channels (*this gets asked a lot in ```#quassel```*).
  * All past combinations of SASL and NickServ-based authentication are still allowed
  * *Also handles capability updates while the settings dialog is open!  That was.. interesting to figure out.*
* Tidy up capability handling code
  * Move ```IrcCap::SaslMechs::maybeSupported``` to ```Network::saslMaybeSupports```, simplifying usage
  * Add ```capAvailable``` to ```Network```, similar to ```capEnabled```, useful for showing elsewhere whether or not a certain capability could've been requested
  * Hide SASL EXTERNAL notice while the client's still loading
* Fix SASL appearing active when ```Use SASL Authentication``` was unchecked
  * Avoid conflict between ```sslUpdated()``` and ```sasl``` QGroupBox state
  * Simplify widget enabling/disabling by using an invisible frame

Explanations shown via ```Details...``` button:
* Messages
  1.  **SASL supported by network**:  The network "{network name}" supports SASL.  In most cases, you should use SASL instead of NickServ identification.
  2.  **SASL not currently supported by network**:  The network "{network name}" does not currently support SASL.  However, support might be added later on.
  3.  **Cannot check if SASL supported when disconnected**:  Quassel cannot check if "{network name}" supports SASL when disconnected.  Connect to the network, or try using SASL anyways.
  4.  **Could not check if SASL supported by network**:  Quassel could not check if "{network name}" supports SASL.  This may be due to unsaved changes or an older Quassel core.  You can still try using SASL.
* Bottom text, same for all
  * *SASL is a standardized way to log in and identify yourself to IRC servers.*

## Examples
### After - SASL placed above, encouraged
![Network settings dialog on client showing the Auto Identify tab.  'Use SASL Authentication' is placed above 'Auto Identify', icon and label indicate it's preferred](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/ft-suggest-sasl/Network%20settings%20v2%20-%20new.png#v1 )

### Before - SASL placed below as if secondary
![Network settings dialog on client showing the Auto Identify tab.  'Auto Identify' is placed above 'Use SASL Authentication', no icon and label to indicate it's preferred](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/ft-suggest-sasl/Network%20settings%20v2%20-%20old.png#v1 )

### SASL messages when supported
*Server announces support for SASL via ```CAP LS```, and if specific support is advertised, ```SASL PLAIN``` is supported*
![Network settings dialog on client showing the Auto Identify tab.  At the bottom of the 'Use SASL Authentication' box, an information icon procedes the message 'Supported by network'.  The 'Details...' button shows message #1 from Implemention.](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/ft-suggest-sasl/Network%20SASL%20v2%20-%20connected%2C%20advertised.png#v4 )

### SASL messages when unsupported
*Server did not announce support for SASL via ```CAP LS```, or if specific support is advertised, ```SASL PLAIN``` was not supported*
![Network settings dialog on client showing the Auto Identify tab.  At the bottom of the 'Use SASL Authentication' box, a warning icon procedes the message 'Not currently supported by network'.  The 'Details...' button shows message #2 from Implemention.](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/ft-suggest-sasl/Network%20SASL%20v2%20-%20connected%2C%20not%20advertised.png#v4 )

### SASL messages when disconnected
*Not connected to server*
![Network settings dialog on client showing the Auto Identify tab.  At the bottom of the 'Use SASL Authentication' box, an information icon procedes the message 'Cannot check if supported when disconnected'.  The 'Details...' button shows message #3 from Implemention.](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/ft-suggest-sasl/Network%20SASL%20v2%20-%20disconnected.png#v4 )

### SASL messages when unknown
*Network was added without being saved, core does not support capability negotiation, etc*
![Network settings dialog on client showing the Auto Identify tab.  At the bottom of the 'Use SASL Authentication' box, an information icon procedes the message 'Could not check if supported by network'.  The 'Details...' button shows message #4 from Implemention.](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/ft-suggest-sasl/Network%20SASL%20v2%20-%20unknown%2C%20changes%20not%20saved.png#v4 )

### All Auto Identify tooltips
* **Use SASL Authentication:** Authenticate using your nickname and password before joining any channels
  * **Account:** Account name, often the same as your nickname
  * **Password:** Account password
* **Auto Identify:** Authenticate to services using your password.  Use SASL instead to identify before joining channels.
  * **Service:** Service user to send your password to, usually NickServ
  * **Password:** Account password

![Network settings dialog on client showing all tooltips in the Auto Identify tab.](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/ft-suggest-sasl/Network%20settings%20-%20tooltips.png#v4 )