### PR TITLE
Allow custom timestamp in away messages

### DIFF
--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -75,8 +75,9 @@ public:
         VerifyServerSSL = 0x0040,          /// IRC server SSL validation
         CustomRateLimits = 0x0080,         /// IRC server custom message rate limits
         DccFileTransfer = 0x0100,
+        AwayFormatTimestamp = 0x0200,      /// Timestamp formatting in away (e.g. %%hh:mm%%)
 
-        NumFeatures = 0x0100
+        NumFeatures = 0x0200
     };
     Q_DECLARE_FLAGS(Features, Feature)
 

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -200,3 +200,18 @@ QByteArray prettyDigest(const QByteArray &digest)
     }
     return prettyDigest;
 }
+
+QString formatCurrentDateTimeInString(QString str)
+{
+    /*
+     * Find %%<text>%% in string. Repleace inside text which is format to QDateTime
+     * with current timestamp.
+     */
+    QRegExp rx("\\%%(.*)\\%%");
+    rx.setMinimal(true);
+    int s = rx.indexIn(str);
+    if (s >= 0)
+        str.replace(s, rx.cap(0).length(), QDateTime::currentDateTime().toString(rx.cap(1)));
+
+    return str;
+}

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -25,6 +25,7 @@
 #include <QVariant>
 #include <QString>
 #include <QMetaMethod>
+#include <QDateTime>
 
 // TODO Use versions from Network instead
 QString nickFromMask(QString mask);
@@ -74,5 +75,7 @@ QList<T> fromVariantList(const QVariantList &variants)
 
 
 QByteArray prettyDigest(const QByteArray &digest);
+
+QString formatCurrentDateTimeInString(QString str);
 
 #endif

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -76,6 +76,12 @@ QList<T> fromVariantList(const QVariantList &variants)
 
 QByteArray prettyDigest(const QByteArray &digest);
 
-QString formatCurrentDateTimeInString(QString str);
+/**
+ * Format a string with %%<text>%% to current date/timestamp via QDateTime.
+ *
+ * @param[in] formatStr String with format codes
+ * @return String with current date/time substituted in via formatting codes
+ */
+QString formatCurrentDateTimeInString(const QString &formatStr);
 
 #endif

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -656,8 +656,11 @@ void CoreNetwork::networkInitialized()
 
     // restore away state
     QString awayMsg = Core::awayMessage(userId(), networkId());
-    if (!awayMsg.isEmpty())
-        userInputHandler()->handleAway(BufferInfo(), Core::awayMessage(userId(), networkId()));
+    if (!awayMsg.isEmpty()) {
+        // Don't re-apply any timestamp formatting in order to preserve escaped percent signs, e.g.
+        // '%%%%%%%%' -> '%%%%'  If processed again, it'd result in '%%'.
+        userInputHandler()->handleAway(BufferInfo(), awayMsg, true);
+    }
 
     sendPerform();
 

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -670,7 +670,7 @@ void CoreSession::clientsDisconnected()
 }
 
 
-void CoreSession::globalAway(const QString &msg)
+void CoreSession::globalAway(const QString &msg, const bool skipFormatting)
 {
     QHash<NetworkId, CoreNetwork *>::iterator netIter = _networks.begin();
     CoreNetwork *net = 0;
@@ -681,7 +681,7 @@ void CoreSession::globalAway(const QString &msg)
         if (!net->isConnected())
             continue;
 
-        net->userInputHandler()->issueAway(msg, false /* no force away */);
+        net->userInputHandler()->issueAway(msg, false /* no force away */, skipFormatting);
     }
 }
 

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -662,7 +662,7 @@ void CoreSession::clientsDisconnected()
 
         if (identity->detachAwayEnabled() && !me->isAway()) {
             if (!identity->detachAwayReason().isEmpty())
-                awayReason = identity->detachAwayReason();
+                awayReason = formatCurrentDateTimeInString(identity->detachAwayReason());
             net->setAutoAwayActive(true);
             net->userInputHandler()->handleAway(BufferInfo(), awayReason);
         }

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -133,8 +133,13 @@ public slots:
 
     QHash<QString, QString> persistentChannels(NetworkId) const;
 
