### PR TITLE
Handle errors when saving CoreSettings

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -120,6 +120,17 @@ void Settings::setVersionMinor(const uint versionMinor)
     s.setValue("Config/VersionMinor", versionMinor);
 }
 
+bool Settings::sync() {
+    create_qsettings;
+    s.sync();
+    switch (s.status()) {
+        case QSettings::NoError:
+            return true;
+        default:
+            return false;
+    }
+}
+
 bool Settings::isWritable() {
     create_qsettings;
     return s.isWritable();

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -120,6 +120,10 @@ void Settings::setVersionMinor(const uint versionMinor)
     s.setValue("Config/VersionMinor", versionMinor);
 }
 
+bool Settings::isWritable() {
+    create_qsettings;
+    return s.isWritable();
+}
 
 QStringList Settings::allLocalKeys()
 {

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -83,6 +83,13 @@ public:
      */
     virtual void setVersionMinor(const uint versionMinor);
 
+    /**
+     * Check if the configuration storage is writable.
+     *
+     * @return true if writable, false otherwise
+     */
+    bool isWritable();
+
 protected:
     inline Settings(QString group_, QString appName_) : group(group_), appName(appName_) {}
     inline virtual ~Settings() {}

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -84,6 +84,13 @@ public:
     virtual void setVersionMinor(const uint versionMinor);
 
     /**
+     * Persist unsaved changes to permanent storage
+     *
+     * @return true if succeeded, false otherwise
+     */
+    bool sync();
+
+    /**
      * Check if the configuration storage is writable.
      *
      * @return true if writable, false otherwise

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -299,7 +299,9 @@ QString Core::setupCore(const QString &adminUser, const QString &adminPassword, 
         return tr("Could not setup storage!");
     }
 
-    saveBackendSettings(backend, setupData);
+    if (!saveBackendSettings(backend, setupData)) {
+        return tr("Could not save backend settings, probably a permission problem.");
+    }
 
     quInfo() << qPrintable(tr("Creating admin user..."));
     _storage->addUser(adminUser, adminPassword);
@@ -705,7 +707,9 @@ bool Core::selectBackend(const QString &backend)
     Storage::State storageState = storage->init(settings);
     switch (storageState) {
     case Storage::IsReady:
-        saveBackendSettings(backend, settings);
+        if (!saveBackendSettings(backend, settings)) {
+            qCritical() << qPrintable(QString("Could not save backend settings, probably a permission problem."));
+        }
         qWarning() << "Switched backend to:" << qPrintable(backend);
         qWarning() << "Backend already initialized. Skipping Migration";
         return true;
@@ -723,7 +727,9 @@ bool Core::selectBackend(const QString &backend)
             return false;
         }
 
-        saveBackendSettings(backend, settings);
+        if (!saveBackendSettings(backend, settings)) {
+            qCritical() << qPrintable(QString("Could not save backend settings, probably a permission problem."));
+        }
         qWarning() << "Switched backend to:" << qPrintable(backend);
         break;
     }
@@ -739,7 +745,10 @@ bool Core::selectBackend(const QString &backend)
         storage = 0;
         if (reader->migrateTo(writer)) {
             qDebug() << "Migration finished!";
-            saveBackendSettings(backend, settings);
+            if (!saveBackendSettings(backend, settings)) {
+                qCritical() << qPrintable(QString("Could not save backend settings, probably a permission problem."));
+                return false;
+            }
             return true;
         }
         return false;
@@ -886,12 +895,14 @@ AbstractSqlMigrationWriter *Core::getMigrationWriter(Storage *storage)
 }
 
 
-void Core::saveBackendSettings(const QString &backend, const QVariantMap &settings)
+bool Core::saveBackendSettings(const QString &backend, const QVariantMap &settings)
 {
     QVariantMap dbsettings;
     dbsettings["Backend"] = backend;
     dbsettings["ConnectionProperties"] = settings;
-    CoreSettings().setStorageSettings(dbsettings);
+    CoreSettings s = CoreSettings();
+    s.setStorageSettings(dbsettings);
+    return s.sync();
 }
 
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -194,7 +194,14 @@ void Core::init()
                                         "to work."));
             exit(1); // TODO make this less brutal (especially for mono client -> popup)
         }
+
         qWarning() << "Core is currently not configured! Please connect with a Quassel Client for basic setup.";
+
+        if (!cs.isWritable()) {
+            qWarning() << "Cannot write quasselcore configuration; probably a permission problem.";
+            exit(EXIT_FAILURE);
+        }
+
     }
 
     if (Quassel::isOptionSet("add-user")) {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -573,7 +573,7 @@ private:
     void unregisterStorageBackend(Storage *);
     bool selectBackend(const QString &backend);
     bool createUser();
-    void saveBackendSettings(const QString &backend, const QVariantMap &settings);
+    bool saveBackendSettings(const QString &backend, const QVariantMap &settings);
     QVariantMap promptForSettings(const Storage *storage);
 
 private:


### PR DESCRIPTION
# Problem

For some reason or another, the permissions on `quasselcore.conf` might prohibit the quasselcore user from reading the file.

`QSettings` in this case returns invalid `QVariant` for any `value()` calls and **fails** later when trying to persist the data.
Persisting data happens through event loop, the destructor or `sync()` method.
Failure reporting is done through the `status()` method, not as the return value of a `setValue()` call.

Quassel never present failure of persisting the configuration, because it relies on the event loop and the destructor to save the data.

Coming back to the unreadable / unwritable `quasselcore.conf`, the startup procedure looks like this:

- Core sets the `_configured` variable to `false` because `CoreSettings` returns an empty string for `Backend`. ( [Here](https://github.com/problame/quassel/blob/413748b97c1e5fd3e800ca7031ff8894beebb9a9/src/core/core.cpp#L182) and [here](https://github.com/problame/quassel/blob/413748b97c1e5fd3e800ca7031ff8894beebb9a9/src/core/core.cpp#L374) )
- Thus, the client presents the instance configuration dialog. 
- The user configures the instance
- Things will work until core is stopped and restarted, probably due to a package update.
- The configuration is not readable, thus `CoreSettings` appears to be empty, loop

# Solution

- Assert the configuration can be written when we are `!_configured`. We stop the daemon immediately to avoid any confusion / frustration with the user.
- Save core settings synchronously and report failure, visible in the instance configuration dialog.

# Comment

This bit me for quite some time because I had not taken permission problems into consideration. The above loop rendered the setup not reboot safe and I had to re-configure the core every time the service was restarted.

`CoreSettings` seems like a very leaky abstraction, with particular blind spots regarding error handling.

I am not a C++ / Qt programmer -- please feel free to make this more idiomatic (exceptions?) ;) 