### PR TITLE
core: Stop ratelimiting log spam with old client

### DIFF
--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -731,8 +731,8 @@ void Network::setMessageRateBurstSize(quint32 burstSize)
     if (burstSize < 1) {
         // Can't go slower than one message at a time.  Also blocks old clients from trying to set
         // this to 0.
-        qWarning() << "Received invalid setMessageRateBurstSize data - message burst size must be "
-                      "non-zero positive, given" << burstSize;
+        qDebug() << "Received invalid setMessageRateBurstSize data - message burst size must be "
+                    "non-zero positive, given" << burstSize;
         return;
     }
     if (_messageRateBurstSize != burstSize) {
@@ -749,8 +749,8 @@ void Network::setMessageRateDelay(quint32 messageDelay)
     if (messageDelay == 0) {
         // Nonsensical to have no delay - just check the Unlimited box instead.  Also blocks old
         // clients from trying to set this to 0.
-        qWarning() << "Received invalid setMessageRateDelay data - message delay must be non-zero "
-                      "positive, given" << messageDelay;
+        qDebug() << "Received invalid setMessageRateDelay data - message delay must be non-zero "
+                    "positive, given" << messageDelay;
         return;
     }
     if (_messageRateDelay != messageDelay) {

--- a/src/common/network.h
+++ b/src/common/network.h
@@ -268,7 +268,7 @@ public :
      *
      * These results aren't valid if the network is disconnected or capability negotiation hasn't
      * happened, and some servers might not correctly advertise capabilities.  Don't treat this as
-     * a guarentee.
+     * a guarantee.
      *
      * @param[in] capability Name of capability
      * @returns True if connected and advertised by the server, otherwise false


### PR DESCRIPTION
## In short
* Downgrade log messages about invalid rate limits
  * Happens when an older client tries to configure a network for a newer core
  * Reduces needless clutter in the log files, still accessible via log level
  * Matches original intent of [implementing pull request #252](https://github.com/quassel/quassel/pull/252 )
* Fix typo in `Network::capAvailable()` comment docs

*For more information, see [pull request #252](https://github.com/quassel/quassel/pull/252 )*

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Makes actual warnings more obvious
Risk | ★☆☆ *1/3* | Might obscure issues with invalid rate limits in the future
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other PRs

## Examples
### After
```
2016-09-21 19:46:07 Debug: Received invalid setMessageRateBurstSize data - message burst size must be non-zero positive, given 0 
2016-09-21 19:46:07 Debug: Received invalid setMessageRateDelay data - message delay must be non-zero positive, given 0
```
*These would be hidden with the default logging level of `info`*

### Before
```
2016-09-21 19:46:07 Warning: Received invalid setMessageRateBurstSize data - message burst size must be non-zero positive, given 0 
2016-09-21 19:46:07 Warning: Received invalid setMessageRateDelay data - message delay must be non-zero positive, given 0
```

*This is a trivial change discovered when testing the LDAP authenticator pull request.*