### PR TITLE
Remove old 'remove buffer' KeyPress code

### DIFF
--- a/src/uisupport/bufferview.cpp
+++ b/src/uisupport/bufferview.cpp
@@ -217,16 +217,6 @@ void BufferView::joinChannel(const QModelIndex &index)
 }
 
 
-void BufferView::keyPressEvent(QKeyEvent *event)
-{
-    if (event->key() == Qt::Key_Backspace || event->key() == Qt::Key_Delete) {
-        event->accept();
-        removeSelectedBuffers();
-    }
-    TreeViewTouch::keyPressEvent(event);
-}
-
-
 void BufferView::dropEvent(QDropEvent *event)
 {
     QModelIndex index = indexAt(event->pos());
@@ -592,13 +582,6 @@ void BufferView::hideCurrentBuffer()
     //The check above means we won't be looking at a network, which should always be the first row, so we can just go backwards.
     changeBuffer(Backward);
 
-    /*if(removedRows.contains(bufferId))
-      continue;
-
-    removedRows << bufferId;*/
-    /*if(permanently)
-      config()->requestRemoveBufferPermanently(bufferId);
-    else*/
     config()->requestRemoveBuffer(bufferId);
 }
 

--- a/src/uisupport/bufferview.h
+++ b/src/uisupport/bufferview.h
@@ -75,7 +75,6 @@ signals:
     void removeBufferPermanently(const QModelIndex &);
 
 protected:
-    virtual void keyPressEvent(QKeyEvent *);
     virtual void dropEvent(QDropEvent *event);
     virtual void rowsInserted(const QModelIndex &parent, int start, int end);
     virtual void wheelEvent(QWheelEvent *);


### PR DESCRIPTION
This removes a (unnecessary) KeyPress event in the BufferView (list). Currently `Delete` or `Backspace` will remove the currently selected buffer (only when the buffer list is in focus).
Since commit 9f33f6e4 a 'hide current buffer' global application shortcut is available. That removes the need for this KeyPress event (imho).
Reference: http://bugs.quassel-irc.org/issues/668

IRC users have also expressed dislike in the use of `Backspace` for this buffer removal shortcut. Some cases allow for easy accidental buffer removals.
That being said **if people are opposed** to losing this function, would dropping `Backspace` and just using `Delete` be a suitable solution?

This PR removes the 'KeyPress' event (entire function) as it no longer has a use.
Also cleans up the 'hideCurrentBuffer' code, removing commented code that really has no use-case with a keyboard shortcut.

Reference: http://bugs.quassel-irc.org/issues/1403
Fixes #1403
_[1402](http://bugs.quassel-irc.org/issues/1402) is a similar bug, but not **entirely** caused by this KeyPress event._

#### Impact:
- Some users may still use this KeyPress event and will need to learn to use the Keyboard Shortcut instead.
- Keyboard Shortcut cannot be `Delete` or `Backspace` as it needs a Modifier key (I believe).

#### Testing:
- Nothing to show graphically or by logs
- Has been compiled and tested; works as expected
- No noticed side effects