### PR TITLE
Let users see a list of their own connected clients, and disconnect them

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -160,6 +160,8 @@ void Client::init()
     p->attachSignal(this, SIGNAL(requestPasswordChange(PeerPtr,QString,QString,QString)), SIGNAL(changePassword(PeerPtr,QString,QString,QString)));
     p->attachSlot(SIGNAL(passwordChanged(PeerPtr,bool)), this, SLOT(corePasswordChanged(PeerPtr,bool)));
 
+    p->attachSignal(this, SIGNAL(requestKickClient(int)), SIGNAL(kickClient(int)));
+
     //connect(mainUi(), SIGNAL(connectToCore(const QVariantMap &)), this, SLOT(connectToCore(const QVariantMap &)));
     connect(mainUi(), SIGNAL(disconnectFromCore()), this, SLOT(disconnectFromCore()));
     connect(this, SIGNAL(connected()), mainUi(), SLOT(connectedToCore()));
@@ -674,6 +676,11 @@ void Client::changePassword(const QString &oldPassword, const QString &newPasswo
     account.setPassword(newPassword);
     coreAccountModel()->createOrUpdateAccount(account);
     emit instance()->requestPasswordChange(nullptr, account.user(), oldPassword, newPassword);
+}
+
+
+void Client::kickClient(int peerId) {
+    emit instance()->requestKickClient(peerId);
 }
 
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -161,6 +161,7 @@ void Client::init()
     p->attachSlot(SIGNAL(passwordChanged(PeerPtr,bool)), this, SLOT(corePasswordChanged(PeerPtr,bool)));
 
     p->attachSignal(this, SIGNAL(requestKickClient(int)), SIGNAL(kickClient(int)));
+    p->attachSlot(SIGNAL(disconnectFromCore()), this, SLOT(disconnectFromCore()));
 
     //connect(mainUi(), SIGNAL(connectToCore(const QVariantMap &)), this, SLOT(connectToCore(const QVariantMap &)));
     connect(mainUi(), SIGNAL(disconnectFromCore()), this, SLOT(disconnectFromCore()));
@@ -679,7 +680,8 @@ void Client::changePassword(const QString &oldPassword, const QString &newPasswo
 }
 
 
-void Client::kickClient(int peerId) {
+void Client::kickClient(int peerId)
+{
     emit instance()->requestKickClient(peerId);
 }
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -147,6 +147,7 @@ public:
     static void purgeKnownBufferIds();
 
     static void changePassword(const QString &oldPassword, const QString &newPassword);
+    static void kickClient(int peerId);
 
 #if QT_VERSION < 0x050000
     static void logMessage(QtMsgType type, const char *msg);
@@ -199,6 +200,8 @@ signals:
 
     //! Requests a password change (user name must match the currently logged in user)
     void requestPasswordChange(PeerPtr peer, const QString &userName, const QString &oldPassword, const QString &newPassword);
+
+    void requestKickClient(int peerId);
     void passwordChanged(bool success);
 
 public slots:

--- a/src/common/internalpeer.cpp
+++ b/src/common/internalpeer.cpp
@@ -58,6 +58,15 @@ QString InternalPeer::description() const
     return tr("internal connection");
 }
 
+QString InternalPeer::address() const
+{
+    return tr("internal connection");
+}
+
+quint16 InternalPeer::port() const
+{
+    return 0;
+}
 
 bool InternalPeer::isOpen() const
 {

--- a/src/common/internalpeer.h
+++ b/src/common/internalpeer.h
@@ -45,6 +45,9 @@ public:
     Protocol::Type protocol() const { return Protocol::InternalProtocol; }
     QString description() const;
 
+    virtual QString address() const;
+    virtual quint16 port() const;
+
     SignalProxy *signalProxy() const;
     void setSignalProxy(SignalProxy *proxy);
 

--- a/src/common/peer.cpp
+++ b/src/common/peer.cpp
@@ -33,6 +33,37 @@ AuthHandler *Peer::authHandler() const
     return _authHandler;
 }
 
+const QDateTime &Peer::connectedSince() const {
+    return _connectedSince;
+}
+
+void Peer::setConnectedSince(const QDateTime &connectedSince) {
+    _connectedSince = connectedSince;
+}
+
+const QString &Peer::buildDate() const {
+    return _buildDate;
+}
+
+void Peer::setBuildDate(const QString &buildDate) {
+    _buildDate = buildDate;
+}
+
+const QString &Peer::clientVersion() const {
+    return _clientVersion;
+}
+
+void Peer::setClientVersion(const QString &clientVersion) {
+    _clientVersion = clientVersion;
+}
+
+int Peer::id() const {
+    return _id;
+}
+
+void Peer::setId(int id) {
+    _id = id;
+}
 
 // PeerPtr is used in RPC signatures for enabling receivers to send replies
 // to a particular peer rather than broadcast to all connected ones.

--- a/src/common/peer.h
+++ b/src/common/peer.h
@@ -50,8 +50,12 @@ public:
 
     virtual int lag() const = 0;
 
+    virtual QString address() const = 0;
+    virtual quint16 port() const = 0;
+
     int _id = -1;
 
+    QDateTime _connectedSince;
     QString _buildDate;
     QString _clientVersion;
 

--- a/src/common/peer.h
+++ b/src/common/peer.h
@@ -34,13 +34,25 @@ class Peer : public QObject
     Q_OBJECT
 
 public:
-    Peer(AuthHandler *authHandler, QObject *parent = 0);
+    explicit Peer(AuthHandler *authHandler, QObject *parent = 0);
 
     virtual Protocol::Type protocol() const = 0;
     virtual QString description() const = 0;
 
     virtual SignalProxy *signalProxy() const = 0;
     virtual void setSignalProxy(SignalProxy *proxy) = 0;
+
+    const QDateTime &connectedSince() const;
+    void setConnectedSince(const QDateTime &connectedSince);
+
+    const QString &buildDate() const;
+    void setBuildDate(const QString &buildDate);
+
+    const QString &clientVersion() const;
+    void setClientVersion(const QString &clientVersion);
+
+    int id() const;
+    void setId(int id);
 
     AuthHandler *authHandler() const;
 
@@ -52,12 +64,6 @@ public:
 
     virtual QString address() const = 0;
     virtual quint16 port() const = 0;
-
-    int _id = -1;
-
-    QDateTime _connectedSince;
-    QString _buildDate;
-    QString _clientVersion;
 
 public slots:
     /* Handshake messages */
@@ -91,6 +97,13 @@ protected:
 
 private:
     QPointer<AuthHandler> _authHandler;
+
+    QDateTime _connectedSince;
+
+    QString _buildDate;
+    QString _clientVersion;
+
+    int _id = -1;
 };
 
 // We need to special-case Peer* in attached signals/slots, so typedef it for the meta type system

--- a/src/common/peer.h
+++ b/src/common/peer.h
@@ -50,6 +50,11 @@ public:
 
     virtual int lag() const = 0;
 
+    int _id = -1;
+
+    QString _buildDate;
+    QString _clientVersion;
+
 public slots:
     /* Handshake messages */
     virtual void dispatch(const Protocol::RegisterClient &) = 0;

--- a/src/common/remotepeer.cpp
+++ b/src/common/remotepeer.cpp
@@ -91,6 +91,22 @@ QString RemotePeer::description() const
     return QString();
 }
 
