### PR TITLE
Fix lastseenmsgid updates in PostgreSQL

### DIFF
--- a/src/core/SQL/PostgreSQL/20/update_buffer_lastseen.sql
+++ b/src/core/SQL/PostgreSQL/20/update_buffer_lastseen.sql
@@ -1,3 +1,3 @@
 UPDATE buffer
-SET lastseenmsgid = min(:lastseenmsgid, buffer.lastmsgid)
+SET lastseenmsgid = least(:lastseenmsgid, buffer.lastmsgid)
 WHERE userid = :userid AND bufferid = :bufferid


### PR DESCRIPTION
GH-273 introduced a workaround for the issue where sometimes the
lastseenmsgid for a buffer was set to a msgid not in that buffer.
However, the workaround was incorrect as the "min()" function in
PostgreSQL is an aggregate function for use on a column, not a
function to return the least of a list of values passed in.  The
correct function for use here is "least()".