### PR TITLE
Updated gitignore to ignore files generated by JetBrains IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 build*
 *.pyc
 tags
+/.idea
+/cmake-build-*
 
 # Qt Creator configuration
 CMakeLists.txt.user


### PR DESCRIPTION
In short
--------

* Adds the folders `.idea` and `cmake-build-*` in the main folder of the repo to `.gitignore`.

Rationale
---------

JetBrains IDEs such as CLion store their settings in a `.idea` folder in the root of the project, as well as a cache for indexing the symbols of the project. Additionally, they by default configure cmake to build into `cmake-build-debug` or `cmake-build-release` for their targets.

This PR adds these folders to the `.gitignore`, to prevent users using CLion from accidentally committing these files.

Impact
-------

This PR only affects development, it has no affect on the build outputs, requires no translations or future documentation.

Risk
----

If, at a future point, we introduce a .idea or cmake-build-* folder in the root of the repo, it might accidentally not be tracked. The risk of this happening, due to the how specific the names are, is minimal.