+QString RemotePeer::address() const
+{
+    if (socket())
+        return socket()->peerAddress().toString();
+
+    return QString();
+}
+
+quint16 RemotePeer::port() const
+{
+    if (socket())
+        return socket()->peerPort();
+
+    return 0;
+}
+
 
 ::SignalProxy *RemotePeer::signalProxy() const
 {

--- a/src/common/remotepeer.h
+++ b/src/common/remotepeer.h
@@ -49,6 +49,9 @@ public:
     virtual QString description() const;
     virtual quint16 enabledFeatures() const { return 0; }
 
+    virtual QString address() const;
+    virtual quint16 port() const;
+
     bool isOpen() const;
     bool isSecure() const;
     bool isLocal() const;

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -838,12 +838,12 @@ Peer *SignalProxy::peerById(int peerId) {
     return _peerMap[peerId];
 }
 
-void SignalProxy::restrictTargetPeers(std::initializer_list<Peer *> peers, std::function<void()> closure)
+void SignalProxy::restrictTargetPeers(QSet<Peer*> peers, std::function<void()> closure)
 {
     auto previousRestrictMessageTarget = _restrictMessageTarget;
     auto previousRestrictedTargets = _restrictedTargets;
     _restrictMessageTarget = true;
-    _restrictedTargets = QSet<Peer*>(peers);
+    _restrictedTargets = peers;
 
     closure();
 

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -290,6 +290,7 @@ bool SignalProxy::addPeer(Peer *peer)
 
     if (peer->_id < 0) {
         peer->_id = nextPeerId();
+        peer->_connectedSince = QDateTime::currentDateTimeUtc();
     }
 
     _peers.insert(peer);
@@ -821,9 +822,10 @@ QVariantList SignalProxy::peerData() {
     for (auto peer : _peers) {
         QVariantMap data;
         data["id"] = peer->_id;
-        data["buildData"] = peer->_buildDate;
         data["clientVersion"] = peer->_clientVersion;
-        data["description"] = peer->description();
+        data["clientVersionDate"] = peer->_buildDate;
+        data["remoteAddress"] = peer->address();
+        data["connectedSince"] = peer->_connectedSince;
         data["secure"] = peer->isSecure();
         result << data;
     }

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -825,6 +825,8 @@ QVariantList SignalProxy::peerData() {
         QVariantMap data;
         data["id"] = peer->_id;
         data["clientVersion"] = peer->_clientVersion;
+        // We explicitly rename this, as, due to the Debian reproducability changes, buildDate isn’t actually the build
+        // date anymore, but on newer clients the date of the last git commit
         data["clientVersionDate"] = peer->_buildDate;
         data["remoteAddress"] = peer->address();
         data["connectedSince"] = peer->_connectedSince;

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -288,7 +288,12 @@ bool SignalProxy::addPeer(Peer *peer)
     if (!peer->parent())
         peer->setParent(this);
 
+    if (peer->_id < 0) {
+        peer->_id = nextPeerId();
+    }
+
     _peers.insert(peer);
+    _peerMap[peer->_id] = peer;
 
     peer->setSignalProxy(this);
 
@@ -331,6 +336,7 @@ void SignalProxy::removePeer(Peer *peer)
     disconnect(peer, 0, this, 0);
     peer->setSignalProxy(0);
 
+    _peerMap.remove(peer->_id);
     _peers.remove(peer);
     emit peerRemoved(peer);
 
@@ -808,6 +814,24 @@ void SignalProxy::updateSecureState()
 
     if (wasSecure != _secure)
         emit secureStateChanged(_secure);
+}
+
+QVariantList SignalProxy::peerData() {
+    QVariantList result;
+    for (auto peer : _peers) {
+        QVariantMap data;
+        data["id"] = peer->_id;
+        data["buildData"] = peer->_buildDate;
+        data["clientVersion"] = peer->_clientVersion;
+        data["description"] = peer->description();
+        data["secure"] = peer->isSecure();
+        result << data;
+    }
+    return result;
+}
+
+Peer *SignalProxy::peerById(int peerId) {
+    return _peerMap[peerId];
 }
 
 

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -24,6 +24,8 @@
 #include <QEvent>
 #include <QSet>
 
+#include <functional>
+
 #include "protocol.h"
 
 struct QMetaObject;

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -83,7 +83,21 @@ public:
      * @param peerIds A list of peers that should receive it
      * @param closure Code you want to execute within of that restricted environment
      */
-    void restrictTargetPeers(std::initializer_list<Peer *> peerIds, std::function<void()> closure);
+    void restrictTargetPeers(QSet<Peer*> peers, std::function<void()> closure);
+    void restrictTargetPeers(Peer *peer, std::function<void()> closure) {
+        QSet<Peer*> set;
+        set.insert(peer);
+        restrictTargetPeers(set, std::move(closure));
+    }
+
+    //A better version, but only implemented on Qt5 if Initializer Lists exist
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#ifdef Q_COMPILER_INITIALIZER_LISTS
+    void restrictTargetPeers(std::initializer_list<Peer*> peers, std::function<void()> closure) {
+        restrictTargetPeers(QSet(peers), std::move(closure));
+    }
+#endif
+#endif
 
     inline int peerCount() const { return _peers.size(); }
     QVariantList peerData();

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -78,6 +78,7 @@ public:
     void dumpProxyStats();
     void dumpSyncMap(SyncableObject *object);
 
+    /**@{*/
     /**
      * This method allows to send a signal only to a limited set of peers
      * @param peerIds A list of peers that should receive it
@@ -94,10 +95,11 @@ public:
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #ifdef Q_COMPILER_INITIALIZER_LISTS
     void restrictTargetPeers(std::initializer_list<Peer*> peers, std::function<void()> closure) {
-        restrictTargetPeers(QSet(peers), std::move(closure));
+        restrictTargetPeers(QSet<Peer*>(peers), std::move(closure));
     }
 #endif
 #endif
+    /**}@*/
 
     inline int peerCount() const { return _peers.size(); }
     QVariantList peerData();

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -77,6 +77,9 @@ public:
     bool isSecure() const { return _secure; }
     void dumpProxyStats();
     void dumpSyncMap(SyncableObject *object);
+
+    void restrictTargetPeers(std::initializer_list<Peer *> peerIds, std::function<void()> closure);
+
     inline int peerCount() const { return _peers.size(); }
     QVariantList peerData();
 
@@ -171,6 +174,9 @@ private:
     bool _secure; // determines if all connections are in a secured state (using ssl or internal connections)
 
     int _lastPeerId = 0;
+
+    QSet<Peer *> _restrictedTargets;
+    bool _restrictMessageTarget = false;
 
     friend class SignalRelay;
     friend class SyncableObject;

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -78,6 +78,9 @@ public:
     void dumpProxyStats();
     void dumpSyncMap(SyncableObject *object);
     inline int peerCount() const { return _peers.size(); }
+    QVariantList peerData();
+
+    Peer *peerById(int peerId);
 
 public slots:
     void detachObject(QObject *obj);
@@ -117,6 +120,10 @@ private:
     void removePeer(Peer *peer);
     void removeAllPeers();
 
+    int nextPeerId() {
+        return _lastPeerId++;
+    }
+
     template<class T>
     void dispatch(const T &protoMessage);
     template<class T>
@@ -140,6 +147,7 @@ private:
     static void disconnectDevice(QIODevice *dev, const QString &reason = QString());
 
     QSet<Peer *> _peers;
+    QHash<int, Peer*> _peerMap;
 
     // containg a list of argtypes for fast access
     QHash<const QMetaObject *, ExtendedMetaObject *> _extendedMetaObjects;
@@ -161,6 +169,8 @@ private:
     int _maxHeartBeatCount;
 
     bool _secure; // determines if all connections are in a secured state (using ssl or internal connections)
+
+    int _lastPeerId = 0;
 
     friend class SignalRelay;
     friend class SyncableObject;

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -83,7 +83,7 @@ public:
     /**@{*/
     /**
      * This method allows to send a signal only to a limited set of peers
-     * @param peerIds A list of peers that should receive it
+     * @param peers A list of peers that should receive it
      * @param closure Code you want to execute within of that restricted environment
      */
     void restrictTargetPeers(QSet<Peer*> peers, std::function<void()> closure);
@@ -103,7 +103,7 @@ public:
 #endif
     /**}@*/
 
-    inline int peerCount() const { return _peers.size(); }
+    inline int peerCount() const { return _peerMap.size(); }
     QVariantList peerData();
 
     Peer *peerById(int peerId);
@@ -177,7 +177,6 @@ private:
 
     static void disconnectDevice(QIODevice *dev, const QString &reason = QString());
 
-    QSet<Peer *> _peers;
     QHash<int, Peer*> _peerMap;
 
     // containg a list of argtypes for fast access
@@ -206,7 +205,7 @@ private:
     QSet<Peer *> _restrictedTargets;
     bool _restrictMessageTarget = false;
 
-    Peer *_sourcePeer;
+    Peer *_sourcePeer = nullptr;
 
     friend class SignalRelay;
     friend class SyncableObject;

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -78,12 +78,22 @@ public:
     void dumpProxyStats();
     void dumpSyncMap(SyncableObject *object);
 
+    /**
+     * This method allows to send a signal only to a limited set of peers
+     * @param peerIds A list of peers that should receive it
+     * @param closure Code you want to execute within of that restricted environment
+     */
     void restrictTargetPeers(std::initializer_list<Peer *> peerIds, std::function<void()> closure);
 
     inline int peerCount() const { return _peers.size(); }
     QVariantList peerData();
 
     Peer *peerById(int peerId);
+
+    /**
+     * @return If handling a signal, the Peer from which the current signal originates
+     */
+    Peer *sourcePeer() { return _sourcePeer; }
 
 public slots:
     void detachObject(QObject *obj);
@@ -177,6 +187,8 @@ private:
 
     QSet<Peer *> _restrictedTargets;
     bool _restrictMessageTarget = false;
+
+    Peer *_sourcePeer;
 
     friend class SignalRelay;
     friend class SyncableObject;

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -179,6 +179,9 @@ void CoreAuthHandler::handle(const RegisterClient &msg)
     // useSsl is only used for the legacy protocol
     _peer->dispatch(ClientRegistered(Quassel::features(), configured, backends, useSsl));
 
+    _peer->_buildDate = msg.buildDate;
+    _peer->_clientVersion = msg.clientVersion;
+
     if (_legacy && useSsl)
         startSsl();
 

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -179,8 +179,8 @@ void CoreAuthHandler::handle(const RegisterClient &msg)
     // useSsl is only used for the legacy protocol
     _peer->dispatch(ClientRegistered(Quassel::features(), configured, backends, useSsl));
 
-    _peer->_buildDate = msg.buildDate;
-    _peer->_clientVersion = msg.clientVersion;
+    _peer->setBuildDate(msg.buildDate);
+    _peer->setClientVersion(msg.clientVersion);
 
     if (_legacy && useSsl)
         startSsl();

--- a/src/core/corecoreinfo.cpp
+++ b/src/core/corecoreinfo.cpp
@@ -40,5 +40,6 @@ QVariantMap CoreCoreInfo::coreData() const
     data["quasselBuildDate"] = Quassel::buildInfo().commitDate; // "BuildDate" for compatibility
     data["startTime"] = Core::instance()->startTime();
     data["sessionConnectedClients"] = _coreSession->signalProxy()->peerCount();
+    data["sessionConnectedClientData"] = _coreSession->signalProxy()->peerData();
     return data;
 }

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -689,8 +689,9 @@ void CoreSession::globalAway(const QString &msg, const bool skipFormatting)
     }
 }
 