-    //! Marks us away (or unaway) on all networks
-    void globalAway(const QString &msg = QString());
+    /**
+     * Marks us away (or unaway) on all networks
+     *
+     * @param[in] msg             Away message, or blank to set unaway
+     * @param[in] skipFormatting  If true, skip timestamp formatting codes (e.g. if already done)
+     */
+    void globalAway(const QString &msg = QString(), const bool skipFormatting = false);
 
 signals:
     void initialized();

--- a/src/core/coreuserinputhandler.cpp
+++ b/src/core/coreuserinputhandler.cpp
@@ -89,7 +89,7 @@ void CoreUserInputHandler::issueAway(const QString &msg, bool autoCheck)
         if (me && !me->isAway()) {
             Identity *identity = network()->identityPtr();
             if (identity) {
-                awayMsg = identity->awayReason();
+                awayMsg = formatCurrentDateTimeInString(identity->awayReason());
             }
             if (awayMsg.isEmpty()) {
                 awayMsg = tr("away");

--- a/src/core/coreuserinputhandler.h
+++ b/src/core/coreuserinputhandler.h
@@ -39,7 +39,17 @@ public:
     int lastParamOverrun(const QString &cmd, const QList<QByteArray> &params);
 
 public slots:
-    void handleAway(const BufferInfo &bufferInfo, const QString &text);
+    /**
+     * Handle the away command, marking as away or unaway
+     *
+     * Applies to the current network unless text begins with "-all".
+     *
+     * @param[in] bufferInfo      Currently active buffer
+     * @param[in] text            Away message, or blank to set unaway
+     * @param[in] skipFormatting  If true, skip timestamp formatting codes (e.g. if already done)
+     */
+    void handleAway(const BufferInfo &bufferInfo, const QString &text,
+                    const bool skipFormatting = true);
     void handleBan(const BufferInfo &bufferInfo, const QString &text);
     void handleUnban(const BufferInfo &bufferInfo, const QString &text);
     void handleCtcp(const BufferInfo &bufferInfo, const QString &text);
@@ -86,7 +96,15 @@ public slots:
      * @param forceImmediate  Immediately quit, skipping queue of other commands
      */
     void issueQuit(const QString &reason, bool forceImmediate = false);
-    void issueAway(const QString &msg, bool autoCheck = true);
+
+    /**
+     * Issues the away command, marking as away or unaway on the current network
+     *
+     * @param[in] msg             Away message, or blank to set unaway
+     * @param[in] autoCheck       If true, always set away, defaulting to the identity away message
+     * @param[in] skipFormatting  If true, skip timestamp formatting codes (e.g. if already done)
+     */
+    void issueAway(const QString &msg, bool autoCheck = true, const bool skipFormatting = false);
 
 protected:
     void timerEvent(QTimerEvent *event);

--- a/src/qtui/settingspages/identityeditwidget.ui
+++ b/src/qtui/settingspages/identityeditwidget.ui
@@ -251,7 +251,7 @@
                <bool>true</bool>
               </property>
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default away reason. You can add date/time to this message using syntax: %% &amp;lt;format&amp;gt; %%. Where &amp;lt;format&amp;gt; is: &lt;br/&gt;hh - the hour&lt;br/&gt;mm - the minutes&lt;br/&gt;ss - second&lt;br/&gt;AP - AM/PM&lt;&lt;br/&gt;dd - day&lt;br/&gt;MM - month&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>Default away reason</string>
               </property>
              </widget>
             </item>
@@ -277,7 +277,7 @@
        <item>
         <widget class="QGroupBox" name="detachAwayEnabled">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set away when all clients have detached from the core. You can add date/time to this message using syntax: %% &amp;lt;format&amp;gt; %%. Where &amp;lt;format&amp;gt; is:&lt;br/&gt;hh - the hour&lt;br/&gt;mm - the minutes&lt;br/&gt;ss - second&lt;br/&gt;AP - AM/PM&lt;br/&gt;dd - day&lt;br/&gt;MM - month&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Set away when all clients have detached from the core</string>
          </property>
          <property name="title">
           <string>Away On Detach</string>

--- a/src/qtui/settingspages/identityeditwidget.ui
+++ b/src/qtui/settingspages/identityeditwidget.ui
@@ -251,7 +251,7 @@
                <bool>true</bool>
               </property>
               <property name="toolTip">
-               <string>Default away reason</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default away reason. You can add date/time to this message using syntax: %% &amp;lt;format&amp;gt; %%. Where &amp;lt;format&amp;gt; is: &lt;br/&gt;hh - the hour&lt;br/&gt;mm - the minutes&lt;br/&gt;ss - second&lt;br/&gt;AP - AM/PM&lt;&lt;br/&gt;dd - day&lt;br/&gt;MM - month&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
@@ -277,7 +277,7 @@
        <item>
         <widget class="QGroupBox" name="detachAwayEnabled">
          <property name="toolTip">
-          <string>Set away when all clients have detached from the core</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set away when all clients have detached from the core. You can add date/time to this message using syntax: %% &amp;lt;format&amp;gt; %%. Where &amp;lt;format&amp;gt; is:&lt;br/&gt;hh - the hour&lt;br/&gt;mm - the minutes&lt;br/&gt;ss - second&lt;br/&gt;AP - AM/PM&lt;br/&gt;dd - day&lt;br/&gt;MM - month&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="title">
           <string>Away On Detach</string>


### PR DESCRIPTION
## In short
* Treat `%%` in away messages as timestamp marker
  * Applies to away-on-detach, default away message, and manual `/away Message`
  * Handles multiple entries, e.g. `Away since %%hh:mm%% on %%dd.MM%%`
  * `%%%%` escapes to a literal `%%`
  * Invalid entries are mostly ignored according to [`QDateTime`](https://doc.qt.io/qt-4.8/qdatetime.html#toString )
* Don't re-process existing away message on startup
  * Preserves any consecutive escapes, e.g. a stored `%%%%` remains as `%%%%`
* Explain formatting in tooltips for away settings
  * Use a table for pretty listing, only mention `t` (*timezone*) [for Qt 5](https://doc.qt.io/qt-5/qdatetime.html#toString )
  * Add feature flag `AwayFormatTimestamp = 0x0200`, only show tooltip when present

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing feature, easier to see if someone's gone for long
Risk | ★★☆ *2/3* | Changes away handling, `%%` needs escaped as `%%%%`
Intrusiveness | ★★☆ *2/3* | Minor changes, new feature flag might conflict with other PRs

This expands upon @bzyx's [pull request #63](https://github.com/quassel/quassel/pull/63 ) (thank you!), addressing some of the concerns from review.

## Rationale
Quassel allows setting an away message whenever all clients detach, a handy way to see if someone's able to get messages.  However, this doesn't indicate how recently they disconnected.  If on Quasseldroid with a poor signal, the connection might drop every few minutes, whereas if one does not use IRC for a while, it could be months.

By allowing custom timestamp formatting in away messages, Quassel simplifies indicating how long ago one actually used their client, or for any other reason in a custom away message.  This remains optional, as always.

This changes handling of `/away` in a non-compatibile manner as `%%` is now treated specially.  `%%%%` translates to a literal `%%`.  However, this shouldn't affect most situations, and `%%` can be changed to any other identifier if needed.

## Examples
### Custom away message
*Complex example with multiple time/date format entries and repeated escape codes*
![Hovering over IRC nickname in Nick list showing the away message tooltip](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/pr-63-away-timestamp/Custom%20away%20message%20in%20user%20list.png#v3 )

**Specified away message**
```Away since %%h:mm ap%% (%%t%%) on %%yyyy-MM-dd%% - %%%% %%%%%%%%be back later%%%%%%%% %%%%```

**Converted away message**
```Away since 4:36 pm (CST) on 2017-01-08 - %% %%%%be back later%%%% %%```

### Settings → Identity tooltips
*New core, new client, Qt 5 (so timezone code is supported)*
![Tooltip when hovering over "Away on Detach" in Settings - IRC - Identities - Away tab.](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/pr-63-away-timestamp/Identity%20away%20message%20tooltip.png#v1 )

**Tooltip text**
> \[Original tooltip message\].
>
> You can add date/time to this message using the syntax: 
> %%*<format>*%%, where *<format>* is:
> 
> n/a| \[headers invisible, just for Markdown\]
> ---|-----------------
> hh | the hour
> mm | the minutes
> ss | seconds
> AP | AM/PM
> dd | day
> MM | month
> t  | current timezone
> 
> Example: Away since %%hh:mm%% on %%dd.MM%%.
> %%%% without anything inside represents %%.  Other format codes are available.