### PR TITLE
Pick first IRC server specified when not failed

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -214,12 +214,16 @@ void CoreNetwork::connectToIrc(bool reconnecting)
     }
     else if (_previousConnectionAttemptFailed) {
         // cycle to next server if previous connection attempt failed
+        _previousConnectionAttemptFailed = false;
         displayMsg(Message::Server, BufferInfo::StatusBuffer, "", tr("Connection failed. Cycling to next Server"));
         if (++_lastUsedServerIndex >= serverList().size()) {
             _lastUsedServerIndex = 0;
         }
     }
-    _previousConnectionAttemptFailed = false;
+    else {
+        // Start out with the top server in the list
+        _lastUsedServerIndex = 0;
+    }
 
     Server server = usedServer();
     displayStatusMsg(tr("Connecting to %1:%2...").arg(server.host).arg(server.port));


### PR DESCRIPTION
With this change, any connect to an IRC Server on initial core start, first connect to new network, or a manual connect after a manual disconnect will use the first server in the Network's server list. This seems to be the intended behavior as there is an ordered list of servers.
Currently Quassel will keep connecting to the last used and working server regardless of position in the list. It would only change servers if the connection fails. There is also the 'useRandomServer' flag, which I believe might be disabled in the SettingsPages right now (or I'm totally missing it). Either way, that behavior is untouched and will still use a random server if enabled.

I also moved the clearing of the '_previousConnectionAttemptFailed' flag to only when it was 'true' and we're trying the next server in the list.

**Use-Case:**
- Please refer to the two issues referenced below as they explain the use cases.

**Impact:**
- Minor to no negative impact on users as this changes nothing user-facing.
- A minor positive impact should be noted as the ordered server list will be used as intended.

**Testing:**
- Please see below comment from @digitalcircuit as he performed a set of testing. I failed to include my testing originally in this PR.

Reference: http://bugs.quassel-irc.org/issues/693
And: http://bugs.quassel-irc.org/issues/1006
Fixes #693 and #1006