### PR TITLE
[Do Not Merge] core: Fix bulk inserted messages hidden due to LastSeenMsg

### DIFF
--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1511,6 +1511,8 @@ bool PostgreSqlStorage::logMessages(MessageList &msgs)
         else {
             logMessageQuery.first();
             msg.setMsgId(logMessageQuery.value(0).toInt());
+            // Also update the lastseenmsgid for this new message
+            setBufferLastMsg(msg.bufferInfo().bufferId(), msg.msgId());
         }
     }
 

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1587,6 +1587,8 @@ bool SqliteStorage::logMessages(MessageList &msgs)
             }
             else {
                 msg.setMsgId(logMessageQuery.lastInsertId().toInt());
+                // Also update the lastseenmsgid for this new message
+                setBufferLastMsg(msg.bufferInfo().bufferId(), msg.msgId());
             }
         }
     }


### PR DESCRIPTION
## In short
* When logging messages in `logMessages()`, update `LastSeenMsg` for each inserted message
  * Mimics the behavior of `logMessage()`
  * Fixes messages not getting fetched if multiple were queued for inserting
  * Slight overhead by updating for each message, same as behavior for one-at-a-time inserts
  * Fixes regressions from [pull request 273](https://github.com/quassel/quassel/pull/273 )

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | Fixes some messages being hidden when fetching backlog
Risk | ★★☆ *2/3* | Slight performance overhead, though risk accepted in previous PRs
Intrusiveness | ★☆☆ *1/3* | Minor code change, shouldn't interfere with other pull requests

*Apologies for missing this in all the recent other pull requests.  This is a bit harder to trigger as it requires multiple messages getting queued on the core to insert at once.*

*Note: [The client-side issue of generating the invalid IDs](https://github.com/quassel/quassel/pull/274#issuecomment-284205802 ) still needs fixed.*

## Implementation

* When logging messages in bulk via `logMessages()`, update the LastSeenMsg for each inserted message
  * Mimics the behavior of `logMessage()` for both PostgreSQL and SQLite
  * Without fix, bulk-inserting messages in `CoreSession::processMessages()` (*i.e. when `_messageQueue.count() > 1`*) will NOT cause `lastseenmsgid` to get updated, resulting in backlog fetching hiding more recent messages
* Performance concerns
  * Adds slight overhead by updating for each message, same as the behavior for currently-existing one-at-a-time message updates
  * If needed, database performance could be improved with additional memory use by building a dictionary list of key/value buffers/msgID, updating all of them at the end.  Transaction handling would need special care to avoid inconsistent states.

## Example
### Before, database
Due to the [`update_buffer_lastseen.sql` constraints](https://github.com/quassel/quassel/blob/2e8511846057783f507a70621c440a4a81f76c41/src/core/SQL/PostgreSQL/20/update_buffer_lastseen.sql), `lastseenmsgid` is limited to `lastmsgid`, however, manually checking the buffer shows that there are later messages that are valid.

*To save space, some columns were trimmed*
```
quassel=# SELECT * FROM buffer WHERE lastseenmsgid < (SELECT messageid FROM backlog WHERE backlog.bufferid = buffer.bufferid ORDER BY messageid DESC LIMIT 1);
 bufferid | buffername | lastseenmsgid | markerlinemsgid | key | joined | lastmsgid
      375 | #STwA      |       6795886 |         6898868 |     | t      |   6795886

quassel=# SELECT messageid FROM backlog WHERE backlog.bufferid=375 ORDER BY messageid DESC LIMIT 1;
 messageid 
-----------
   6902860
(1 row)
```

The `lastmsgid` of **`6795886`** is much lower than the actual latest message id **`6902860`**.

### Before, client
*Quassel unread backlog fetching misses new bulk-inserted messages, e.g. several days of join/quit messages are missing.  However, loading via additional context (mark channel read, re-launch Quassel) loads the hidden messages.*
![Backlog fetching set to unread, Quassel client above fetching via unread with broken core, does not show all new messages that happened while disconnected, Quassel client below fetching via context, showing the missing messages](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-sql-insert-multi-msg/Before%20-%20fetching%20messages%20via%20unread,%20context.png#v2 )

### After
**No regressions, but unable to test original conditions**

I do not know what triggers bulk message inserting, so I've only verified the fix doesn't cause regressions by forcing the use of `logMessages()` over `logMessage()`.  This works in SQLite and PostgreSQL.

It also *seems* reasonable from inspection, but I've not been able to verify it fixes the issue with the original conditions.

**Testing code:**
```diff
diff --git a/src/core/coresession.cpp b/src/core/coresession.cpp
index 5c377c8..62a2454 100644
--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -358,7 +358,7 @@ void CoreSession::customEvent(QEvent *event)
 
 void CoreSession::processMessages()
 {
-    if (_messageQueue.count() == 1) {
+    if (false) {
         const RawMessage &rawMsg = _messageQueue.first();
         bool createBuffer = !(rawMsg.flags & Message::Redirected);
         BufferInfo bufferInfo = Core::bufferInfo(user(), rawMsg.networkId, rawMsg.bufferType, rawMsg.target, createBuffer);
         if (!bufferInfo.isValid()) {
             Q_ASSERT(!createBuffer);
             bufferInfo = Core::bufferInfo(user(), rawMsg.networkId, BufferInfo::StatusBuffer, "");
         }
         Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender, rawMsg.flags);
         if(Core::storeMessage(msg))
             emit displayMsg(msg);
     }
     else {
         QHash<NetworkId, QHash<QString, BufferInfo> > bufferInfoCache;
```