### PR TITLE
Add 'Configure' to the right-click Menu of a Network in the buffer list

### DIFF
--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -204,6 +204,7 @@ void MainWin::init()
         SLOT(messagesInserted(const QModelIndex &, int, int)));
     connect(GraphicalUi::contextMenuActionProvider(), SIGNAL(showChannelList(NetworkId)), SLOT(showChannelList(NetworkId)));
     connect(Client::instance(), SIGNAL(showChannelList(NetworkId)), SLOT(showChannelList(NetworkId)));
+    connect(GraphicalUi::contextMenuActionProvider(), SIGNAL(showNetworkConfig(NetworkId)), SLOT(showNetworkConfig(NetworkId)));
     connect(GraphicalUi::contextMenuActionProvider(), SIGNAL(showIgnoreList(QString)), SLOT(showIgnoreList(QString)));
     connect(Client::instance(), SIGNAL(showIgnoreList(QString)), SLOT(showIgnoreList(QString)));
 
@@ -1390,6 +1391,15 @@ void MainWin::showChannelList(NetworkId netId)
     channelListDlg->setAttribute(Qt::WA_DeleteOnClose);
     channelListDlg->setNetwork(netId);
     channelListDlg->show();
+}
+
+
+void MainWin::showNetworkConfig(NetworkId netId)
+{
+    SettingsPageDlg dlg(new NetworksSettingsPage(this), this);
+    if (netId.isValid())
+        qobject_cast<NetworksSettingsPage *>(dlg.currentPage())->bufferList_Open(netId);
+    dlg.exec();
 }
 
 

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -119,6 +119,7 @@ private slots:
     void messagesInserted(const QModelIndex &parent, int start, int end);
     void showAboutDlg();
     void showChannelList(NetworkId netId = NetworkId());
+    void showNetworkConfig(NetworkId netId = NetworkId());
     void showCoreConnectionDlg();
     void showCoreConfigWizard(const QVariantList &, const QVariantList &);
     void showCoreInfoDlg();

--- a/src/qtui/settingspages/networkssettingspage.cpp
+++ b/src/qtui/settingspages/networkssettingspage.cpp
@@ -567,6 +567,14 @@ QListWidgetItem *NetworksSettingsPage::insertNetwork(const NetworkInfo &info)
 }
 
 
+// Called when selecting 'Configure' from the buffer list
+void NetworksSettingsPage::bufferList_Open(NetworkId netId)
+{
+    QListWidgetItem *item = networkItem(netId);
+    ui.networkList->setCurrentItem(item, QItemSelectionModel::SelectCurrent);
+}
+
+
 void NetworksSettingsPage::displayNetwork(NetworkId id)
 {
     _ignoreWidgetChanges = true;

--- a/src/qtui/settingspages/networkssettingspage.h
+++ b/src/qtui/settingspages/networkssettingspage.h
@@ -47,6 +47,7 @@ public:
 public slots:
     void save();
     void load();
+    void bufferList_Open(NetworkId);
 
 private slots:
     void widgetHasChanged();

--- a/src/uisupport/contextmenuactionprovider.cpp
+++ b/src/uisupport/contextmenuactionprovider.cpp
@@ -90,6 +90,7 @@ ContextMenuActionProvider::ContextMenuActionProvider(QObject *parent) : NetworkM
     registerAction(HideBufferTemporarily, tr("Hide Chat(s) Temporarily"));
     registerAction(HideBufferPermanently, tr("Hide Chat(s) Permanently"));
     registerAction(ShowChannelList, tr("Show Channel List"));
+    registerAction(ShowNetworkConfig, tr("Configure"));
     registerAction(ShowIgnoreList, tr("Show Ignore List"));
 
     QMenu *hideEventsMenu = new QMenu();
@@ -285,6 +286,8 @@ void ContextMenuActionProvider::addNetworkItemActions(QMenu *menu, const QModelI
     if (!network)
         return;
 
+    addAction(ShowNetworkConfig, menu, index);
+    menu->addSeparator();
     addAction(NetworkConnect, menu, network->connectionState() == Network::Disconnected);
     addAction(NetworkDisconnect, menu, network->connectionState() != Network::Disconnected);
     menu->addSeparator();

--- a/src/uisupport/networkmodelcontroller.cpp
+++ b/src/uisupport/networkmodelcontroller.cpp
@@ -414,6 +414,10 @@ void NetworkModelController::handleGeneralAction(ActionType type, QAction *actio
         if (networkId.isValid())
             emit showChannelList(networkId);
         break;
+    case ShowNetworkConfig:
+        if (networkId.isValid())
+            emit showNetworkConfig(networkId);
+        break;
     case ShowIgnoreList:
         if (networkId.isValid())
             emit showIgnoreList(QString());

--- a/src/uisupport/networkmodelcontroller.h
+++ b/src/uisupport/networkmodelcontroller.h
@@ -75,6 +75,7 @@ public:
         JoinChannel = 0x1000,
         ShowChannelList = 0x2000,
         ShowIgnoreList = 0x3000,
+        ShowNetworkConfig = 0x4000,
 
         // Nick actions
         NickMask = 0xff0000,
@@ -154,6 +155,7 @@ protected slots:
 
 signals:
     void showChannelList(NetworkId);
+    void showNetworkConfig(NetworkId);
     void showIgnoreList(QString);
 
 protected:


### PR DESCRIPTION
This adds a menu item of 'Configure' to the right-click menu for a Network in the buffer list.
Clicking on 'Configure' will open the Configure Networks dialog to the respective Network's settings.

**Use-Case:** 
* Large network lists, when you need to make a change to a network...it's now just a click away instead of going through the Main Menu or the Main Settings dialog.
* Continuous modification of Networks, ie: IRC Development, TestNets, etc.

**Impact:**
* 'Configure' is added above 'Disconnect/Connect', this could cause some users to re-learn habits if they are very used to using the 'Disconnect/Connect' items in this menu.

**Testing:**
Tested this with:
* A single, connected Network (as seen below)
* A single, disconnected Network
* Multiple Networks, both connected and disconnected

Every method provides the expected results and no crashes.

![quassel-configure](https://cloud.githubusercontent.com/assets/16250417/24326949/7a9718b0-1180-11e7-8165-5f63d6e6fc39.png)

_This is my first time working with Qt code, my apologies if this is done horribly wrong._ Any comments, suggestions, etc are welcome!
