### PR TITLE
core: Fix Postgres messagesNewerThan wrong buffer

### DIFF
--- a/src/core/SQL/PostgreSQL/20/select_messagesNewerThan.sql
+++ b/src/core/SQL/PostgreSQL/20/select_messagesNewerThan.sql
@@ -2,7 +2,7 @@ SELECT messageid, time,  type, flags, sender, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= $1
-AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = $1)
+AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = $2)
 AND bufferid = $2
 ORDER BY messageid DESC
 LIMIT $3


### PR DESCRIPTION
## In short
* Fix the PostgreSQL `select_messagesNewerThan` statement limiting to the wrong buffer
  * Replace use of message ID `$1` for `bufferid` in inner `SELECT` with the actual buffer ID, `$2`
  * Fixes using the wrong buffer for `lastmsgid` limit, resolving missing messages with unread fetching
  * Fixes regressions from [pull request 273](https://github.com/quassel/quassel/pull/273 ), missed in [pull request 274](https://github.com/quassel/quassel/pull/274 )

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | Fixes missing messages with Postgres unread backlog fetching
Risk | ★☆☆ *1/3* | Variable change shouldn't break more, risk accepted in previous PRs
Intrusiveness | ★★☆ *2/3* | Minor schema change, might interfere with other pull requests

*Apologies for missing this in [pull request 274](https://github.com/quassel/quassel/pull/274 ).  There, I tested that loading backlog worked for new setups.  I did not test on a larger data-set.*

*Note: This does not fix [the client-side issue of generating the invalid IDs](https://github.com/quassel/quassel/pull/274#issuecomment-284205802 ).  That still needs fixed in a follow-up.*

## Example
### Before
*Quassel with unread fetching misses new messages, e.g. `Test` message does not show, Freenode does not show activity in status buffer*
![Backlog fetching set to unread, Quassel client with broken core on PostgreSQL does not show all new messages that happened while disconnected, resulting in a gap](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/fix-sql-postgres-newerthan/Before%20-%20broken%20fetch%2C%20missing%20messages.png#v1 )

### After
*Unread fetching grabs the new messages, e.g. `Test` message does show, Freenode shows activity in status buffer*
![Backlog fetching set to unread, Quassel client with fixed core on PostgreSQL shows all new messages that happened while disconnected, no gaps, etc](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/fix-sql-postgres-newerthan/After%20-%20fixed%20fetch%2C%20showing%20messages.png#v1 )

### Side-by-side (production)
*Quasseldroid uses fixed fetching, Quassel desktop uses unread fetching, both on the `git master` core.  Notice the `#sandstorm` channel and the Freenode status buffer*
![Backlog fetching set to unread, Quassel client with broken core on PostgreSQL misses buffer activity, Quasseldroid set to use fixed fetching works and shows activity](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/fix-sql-postgres-newerthan/Side-by-side%20-%20broken%20fetch.png#v2 )