### PR TITLE
Added ctrl+u to clear buffer.

### DIFF
--- a/src/qtui/bufferwidget.cpp
+++ b/src/qtui/bufferwidget.cpp
@@ -228,6 +228,13 @@ bool BufferWidget::eventFilter(QObject *watched, QEvent *event)
         return false;
 
     switch (keyEvent->key()) {
+	case Qt::Key_U:
+		if (!(keyEvent->modifiers() & Qt::ControlModifier))
+			return false;
+		else {
+			inputLine->clear();
+			return true;
+		}
     case Qt::Key_Up:
     case Qt::Key_Down:
         if (!(keyEvent->modifiers() & Qt::ShiftModifier))


### PR DESCRIPTION
The client was unusable for me without the ctrl+u hotkey which clears the buffer from GNU Readline (I believe). So I changed that.

It's a very simple change that should make the line editing more intuitive to users used to GNU Readline.