-void CoreSession::changePassword(PeerPtr peer, const QString &userName, const QString &oldPassword, const QString &newPassword)
-{
+void CoreSession::changePassword(PeerPtr peer, const QString &userName, const QString &oldPassword, const QString &newPassword) {
+    Q_UNUSED(peer);
+
     bool success = false;
     UserId uid = Core::validateUser(userName, oldPassword);
     if (uid.isValid() && uid == user())

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -105,6 +105,8 @@ CoreSession::CoreSession(UserId uid, bool restoreState, QObject *parent)
     p->attachSlot(SIGNAL(changePassword(PeerPtr,QString,QString,QString)), this, SLOT(changePassword(PeerPtr,QString,QString,QString)));
     p->attachSignal(this, SIGNAL(passwordChanged(PeerPtr,bool)));
 
+    p->attachSlot(SIGNAL(kickClient(int)), this, SLOT(kickClient(int)));
+
     loadSettings();
     initScriptEngine();
 
@@ -694,4 +696,12 @@ void CoreSession::changePassword(PeerPtr peer, const QString &userName, const QS
         success = Core::changeUserPassword(uid, newPassword);
 
     emit passwordChanged(peer, success);
+}
+
+void CoreSession::kickClient(int peerId) {
+    auto peer = signalProxy()->peerById(peerId);
+    if (!peer) {
+        qWarning() << "Invalid peer Id: " << peerId;
+    }
+    peer->close("Terminated by user action");
 }

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -106,6 +106,7 @@ CoreSession::CoreSession(UserId uid, bool restoreState, QObject *parent)
     p->attachSignal(this, SIGNAL(passwordChanged(PeerPtr,bool)));
 
     p->attachSlot(SIGNAL(kickClient(int)), this, SLOT(kickClient(int)));
+    p->attachSignal(this, SIGNAL(disconnectFromCore()));
 
     loadSettings();
     initScriptEngine();
@@ -699,9 +700,15 @@ void CoreSession::changePassword(PeerPtr peer, const QString &userName, const QS
 }
 
 void CoreSession::kickClient(int peerId) {
+    qWarning() << "kickClient(" << peerId << ")";
+
     auto peer = signalProxy()->peerById(peerId);
-    if (!peer) {
+    if (peer == nullptr) {
         qWarning() << "Invalid peer Id: " << peerId;
+        return;
     }
-    peer->close("Terminated by user action");
+    signalProxy()->restrictTargetPeers({peer}, [&]{
+        qWarning() << "executing closure";
+        emit disconnectFromCore();
+    });
 }

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -696,7 +696,7 @@ void CoreSession::changePassword(PeerPtr peer, const QString &userName, const QS
     if (uid.isValid() && uid == user())
         success = Core::changeUserPassword(uid, newPassword);
 
-    signalProxy()->restrictTargetPeers({signalProxy()->sourcePeer()}, [&]{
+    signalProxy()->restrictTargetPeers(signalProxy()->sourcePeer(), [&]{
         emit passwordChanged(nullptr, success);
     });
 }
@@ -707,7 +707,7 @@ void CoreSession::kickClient(int peerId) {
         qWarning() << "Invalid peer Id: " << peerId;
         return;
     }
-    signalProxy()->restrictTargetPeers({peer}, [&]{
+    signalProxy()->restrictTargetPeers(peer, [&]{
         emit disconnectFromCore();
     });
 }

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -696,19 +696,18 @@ void CoreSession::changePassword(PeerPtr peer, const QString &userName, const QS
     if (uid.isValid() && uid == user())
         success = Core::changeUserPassword(uid, newPassword);
 
-    emit passwordChanged(peer, success);
+    signalProxy()->restrictTargetPeers({signalProxy()->sourcePeer()}, [&]{
+        emit passwordChanged(nullptr, success);
+    });
 }
 
 void CoreSession::kickClient(int peerId) {
-    qWarning() << "kickClient(" << peerId << ")";
-
     auto peer = signalProxy()->peerById(peerId);
     if (peer == nullptr) {
         qWarning() << "Invalid peer Id: " << peerId;
         return;
     }
     signalProxy()->restrictTargetPeers({peer}, [&]{
-        qWarning() << "executing closure";
         emit disconnectFromCore();
     });
 }

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -171,6 +171,8 @@ signals:
 
     void passwordChanged(PeerPtr peer, bool success);
 
+    void disconnectFromCore();
+
 protected:
     virtual void customEvent(QEvent *event);
 

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -131,6 +131,8 @@ public slots:
 
     void changePassword(PeerPtr peer, const QString &userName, const QString &oldPassword, const QString &newPassword);
 
+    void kickClient(int peerId);
+
     QHash<QString, QString> persistentChannels(NetworkId) const;
 
     /**

--- a/src/qtui/CMakeLists.txt
+++ b/src/qtui/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SOURCES
     coreconnectdlg.cpp
     coreconnectionstatuswidget.cpp
     coreinfodlg.cpp
+        coresessionwidget.cpp
     debugbufferviewoverlay.cpp
     debugconsole.cpp
     debuglogwidget.cpp
@@ -65,6 +66,7 @@ set(FORMS
     coreconfigwizardsyncpage.ui
     coreconnectauthdlg.ui
     coreconnectionstatuswidget.ui
+        coresessionwidget.ui
     coreinfodlg.ui
     debugbufferviewoverlay.ui
     debugconsole.ui

--- a/src/qtui/CMakeLists.txt
+++ b/src/qtui/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SOURCES
     coreconnectdlg.cpp
     coreconnectionstatuswidget.cpp
     coreinfodlg.cpp
-        coresessionwidget.cpp
+    coresessionwidget.cpp
     debugbufferviewoverlay.cpp
     debugconsole.cpp
     debuglogwidget.cpp

--- a/src/qtui/CMakeLists.txt
+++ b/src/qtui/CMakeLists.txt
@@ -66,8 +66,8 @@ set(FORMS
     coreconfigwizardsyncpage.ui
     coreconnectauthdlg.ui
     coreconnectionstatuswidget.ui
-        coresessionwidget.ui
     coreinfodlg.ui
+    coresessionwidget.ui
     debugbufferviewoverlay.ui
     debugconsole.ui
     debuglogwidget.ui

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -43,8 +43,6 @@ void CoreInfoDlg::coreInfoAvailable()
     ui.labelCoreVersionDate->setText(_coreInfo["quasselBuildDate"].toString()); // "BuildDate" for compatibility
     ui.labelClientCount->setNum(_coreInfo["sessionConnectedClients"].toInt());
 
-    qWarning() << _coreInfo["sessionConnectedClientData"];
-
     for (const auto &peerData : _coreInfo["sessionConnectedClientData"].toList()) {
         auto coreSessionWidget = new CoreSessionWidget(ui.coreSessionScrollContainer);
         coreSessionWidget->setData(peerData.toMap());

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -40,6 +40,23 @@ void CoreInfoDlg::coreInfoAvailable()
     ui.labelCoreVersion->setText(_coreInfo["quasselVersion"].toString());
     ui.labelCoreVersionDate->setText(_coreInfo["quasselBuildDate"].toString()); // "BuildDate" for compatibility
     ui.labelClientCount->setNum(_coreInfo["sessionConnectedClients"].toInt());
+
+    /*
+    qWarning() << _coreInfo["sessionConnectedClientData"];
+
+    int lastPeerId = -1;
+    QMap<QString, QVariant> lastPeerData;
+    for (const auto &peerData : _coreInfo["sessionConnectedClientData"].toList()) {
+        lastPeerData = peerData.toMap();
+        lastPeerId = lastPeerData["id"].toInt();
+    }
+
+    if (lastPeerId != -1) {
+        qWarning() << "Kicking client " << lastPeerId;
+        Client::kickClient(lastPeerId);
+    }
+    */
+
     updateUptime();
     startTimer(1000);
 }

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -43,12 +43,17 @@ void CoreInfoDlg::coreInfoAvailable()
     ui.labelCoreVersionDate->setText(_coreInfo["quasselBuildDate"].toString()); // "BuildDate" for compatibility
     ui.labelClientCount->setNum(_coreInfo["sessionConnectedClients"].toInt());
 
+    auto coreSessionSupported = false;
     for (const auto &peerData : _coreInfo["sessionConnectedClientData"].toList()) {
+        coreSessionSupported = true;
+
         auto coreSessionWidget = new CoreSessionWidget(ui.coreSessionScrollContainer);
         coreSessionWidget->setData(peerData.toMap());
         ui.coreSessionContainer->addWidget(coreSessionWidget);
         connect(coreSessionWidget, SIGNAL(disconnectClicked(int)), this, SLOT(disconnectClicked(int)));
     }
+
+    ui.coreSessionScrollArea->setVisible(coreSessionSupported);
 
     ui.coreSessionContainer->addStretch(1);
 

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -24,6 +24,8 @@
 
 #include "client.h"
 #include "signalproxy.h"
+#include "bufferwidget.h"
+#include "coresessionwidget.h"
 
 CoreInfoDlg::CoreInfoDlg(QWidget *parent)
     : QDialog(parent),
@@ -41,21 +43,15 @@ void CoreInfoDlg::coreInfoAvailable()
     ui.labelCoreVersionDate->setText(_coreInfo["quasselBuildDate"].toString()); // "BuildDate" for compatibility
     ui.labelClientCount->setNum(_coreInfo["sessionConnectedClients"].toInt());
 
-    /*
     qWarning() << _coreInfo["sessionConnectedClientData"];
 
-    int lastPeerId = -1;
-    QMap<QString, QVariant> lastPeerData;
     for (const auto &peerData : _coreInfo["sessionConnectedClientData"].toList()) {
-        lastPeerData = peerData.toMap();
-        lastPeerId = lastPeerData["id"].toInt();
+        auto coreSessionWidget = new CoreSessionWidget(ui.coreSessionScrollContainer);
+        coreSessionWidget->setData(peerData.toMap());
+        ui.coreSessionContainer->addWidget(coreSessionWidget);
     }
 
-    if (lastPeerId != -1) {
-        qWarning() << "Kicking client " << lastPeerId;
-        Client::kickClient(lastPeerId);
-    }
-    */
+    ui.coreSessionContainer->addStretch(1);
 
     updateUptime();
     startTimer(1000);

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -49,6 +49,7 @@ void CoreInfoDlg::coreInfoAvailable()
         auto coreSessionWidget = new CoreSessionWidget(ui.coreSessionScrollContainer);
         coreSessionWidget->setData(peerData.toMap());
         ui.coreSessionContainer->addWidget(coreSessionWidget);
+        connect(coreSessionWidget, SIGNAL(disconnectClicked(int)), this, SLOT(disconnectClicked(int)));
     }
 
     ui.coreSessionContainer->addStretch(1);
@@ -70,4 +71,8 @@ void CoreInfoDlg::updateUptime()
     QString uptimeText = tr("%n Day(s)", "", updays)
                          + tr(" %1:%2:%3 (since %4)").arg(uphours, 2, 10, QChar('0')).arg(upmins, 2, 10, QChar('0')).arg(uptime, 2, 10, QChar('0')).arg(startTime.toLocalTime().toString(Qt::TextDate));
     ui.labelUptime->setText(uptimeText);
+}
+void CoreInfoDlg::disconnectClicked(int peerId)
+{
+    Client::kickClient(peerId);
 }

--- a/src/qtui/coreinfodlg.h
+++ b/src/qtui/coreinfodlg.h
@@ -42,6 +42,7 @@ protected:
 private slots:
     void on_closeButton_clicked() { reject(); }
     void updateUptime();
+    void disconnectClicked(int peerId);
 
 private:
     Ui::CoreInfoDlg ui;

--- a/src/qtui/coresessionwidget.cpp
+++ b/src/qtui/coresessionwidget.cpp
@@ -18,9 +18,10 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
+#include <QDateTime>
+
+#include "client.h"
 #include "coresessionwidget.h"
-#include <QtCore/QDateTime>
-#include <client.h>
 
 
 CoreSessionWidget::CoreSessionWidget(QWidget *parent)
@@ -35,6 +36,8 @@ CoreSessionWidget::CoreSessionWidget(QWidget *parent)
 void CoreSessionWidget::setData(QMap<QString, QVariant> map)
 {
     QLabel *iconSecure = ui.iconSecure;
+    // TODO: Implement "secure" icon
+    Q_UNUSED(iconSecure);
 
     ui.labelRemoteAddress->setText(map["remoteAddress"].toString());
     ui.labelLocation->setText(map["location"].toString());

--- a/src/qtui/coresessionwidget.cpp
+++ b/src/qtui/coresessionwidget.cpp
@@ -1,3 +1,23 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2016 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
 #include "coresessionwidget.h"
 #include <QtCore/QDateTime>
 #include <client.h>

--- a/src/qtui/coresessionwidget.cpp
+++ b/src/qtui/coresessionwidget.cpp
@@ -1,10 +1,6 @@
 #include "coresessionwidget.h"
-#include <QLayout>
-#include <QVariant>
-#include <QtCore/QMap>
-#include <QtWidgets/QLabel>
-#include <QtWidgets/QPushButton>
 #include <QtCore/QDateTime>
+#include <client.h>
 
 
 CoreSessionWidget::CoreSessionWidget(QWidget *parent)
@@ -13,12 +9,12 @@ CoreSessionWidget::CoreSessionWidget(QWidget *parent)
     ui.setupUi(this);
     layout()->setContentsMargins(0, 0, 0, 0);
     layout()->setSpacing(0);
+    connect(ui.disconnectButton, SIGNAL(released()), this, SLOT(disconnectClicked()));
 }
 
 void CoreSessionWidget::setData(QMap<QString, QVariant> map)
 {
     QLabel *iconSecure = ui.iconSecure;
-    QPushButton *disconnectButton = ui.disconnectButton;
 
     ui.labelRemoteAddress->setText(map["remoteAddress"].toString());
     ui.labelLocation->setText(map["location"].toString());
@@ -30,4 +26,13 @@ void CoreSessionWidget::setData(QMap<QString, QVariant> map)
         ui.labelLocation->hide();
         ui.labelLocationTitle->hide();
     }
+
+    bool success = false;
+    _peerId = map["id"].toInt(&success);
+    if (!success) _peerId = -1;
+}
+
+void CoreSessionWidget::disconnectClicked()
+{
+    emit disconnectClicked(_peerId);
 }

--- a/src/qtui/coresessionwidget.cpp
+++ b/src/qtui/coresessionwidget.cpp
@@ -1,0 +1,33 @@
+#include "coresessionwidget.h"
+#include <QLayout>
+#include <QVariant>
+#include <QtCore/QMap>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QPushButton>
+#include <QtCore/QDateTime>
+
+
+CoreSessionWidget::CoreSessionWidget(QWidget *parent)
+    : QWidget(parent)
+{
+    ui.setupUi(this);
+    layout()->setContentsMargins(0, 0, 0, 0);
+    layout()->setSpacing(0);
+}
+
+void CoreSessionWidget::setData(QMap<QString, QVariant> map)
+{
+    QLabel *iconSecure = ui.iconSecure;
+    QPushButton *disconnectButton = ui.disconnectButton;
+
+    ui.labelRemoteAddress->setText(map["remoteAddress"].toString());
+    ui.labelLocation->setText(map["location"].toString());
+    ui.labelClient->setText(map["clientVersion"].toString());
+    ui.labelVersionDate->setText(map["clientVersionDate"].toString());
+    ui.labelUptime
+        ->setText(map["connectedSince"].toDateTime().toLocalTime().toString(Qt::DateFormat::SystemLocaleShortDate));
+    if (map["location"].toString().isEmpty()) {
+        ui.labelLocation->hide();
+        ui.labelLocationTitle->hide();
+    }
+}

--- a/src/qtui/coresessionwidget.h
+++ b/src/qtui/coresessionwidget.h
@@ -1,0 +1,25 @@
+//
+// Created by kuschku on 27.08.17.
+//
+
+#ifndef CORESESSIONWIDGET_H
+#define CORESESSIONWIDGET_H
+
+#include <QtWidgets/QWidget>
+#include <ui_coresessionwidget.h>
+#include <QtCore/QMap>
+
+class CoreSessionWidget: public QWidget
+{
+Q_OBJECT
+
+public:
+    explicit CoreSessionWidget(QWidget *);
+
+    void setData(QMap<QString, QVariant>);
+
+private:
+    Ui::CoreSessionWidget ui;
+};
+
+#endif //CORESESSIONWIDGET_H

--- a/src/qtui/coresessionwidget.h
+++ b/src/qtui/coresessionwidget.h
@@ -17,13 +17,12 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
+#pragma once
 
-#ifndef CORESESSIONWIDGET_H
-#define CORESESSIONWIDGET_H
-
-#include <QWidget>
-#include <ui_coresessionwidget.h>
 #include <QMap>
+#include <QWidget>
+
+#include "ui_coresessionwidget.h"
 
 class CoreSessionWidget: public QWidget
 {
@@ -44,5 +43,3 @@ private:
     Ui::CoreSessionWidget ui;
     int _peerId;
 };
-
-#endif //CORESESSIONWIDGET_H

--- a/src/qtui/coresessionwidget.h
+++ b/src/qtui/coresessionwidget.h
@@ -18,8 +18,15 @@ public:
 
     void setData(QMap<QString, QVariant>);
 
+signals:
+    void disconnectClicked(int);
+
+private slots:
+    void disconnectClicked();
+
 private:
     Ui::CoreSessionWidget ui;
+    int _peerId;
 };
 
 #endif //CORESESSIONWIDGET_H

--- a/src/qtui/coresessionwidget.h
+++ b/src/qtui/coresessionwidget.h
@@ -1,13 +1,29 @@
-//
-// Created by kuschku on 27.08.17.
-//
+/***************************************************************************
+ *   Copyright (C) 2005-2016 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
 
 #ifndef CORESESSIONWIDGET_H
 #define CORESESSIONWIDGET_H
 
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include <ui_coresessionwidget.h>
-#include <QtCore/QMap>
+#include <QMap>
 
 class CoreSessionWidget: public QWidget
 {

--- a/src/qtui/ui/coreinfodlg.ui
+++ b/src/qtui/ui/coreinfodlg.ui
@@ -1,145 +1,158 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>CoreInfoDlg</class>
-    <widget class="QDialog" name="CoreInfoDlg">
-        <property name="geometry">
+ <widget class="QDialog" name="CoreInfoDlg">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-       <width>566</width>
-       <height>349</height>
+    <width>566</width>
+    <height>349</height>
    </rect>
   </property>
-        <property name="windowTitle">
+  <property name="windowTitle">
    <string>Core Information</string>
   </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0,0">
    <item>
-       <layout class="QGridLayout" name="gridLayout">
-           <item row="0" column="0">
-               <widget class="QLabel" name="label_2">
-                   <property name="text">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelCoreVersionTitle">
+       <property name="text">
         <string>Version:</string>
        </property>
       </widget>
      </item>
-           <item row="0" column="1">
-               <widget class="QLabel" name="labelCoreVersion">
-                   <property name="text">
-                       <string>&lt;core version&gt;</string>
+     <item row="0" column="1">
+      <widget class="QLabel" name="labelCoreVersion">
+       <property name="text">
+        <string notr="true">&lt;core version&gt;</string>
        </property>
       </widget>
      </item>
-           <item row="2" column="0">
-               <widget class="QLabel" name="label_4">
-                   <property name="text">
-        <string>Uptime:</string>
-       </property>
-      </widget>
-     </item>
-           <item row="3" column="0">
-               <widget class="QLabel" name="label_3">
-                   <property name="text">
-        <string>Connected Clients:</string>
-       </property>
-      </widget>
-     </item>
-           <item row="3" column="1">
-               <widget class="QLabel" name="labelClientCount">
-                   <property name="text">
-                       <string>&lt;connected clients&gt;</string>
-       </property>
-      </widget>
-     </item>
-           <item row="2" column="1">
-               <widget class="QLabel" name="labelUptime">
-                   <property name="text">
-                       <string>&lt;core uptime&gt;</string>
-       </property>
-      </widget>
-     </item>
-           <item row="1" column="0">
-               <widget class="QLabel" name="label">
-                   <property name="text">
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelCoreVersionDateTitle">
+       <property name="text">
         <string>Version date:</string>
        </property>
       </widget>
      </item>
-           <item row="1" column="1">
-               <widget class="QLabel" name="labelCoreVersionDate">
-                   <property name="text">
-                       <string>&lt;version date&gt;</string>
+     <item row="1" column="1">
+      <widget class="QLabel" name="labelCoreVersionDate">
+       <property name="text">
+        <string notr="true">&lt;version date&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelUptimeTitle">
+       <property name="text">
+        <string>Uptime:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="labelUptime">
+       <property name="text">
+        <string notr="true">&lt;core uptime&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelClientCountTitle">
+       <property name="text">
+        <string>Connected Clients:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLabel" name="labelClientCount">
+       <property name="text">
+        <string notr="true">&lt;connected clients&gt;</string>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
-       <widget class="QScrollArea" name="coreSessionScrollArea">
-           <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-               </sizepolicy>
+    <widget class="QScrollArea" name="coreSessionScrollArea">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignHCenter|Qt::AlignTop</set>
+     </property>
+     <widget class="QWidget" name="coreSessionScrollContainer">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>550</width>
+        <height>187</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QVBoxLayout" name="coreSessionContainer">
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
            </property>
-           <property name="widgetResizable">
-               <bool>true</bool>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
            </property>
-           <property name="alignment">
-               <set>Qt::AlignHCenter|Qt::AlignTop</set>
-           </property>
-           <widget class="QWidget" name="coreSessionScrollContainer">
-               <property name="geometry">
-                   <rect>
-                       <x>0</x>
-                       <y>0</y>
-                       <width>550</width>
-                       <height>193</height>
-                   </rect>
-               </property>
-               <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                   </sizepolicy>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_3">
-                   <item>
-                       <layout class="QVBoxLayout" name="coreSessionContainer">
-                           <item>
-                               <spacer name="verticalSpacer">
-                                   <property name="orientation">
-                                       <enum>Qt::Vertical</enum>
-                                   </property>
-                                   <property name="sizeHint" stdset="0">
-                                       <size>
-                                           <width>20</width>
-                                           <height>40</height>
-                                       </size>
-                                   </property>
-                               </spacer>
-                           </item>
-                       </layout>
-                   </item>
-               </layout>
-           </widget>
-       </widget>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
-            <item>
-                <layout class="QGridLayout" name="gridLayout_2">
-                    <item row="1" column="1">
-                        <widget class="QPushButton" name="closeButton">
-                            <property name="text">
+   <item>
+    <spacer name="mainSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="1" column="1">
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
         <string>Close</string>
        </property>
       </widget>
      </item>
-                    <item row="1" column="0">
-                        <spacer name="horizontalSpacer">
-                            <property name="orientation">
+     <item row="1" column="0">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-                            <property name="sizeHint" stdset="0">
+       <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>
@@ -147,12 +160,12 @@
        </property>
       </spacer>
      </item>
-                    <item row="1" column="2">
-                        <spacer name="horizontalSpacer_2">
-                            <property name="orientation">
+     <item row="1" column="2">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-                            <property name="sizeHint" stdset="0">
+       <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>

--- a/src/qtui/ui/coreinfodlg.ui
+++ b/src/qtui/ui/coreinfodlg.ui
@@ -1,93 +1,145 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>CoreInfoDlg</class>
- <widget class="QDialog" name="CoreInfoDlg" >
-  <property name="geometry" >
+    <widget class="QDialog" name="CoreInfoDlg">
+        <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>282</width>
-    <height>126</height>
+       <width>566</width>
+       <height>349</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+        <property name="windowTitle">
    <string>Core Information</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" >
+        <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout" >
-     <item row="0" column="0" >
-      <widget class="QLabel" name="label_2" >
-       <property name="text" >
+       <layout class="QGridLayout" name="gridLayout">
+           <item row="0" column="0">
+               <widget class="QLabel" name="label_2">
+                   <property name="text">
         <string>Version:</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1" >
-      <widget class="QLabel" name="labelCoreVersion" >
-       <property name="text" >
-        <string>&lt;core version></string>
+           <item row="0" column="1">
+               <widget class="QLabel" name="labelCoreVersion">
+                   <property name="text">
+                       <string>&lt;core version&gt;</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0" >
-      <widget class="QLabel" name="label_4" >
-       <property name="text" >
+           <item row="2" column="0">
+               <widget class="QLabel" name="label_4">
+                   <property name="text">
         <string>Uptime:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0" >
-      <widget class="QLabel" name="label_3" >
-       <property name="text" >
+           <item row="3" column="0">
+               <widget class="QLabel" name="label_3">
+                   <property name="text">
         <string>Connected Clients:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1" >
-      <widget class="QLabel" name="labelClientCount" >
-       <property name="text" >
-        <string>&lt;connected clients></string>
+           <item row="3" column="1">
+               <widget class="QLabel" name="labelClientCount">
+                   <property name="text">
+                       <string>&lt;connected clients&gt;</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1" >
-      <widget class="QLabel" name="labelUptime" >
-       <property name="text" >
-        <string>&lt;core uptime></string>
+           <item row="2" column="1">
+               <widget class="QLabel" name="labelUptime">
+                   <property name="text">
+                       <string>&lt;core uptime&gt;</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0" >
-      <widget class="QLabel" name="label" >
-       <property name="text" >
+           <item row="1" column="0">
+               <widget class="QLabel" name="label">
+                   <property name="text">
         <string>Version date:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1" >
-      <widget class="QLabel" name="labelCoreVersionDate" >
-       <property name="text" >
-        <string>&lt;version date></string>
+           <item row="1" column="1">
+               <widget class="QLabel" name="labelCoreVersionDate">
+                   <property name="text">
+                       <string>&lt;version date&gt;</string>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
-    <layout class="QGridLayout" name="gridLayout_2" >
-     <item row="0" column="1" >
-      <widget class="QPushButton" name="closeButton" >
-       <property name="text" >
+       <widget class="QScrollArea" name="coreSessionScrollArea">
+           <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+               </sizepolicy>
+           </property>
+           <property name="widgetResizable">
+               <bool>true</bool>
+           </property>
+           <property name="alignment">
+               <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           </property>
+           <widget class="QWidget" name="coreSessionScrollContainer">
+               <property name="geometry">
+                   <rect>
+                       <x>0</x>
+                       <y>0</y>
+                       <width>550</width>
+                       <height>193</height>
+                   </rect>
+               </property>
+               <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                   </sizepolicy>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_3">
+                   <item>
+                       <layout class="QVBoxLayout" name="coreSessionContainer">
+                           <item>
+                               <spacer name="verticalSpacer">
+                                   <property name="orientation">
+                                       <enum>Qt::Vertical</enum>
+                                   </property>
+                                   <property name="sizeHint" stdset="0">
+                                       <size>
+                                           <width>20</width>
+                                           <height>40</height>
+                                       </size>
+                                   </property>
+                               </spacer>
+                           </item>
+                       </layout>
+                   </item>
+               </layout>
+           </widget>
+       </widget>
+   </item>
+            <item>
+                <layout class="QGridLayout" name="gridLayout_2">
+                    <item row="1" column="1">
+                        <widget class="QPushButton" name="closeButton">
+                            <property name="text">
         <string>Close</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="0" >
-      <spacer name="horizontalSpacer" >
-       <property name="orientation" >
+                    <item row="1" column="0">
+                        <spacer name="horizontalSpacer">
+                            <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint" stdset="0" >
+                            <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>
@@ -95,12 +147,12 @@
        </property>
       </spacer>
      </item>
-     <item row="0" column="2" >
-      <spacer name="horizontalSpacer_2" >
-       <property name="orientation" >
+                    <item row="1" column="2">
+                        <spacer name="horizontalSpacer_2">
+                            <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint" stdset="0" >
+                            <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>
@@ -109,19 +161,6 @@
       </spacer>
      </item>
     </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer" >
-     <property name="orientation" >
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0" >
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/qtui/ui/coresessionwidget.ui
+++ b/src/qtui/ui/coresessionwidget.ui
@@ -1,198 +1,198 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-    <class>CoreSessionWidget</class>
-    <widget class="QWidget" name="CoreSessionWidget">
-        <property name="geometry">
-            <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>509</width>
-                <height>204</height>
-            </rect>
-        </property>
-        <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-            </sizepolicy>
-        </property>
-        <property name="minimumSize">
-            <size>
-                <width>480</width>
-                <height>0</height>
-            </size>
-        </property>
-        <property name="maximumSize">
-            <size>
-                <width>16777215</width>
-                <height>16777215</height>
-            </size>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_4">
-            <item row="0" column="0">
-                <layout class="QGridLayout" name="mainLayout" rowstretch="0,0,0">
-                    <item row="0" column="0">
-                        <layout class="QHBoxLayout" name="titleLayout">
-                            <item>
-                                <widget class="QLabel" name="labelRemoteAddress">
-                                    <property name="font">
-                                        <font>
-                                            <pointsize>13</pointsize>
-                                            <weight>75</weight>
-                                            <bold>true</bold>
-                                        </font>
-                                    </property>
-                                    <property name="text">
-                                        <string>86.103.223.212</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item>
-                                <widget class="QLabel" name="iconSecure">
-                                    <property name="sizePolicy">
-                                        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                                            <horstretch>0</horstretch>
-                                            <verstretch>0</verstretch>
-                                        </sizepolicy>
-                                    </property>
-                                    <property name="minimumSize">
-                                        <size>
-                                            <width>32</width>
-                                            <height>32</height>
-                                        </size>
-                                    </property>
-                                    <property name="text">
-                                        <string/>
-                                    </property>
-                                    <property name="alignment">
-                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                    </property>
-                                    <property name="textInteractionFlags">
-                                        <set>Qt::NoTextInteraction</set>
-                                    </property>
-                                </widget>
-                            </item>
-                        </layout>
-                    </item>
-                    <item row="1" column="0">
-                        <layout class="QGridLayout" name="contentLayout" columnstretch="1,3">
-                            <item row="0" column="0">
-                                <widget class="QLabel" name="labelClientTitle">
-                                    <property name="styleSheet">
-                                        <string notr="true">color: rgb(119, 119, 119);</string>
-                                    </property>
-                                    <property name="text">
-                                        <string>Client:</string>
-                                    </property>
-                                    <property name="alignment">
-                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="0" column="1">
-                                <widget class="QLabel" name="labelClient">
-                                    <property name="text">
-                                        <string>v0.13-pre (0.12.0+372 git-12df418)</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="2" column="0">
-                                <widget class="QLabel" name="labelLocationTitle">
-                                    <property name="styleSheet">
-                                        <string notr="true">color: rgb(119, 119, 119);</string>
-                                    </property>
-                                    <property name="text">
-                                        <string>Location:</string>
-                                    </property>
-                                    <property name="alignment">
-                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="2" column="1">
-                                <widget class="QLabel" name="labelLocation">
-                                    <property name="text">
-                                        <string>Kiel, Germany</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="1" column="1">
-                                <widget class="QLabel" name="labelVersionDate">
-                                    <property name="text">
-                                        <string>Sun Aug 27 04:29:53 2017</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="1" column="0">
-                                <widget class="QLabel" name="labelVersionDateTitle">
-                                    <property name="styleSheet">
-                                        <string notr="true">color: rgb(119, 119, 119);</string>
-                                    </property>
-                                    <property name="text">
-                                        <string>Version Date:</string>
-                                    </property>
-                                    <property name="alignment">
-                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="3" column="1">
-                                <widget class="QLabel" name="labelUptime">
-                                    <property name="text">
-                                        <string>Sun Aug 27 15:03:10 2017</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="3" column="0">
-                                <widget class="QLabel" name="labelUptimeTitle">
-                                    <property name="styleSheet">
-                                        <string notr="true">color: rgb(119, 119, 119);</string>
-                                    </property>
-                                    <property name="text">
-                                        <string>Connected Since:</string>
-                                    </property>
-                                    <property name="alignment">
-                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                    </property>
-                                </widget>
-                            </item>
-                        </layout>
-                    </item>
-                    <item row="2" column="0">
-                        <layout class="QHBoxLayout" name="actionsLayout">
-                            <item>
-                                <spacer name="horizontalSpacer">
-                                    <property name="orientation">
-                                        <enum>Qt::Horizontal</enum>
-                                    </property>
-                                    <property name="sizeHint" stdset="0">
-                                        <size>
-                                            <width>40</width>
-                                            <height>20</height>
-                                        </size>
-                                    </property>
-                                </spacer>
-                            </item>
-                            <item>
-                                <widget class="QPushButton" name="disconnectButton">
-                                    <property name="text">
-                                        <string>End Session</string>
-                                    </property>
-                                </widget>
-                            </item>
-                        </layout>
-                    </item>
-                </layout>
-            </item>
-            <item row="2" column="0">
-                <widget class="Line" name="line">
-                    <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                    </property>
-                </widget>
-            </item>
-        </layout>
+ <class>CoreSessionWidget</class>
+ <widget class="QWidget" name="CoreSessionWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>509</width>
+    <height>204</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>480</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_4">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="mainLayout" rowstretch="0,0,0">
+     <item row="0" column="0">
+      <layout class="QHBoxLayout" name="titleLayout">
+       <item>
+        <widget class="QLabel" name="labelRemoteAddress">
+         <property name="font">
+          <font>
+           <pointsize>13</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string notr="true">10.104.241.277</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="iconSecure">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+         <property name="text">
+          <string />
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::NoTextInteraction</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="0">
+      <layout class="QGridLayout" name="contentLayout" columnstretch="1,3">
+       <item row="0" column="0">
+        <widget class="QLabel" name="labelClientTitle">
+         <property name="styleSheet">
+          <string notr="true">opacity: 0.66;</string>
+         </property>
+         <property name="text">
+          <string>Client:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="labelClient">
+         <property name="text">
+          <string notr="true">v0.13-pre (0.12.0+372 git-12df418)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="labelVersionDateTitle">
+         <property name="styleSheet">
+          <string notr="true">color: rgb(119, 119, 119);</string>
+         </property>
+         <property name="text">
+          <string>Version Date:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="labelVersionDate">
+         <property name="text">
+          <string notr="true">Sun Aug 27 04:29:53 2017</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="labelLocationTitle">
+         <property name="styleSheet">
+          <string notr="true">opacity: 0.66;</string>
+         </property>
+         <property name="text">
+          <string>Location:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="labelLocation">
+         <property name="text">
+          <string notr="true">Kiel, Germany</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="labelUptimeTitle">
+         <property name="styleSheet">
+          <string notr="true">color: rgb(119, 119, 119);</string>
+         </property>
+         <property name="text">
+          <string>Connected Since:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="labelUptime">
+         <property name="text">
+          <string notr="true">Sun Aug 27 15:03:10 2017</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="2" column="0">
+      <layout class="QHBoxLayout" name="actionsLayout">
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="disconnectButton">
+         <property name="text">
+          <string>End Session</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
     </widget>
-    <resources/>
-    <connections/>
+   </item>
+  </layout>
+ </widget>
+ <resources />
+ <connections />
 </ui>

--- a/src/qtui/ui/coresessionwidget.ui
+++ b/src/qtui/ui/coresessionwidget.ui
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+    <class>CoreSessionWidget</class>
+    <widget class="QWidget" name="CoreSessionWidget">
+        <property name="geometry">
+            <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>509</width>
+                <height>204</height>
+            </rect>
+        </property>
+        <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+            </sizepolicy>
+        </property>
+        <property name="minimumSize">
+            <size>
+                <width>480</width>
+                <height>0</height>
+            </size>
+        </property>
+        <property name="maximumSize">
+            <size>
+                <width>16777215</width>
+                <height>16777215</height>
+            </size>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
+            <item row="0" column="0">
+                <layout class="QGridLayout" name="mainLayout" rowstretch="0,0,0">
+                    <item row="0" column="0">
+                        <layout class="QHBoxLayout" name="titleLayout">
+                            <item>
+                                <widget class="QLabel" name="labelRemoteAddress">
+                                    <property name="font">
+                                        <font>
+                                            <pointsize>13</pointsize>
+                                            <weight>75</weight>
+                                            <bold>true</bold>
+                                        </font>
+                                    </property>
+                                    <property name="text">
+                                        <string>86.103.223.212</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item>
+                                <widget class="QLabel" name="iconSecure">
+                                    <property name="sizePolicy">
+                                        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                            <horstretch>0</horstretch>
+                                            <verstretch>0</verstretch>
+                                        </sizepolicy>
+                                    </property>
+                                    <property name="minimumSize">
+                                        <size>
+                                            <width>32</width>
+                                            <height>32</height>
+                                        </size>
+                                    </property>
+                                    <property name="text">
+                                        <string/>
+                                    </property>
+                                    <property name="alignment">
+                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                                    </property>
+                                    <property name="textInteractionFlags">
+                                        <set>Qt::NoTextInteraction</set>
+                                    </property>
+                                </widget>
+                            </item>
+                        </layout>
+                    </item>
+                    <item row="1" column="0">
+                        <layout class="QGridLayout" name="contentLayout" columnstretch="1,3">
+                            <item row="0" column="0">
+                                <widget class="QLabel" name="labelClientTitle">
+                                    <property name="styleSheet">
+                                        <string notr="true">color: rgb(119, 119, 119);</string>
+                                    </property>
+                                    <property name="text">
+                                        <string>Client:</string>
+                                    </property>
+                                    <property name="alignment">
+                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="0" column="1">
+                                <widget class="QLabel" name="labelClient">
+                                    <property name="text">
+                                        <string>v0.13-pre (0.12.0+372 git-12df418)</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="2" column="0">
+                                <widget class="QLabel" name="labelLocationTitle">
+                                    <property name="styleSheet">
+                                        <string notr="true">color: rgb(119, 119, 119);</string>
+                                    </property>
+                                    <property name="text">
+                                        <string>Location:</string>
+                                    </property>
+                                    <property name="alignment">
+                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="2" column="1">
+                                <widget class="QLabel" name="labelLocation">
+                                    <property name="text">
+                                        <string>Kiel, Germany</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="1" column="1">
+                                <widget class="QLabel" name="labelVersionDate">
+                                    <property name="text">
+                                        <string>Sun Aug 27 04:29:53 2017</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="1" column="0">
+                                <widget class="QLabel" name="labelVersionDateTitle">
+                                    <property name="styleSheet">
+                                        <string notr="true">color: rgb(119, 119, 119);</string>
+                                    </property>
+                                    <property name="text">
+                                        <string>Version Date:</string>
+                                    </property>
+                                    <property name="alignment">
+                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="3" column="1">
+                                <widget class="QLabel" name="labelUptime">
+                                    <property name="text">
+                                        <string>Sun Aug 27 15:03:10 2017</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="3" column="0">
+                                <widget class="QLabel" name="labelUptimeTitle">
+                                    <property name="styleSheet">
+                                        <string notr="true">color: rgb(119, 119, 119);</string>
+                                    </property>
+                                    <property name="text">
+                                        <string>Connected Since:</string>
+                                    </property>
+                                    <property name="alignment">
+                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                                    </property>
+                                </widget>
+                            </item>
+                        </layout>
+                    </item>
+                    <item row="2" column="0">
+                        <layout class="QHBoxLayout" name="actionsLayout">
+                            <item>
+                                <spacer name="horizontalSpacer">
+                                    <property name="orientation">
+                                        <enum>Qt::Horizontal</enum>
+                                    </property>
+                                    <property name="sizeHint" stdset="0">
+                                        <size>
+                                            <width>40</width>
+                                            <height>20</height>
+                                        </size>
+                                    </property>
+                                </spacer>
+                            </item>
+                            <item>
+                                <widget class="QPushButton" name="disconnectButton">
+                                    <property name="text">
+                                        <string>End Session</string>
+                                    </property>
+                                </widget>
+                            </item>
+                        </layout>
+                    </item>
+                </layout>
+            </item>
+            <item row="2" column="0">
+                <widget class="Line" name="line">
+                    <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                    </property>
+                </widget>
+            </item>
+        </layout>
+    </widget>
+    <resources/>
+    <connections/>
+</ui>


### PR DESCRIPTION
## In Short
* Via the coreinfo sync, clients can get a list of all peers of the same user that are connected.
* This includes client version, build date, IP, current lag, and a unique ID
* Introduces an RPC call to kick a peer by unique ID
* The coreinfo dialog shows this list of clients (maybe even with GeoIP?) and allows users to kick them

## Status
- [x] Transmit the relevant information to the client
- [x] Implement RPC call functionality
- [x] Implement the required UI
- [x] Implement graceful disconnects (currently the client just reconnects)

## Rationale
Often the request to kick clients of yourself, or to see currently connected versions (so users can see if an old device is still eating new messages) is requested.

## Problems
The client will always reconnect, no matter the error message, so we might want to add a graceful disconnection feature that requests from the client that it disconnects (without then reconnecting)

## Future Improvement Opportunities
- Once Client Features are implemented, they could be used to detect if a client supports this feature
- Once Session Tokens are implemented, they should probably be integrated with this menu
- Once Qt4 support is dropped, the fallback for it can be removed
- Potentially implement GeoIP