### PR TITLE
Fix expanding networks in Chat Monitor settings

### DIFF
--- a/src/uisupport/bufferview.cpp
+++ b/src/uisupport/bufferview.cpp
@@ -130,6 +130,11 @@ void BufferView::setModel(QAbstractItemModel *model)
     }
 
     connect(model, SIGNAL(layoutChanged()), this, SLOT(on_layoutChanged()));
+
+    // Make sure collapsation is correct after setting a model
+    // This might not be needed here, only in BufferView::setFilteredModel().  If issues arise, just
+    // move down to setFilteredModel (which calls this function).
+    setExpandedState();
 }
 
 
@@ -330,7 +335,19 @@ void BufferView::on_configChanged()
 {
     Q_ASSERT(model());
 
-    // expand all active networks... collapse inactive ones... unless manually changed
+    // Expand/collapse as needed
+    setExpandedState();
+
+    if (config()) {
+        // update selection to current one
+        Client::bufferModel()->synchronizeView(this);
+    }
+}
+
+
+void BufferView::setExpandedState()
+{
+    // Expand all active networks, collapse inactive ones... unless manually changed
     QModelIndex networkIdx;
     NetworkId networkId;
     for (int row = 0; row < model()->rowCount(); row++) {
@@ -343,11 +360,6 @@ void BufferView::on_configChanged()
             continue;
 
         setExpandedState(networkIdx);
-    }
-
-    if (config()) {
-        // update selection to current one
-        Client::bufferModel()->synchronizeView(this);
     }
 }
 

--- a/src/uisupport/bufferview.h
+++ b/src/uisupport/bufferview.h
@@ -93,7 +93,31 @@ private slots:
     void joinChannel(const QModelIndex &index);
     void toggleHeader(bool checked);
 
+    /**
+     * Expand all active networks and collapse inactive ones unless manually changed
+     *
+     * Applies to all networks.  Shouldn't need called except during initialization.
+     */
+    void setExpandedState();
+
+    /**
+     * Save the current display state of the given network
+     *
+     * Tracks expanded or collapsed and active or inactive.
+     *
+     * @see setExpandedState()
+     * @param[in] networkIdx QModelIndex of the root network to store
+     */
     void storeExpandedState(const QModelIndex &networkIdx);
+
+    /**
+     * Set the display state of the given network according to network status and manual changes
+     *
+     * Expands if active or previously expanded, collapses if inactive or previously collapsed.
+     *
+     * @see storeExpandedState()
+     * @param[in] networkIdx QModelIndex of the root network to update
+     */
     void setExpandedState(const QModelIndex &networkIdx);
 
     void on_configChanged();


### PR DESCRIPTION
## In short
* Fix connected networks not expanding when opening Chat Monitor settings
  * Move network expand/collapse logic to ```setExpandedState()```, no arguments
  * Add call to ```setExpandedState()``` when setting a model for ```BufferView```
  * Regression from [pull request #237](https://github.com/quassel/quassel/pull/237 ), now expanding connected networks in Chat Monitor by default

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing interface polish, fixes pull request regression
Risk | ★☆☆ *1/3* | Might not expand networks, possible slight performance penalty
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other pull requests

## Testing
* Ubuntu 16.04 LTS
  * Qt4 build now works properly
  * Qt5 build now works properly
* Windows 7
  * Qt5 build now works properly

## Example
### Before: connected networks collapsed
![Chat Monitor network list showing collapsed connected networks](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/fix-net-expand-filtered/Chat%20Monitor%20list%20collapsed.png#v1 )

### After: connected networks expanded
*List manually scrolled to bottom to show more relevant information*
![Chat Monitor network list showing expanded connected networks](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/fix-net-expand-filtered/Chat%20Monitor%20list%20expanded.png#v1 )