### PR TITLE
Prevent DNS leaks on connection when using proxy

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -242,8 +242,10 @@ void CoreNetwork::connectToIrc(bool reconnecting)
     // Qt caches DNS entries for a minute, resulting in round-robin (e.g. for chat.freenode.net) not working if several users
     // connect at a similar time. QHostInfo::fromName(), however, always performs a fresh lookup, overwriting the cache entry.
     if (! server.useProxy) {
-		QHostInfo::fromName(server.host);
-	}
+        //Avoid hostname lookups when a proxy is specified. The lookups won't use the proxy and may therefore leak the DNS
+        //hostname of the server. Qt's DNS cache also isn't used by the proxy so we don't need to refresh the entry.
+        QHostInfo::fromName(server.host);
+    }
 #ifdef HAVE_SSL
     if (server.useSsl) {
         CoreIdentity *identity = identityPtr();

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -241,8 +241,9 @@ void CoreNetwork::connectToIrc(bool reconnecting)
 
     // Qt caches DNS entries for a minute, resulting in round-robin (e.g. for chat.freenode.net) not working if several users
     // connect at a similar time. QHostInfo::fromName(), however, always performs a fresh lookup, overwriting the cache entry.
-    QHostInfo::fromName(server.host);
-
+    if (! server.useProxy) {
+		QHostInfo::fromName(server.host);
+	}
 #ifdef HAVE_SSL
     if (server.useSsl) {
         CoreIdentity *identity = identityPtr();


### PR DESCRIPTION
After using tcpdump on my server I realized that I was seeing DNS queries that only quassel should be making. However, for those a proxy (tor) has been configured, so I shouldn't have seen them. This implied a DNS leak in quassel. 

96fe7e713 introduced a call to QHostInfo::fromName() in order to avoid problems related to the caching of DNS queries. It however is also called when the user has specified that a proxy should be used. This behavior therefore introduces a DNS leak.

This commit ensures that QHostInfo::fromName() is not called when a proxy has been specified.