### PR TITLE
core: Fix timestamps in manual /away messages

### DIFF
--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -662,8 +662,9 @@ void CoreSession::clientsDisconnected()
 
         if (identity->detachAwayEnabled() && !me->isAway()) {
             if (!identity->detachAwayReason().isEmpty())
-                awayReason = formatCurrentDateTimeInString(identity->detachAwayReason());
+                awayReason = identity->detachAwayReason();
             net->setAutoAwayActive(true);
+            // Allow handleAway() to format the current date/time in the string.
             net->userInputHandler()->handleAway(BufferInfo(), awayReason);
         }
     }

--- a/src/core/coreuserinputhandler.h
+++ b/src/core/coreuserinputhandler.h
@@ -49,7 +49,7 @@ public slots:
      * @param[in] skipFormatting  If true, skip timestamp formatting codes (e.g. if already done)
      */
     void handleAway(const BufferInfo &bufferInfo, const QString &text,
-                    const bool skipFormatting = true);
+                    const bool skipFormatting = false);
     void handleBan(const BufferInfo &bufferInfo, const QString &text);
     void handleUnban(const BufferInfo &bufferInfo, const QString &text);
     void handleCtcp(const BufferInfo &bufferInfo, const QString &text);


### PR DESCRIPTION
## In short
* Apply custom timestamps to manual `/away` messages, too
  * This was the original intent of [pull request #270](https://github.com/quassel/quassel/pull/270)
  * Makes `/away` consistent with automatic away settings

*For more information, see [pull request #270](https://github.com/quassel/quassel/pull/270)*

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Makes `/away` consistent, fixes mistake in [pull request #270](https://github.com/quassel/quassel/pull/270)
Risk | ★☆☆ *1/3* | Might result in timestamps getting formatted twice
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other PRs

## Examples
### After, manual `/away` working
**Specified away message**
```
/away Away since %%h:mm ap%% (%%t%%) on %%yyyy-MM-dd%% - %%%% %%%%%%%%be back later%%%%%%%% %%%%
```

**Resulting away message**
```
* [Whois] digitalcircuit is away: "Away since 7:28 pm (CDT) on 2017-04-13 - %% %%%%be back later%%%% %%"
```

Closing the Quassel client and restarting the core does *not* result in double-parsing the away message, working as intended.

### Before, manual `/away` broken
**Specified away message**
```
/away Away since %%h:mm ap%% (%%t%%) on %%yyyy-MM-dd%% - %%%% %%%%%%%%be back later%%%%%%%% %%%%
```

**Resulting away message**
```
* [Whois] digitalcircuit is away: "Away since %%h:mm ap%% (%%t%%) on %%yyyy-MM-dd%% - %%%% %%%%%%%%be back later%%%%%%%% %%%%"
```