### PR TITLE
Fix .gitignore accidentally ignoring tracked (and important) files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build*
+/build*
 *.pyc
 tags
 


### PR DESCRIPTION
In short
--------

* Before, all folders with the name `build`, no matter in what subfolder, were ignored by git.
* After, only the `build` folder in the root of the repository will be ignored.

Rationale
---------

The project has several files under `scripts/build/`, which are important to create and generate the Windows installer, Mac OS X package, and configure Snore.

Those files are matched by the ignore rule `build*`, and therefore any change to them is untracked.

This pull requests fixes aforementioned issue.