### PR TITLE
Implement Core-Side Highlights

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -420,6 +420,11 @@ void Client::setSyncedToCore()
     _ignoreListManager = new ClientIgnoreListManager(this);
     p->synchronize(ignoreListManager());
 
+    // create Core-Side HighlightRuleManager
+    Q_ASSERT(!_highlightRuleManager);
+    _highlightRuleManager = new HighlightRuleManager(this);
+    p->synchronize(highlightRuleManager());
+
     // create TransferManager and DccConfig if core supports them
     Q_ASSERT(!_dccConfig);
     Q_ASSERT(!_transferManager);
@@ -506,6 +511,11 @@ void Client::setDisconnectedFromCore()
     if (_ignoreListManager) {
         _ignoreListManager->deleteLater();
         _ignoreListManager = 0;
+    }
+
+    if (_highlightRuleManager) {
+        _highlightRuleManager->deleteLater();
+        _highlightRuleManager = nullptr;
     }
 
     if (_transferManager) {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -107,6 +107,7 @@ Client::Client(QObject *parent)
     _inputHandler(0),
     _networkConfig(0),
     _ignoreListManager(0),
+    _highlightRuleManager(0),
     _transferManager(0),
     _transferModel(new TransferModel(this)),
     _messageModel(0),

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -23,6 +23,7 @@
 
 #include <QList>
 #include <QPointer>
+#include <highlightrulemanager.h>
 
 #include "bufferinfo.h"
 #include "coreaccount.h"
@@ -122,6 +123,7 @@ public:
     static inline ClientUserInputHandler *inputHandler() { return instance()->_inputHandler; }
     static inline NetworkConfig *networkConfig() { return instance()->_networkConfig; }
     static inline ClientIgnoreListManager *ignoreListManager() { return instance()->_ignoreListManager; }
+    static inline HighlightRuleManager *highlightRuleManager() { return instance()->_highlightRuleManager; }
     static inline ClientTransferManager *transferManager() { return instance()->_transferManager; }
     static inline TransferModel *transferModel() { return instance()->_transferModel; }
 
@@ -260,6 +262,7 @@ private:
     ClientUserInputHandler *_inputHandler;
     NetworkConfig *_networkConfig;
     ClientIgnoreListManager *_ignoreListManager;
+    HighlightRuleManager *_highlightRuleManager;
     ClientTransferManager *_transferManager;
     TransferModel *_transferModel;
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     dccconfig.cpp
     event.cpp
     eventmanager.cpp
+    highlightrulemanager.cpp
     identity.cpp
     ignorelistmanager.cpp
     internalpeer.cpp

--- a/src/common/highlightrulemanager.cpp
+++ b/src/common/highlightrulemanager.cpp
@@ -1,0 +1,184 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2016 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include "highlightrulemanager.h"
+#include "util.h"
+
+#include <QtCore>
+#include <QDebug>
+#include <QStringList>
+
+INIT_SYNCABLE_OBJECT(HighlightRuleManager)
+HighlightRuleManager &HighlightRuleManager::operator=(const HighlightRuleManager &other)
+{
+    if (this == &other)
+        return *this;
+
+    SyncableObject::operator=(other);
+    _highlightRuleList = other._highlightRuleList;
+    return *this;
+}
+
+
+int HighlightRuleManager::indexOf(const QString &name) const
+{
+    for (int i = 0; i < _highlightRuleList.count(); i++) {
+        if (_highlightRuleList[i].name == name)
+            return i;
+    }
+    return -1;
+}
+
+
+QVariantMap HighlightRuleManager::initHighlightRuleList() const
+{
+    QVariantMap highlightRuleListMap;
+    QStringList name;
+    QVariantList isRegEx;
+    QVariantList isCaseSensitive;
+    QVariantList isActive;
+    QStringList channel;
+
+    for (int i = 0; i < _highlightRuleList.count(); i++) {
+        name << _highlightRuleList[i].name;
+        isRegEx << _highlightRuleList[i].isRegEx;
+        isCaseSensitive << _highlightRuleList[i].isCaseSensitive;
+        isActive << _highlightRuleList[i].isEnabled;
+        channel << _highlightRuleList[i].chanName;
+    }
+
+    highlightRuleListMap["name"] = name;
+    highlightRuleListMap["isRegEx"] = isRegEx;
+    highlightRuleListMap["isCaseSensitive"] = isCaseSensitive;
+    highlightRuleListMap["isEnabled"] = isActive;
+    highlightRuleListMap["channel"] = channel;
+    return highlightRuleListMap;
+}
+
+
+void HighlightRuleManager::initSetHighlightRuleList(const QVariantMap &highlightRuleList)
+{
+    QStringList name = highlightRuleList["name"].toStringList();
+    QVariantList isRegEx = highlightRuleList["isRegEx"].toList();
+    QVariantList isCaseSensitive = highlightRuleList["isCaseSensitive"].toList();
+    QVariantList isActive = highlightRuleList["isEnabled"].toList();
+    QStringList channel = highlightRuleList["channel"].toStringList();
+
+    int count = name.count();
+    if (count != isRegEx.count() || count != isCaseSensitive.count() ||
+        count != isActive.count() || count != channel.count()) {
+        qWarning() << "Corrupted HighlightRuleList settings! (Count mismatch)";
+        return;
+    }
+
+    _highlightRuleList.clear();
+    for (int i = 0; i < name.count(); i++) {
+        _highlightRuleList << HighlightRule(name[i], isRegEx[i].toBool(), isCaseSensitive[i].toBool(),
+                                            isActive[i].toBool(), channel[i]);
+    }
+}
+
+void HighlightRuleManager::addHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive, bool isActive,
+                                            const QString &channel)
+{
+    if (contains(name)) {
+        return;
+    }
+
+    HighlightRule newItem = HighlightRule(name, isRegEx, isCaseSensitive, isActive, channel);
+    _highlightRuleList << newItem;
+
+    SYNC(ARG(name), ARG(isRegEx), ARG(isCaseSensitive), ARG(isActive), ARG(channel))
+}
+
+
+bool HighlightRuleManager::_match(const QString &msgContents, const QString &msgSender, Message::Type msgType, Message::Flags msgFlags, const QString &bufferName, const QString &currentNick, const QStringList identityNicks)
+{
+    if (!((msgType & (Message::Plain | Message::Notice | Message::Action)) && !(msgFlags & Message::Self))) {
+       return false;
+    }
+
+    if (!currentNick.isEmpty()) {
+        QStringList nickList;
+        if (_highlightNick == CurrentNick) {
+            nickList << currentNick;
+        }
+        else if (_highlightNick == AllNicks) {
+            nickList = identityNicks;
+            if (!nickList.contains(currentNick))
+                nickList.prepend(currentNick);
+        }
+            foreach(QString nickname, nickList) {
+                QRegExp nickRegExp("(^|\\W)" + QRegExp::escape(nickname) + "(\\W|$)", _nicksCaseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
+                if (nickRegExp.indexIn(stripFormatCodes(msgContents)) >= 0) {
+                    return true;
+                }
+            }
+
+        for (int i = 0; i < _highlightRuleList.count(); i++) {
+            const HighlightRule &rule = _highlightRuleList.at(i);
+            if (!rule.isEnabled)
+                continue;
+
+            if (rule.chanName.size() > 0 && rule.chanName.compare(".*") != 0) {
+                if (rule.chanName.startsWith("!")) {
+                    QRegExp rx(rule.chanName.mid(1), Qt::CaseInsensitive);
+                    if (rx.exactMatch(bufferName))
+                        continue;
+                }
+                else {
+                    QRegExp rx(rule.chanName, Qt::CaseInsensitive);
+                    if (!rx.exactMatch(bufferName))
+                        continue;
+                }
+            }
+
+            QRegExp rx;
+            if (rule.isRegEx) {
+                rx = QRegExp(rule.name, rule.isCaseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
+            }
+            else {
+                rx = QRegExp("(^|\\W)" + QRegExp::escape(rule.name) + "(\\W|$)", rule.isCaseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
+            }
+            bool match = (rx.indexIn(stripFormatCodes(msgContents)) >= 0);
+            if (match) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+void HighlightRuleManager::removeHighlightRule(const QString &highlightRule)
+{
+    removeAt(indexOf(highlightRule));
+    SYNC(ARG(highlightRule))
+}
+
+
+void HighlightRuleManager::toggleHighlightRule(const QString &highlightRule)
+{
+    int idx = indexOf(highlightRule);
+    if (idx == -1)
+        return;
+    _highlightRuleList[idx].isEnabled = !_highlightRuleList[idx].isEnabled;
+    SYNC(ARG(highlightRule))
+}

--- a/src/common/highlightrulemanager.cpp
+++ b/src/common/highlightrulemanager.cpp
@@ -188,3 +188,8 @@ void HighlightRuleManager::toggleHighlightRule(const QString &highlightRule)
     _highlightRuleList[idx].isEnabled = !_highlightRuleList[idx].isEnabled;
     SYNC(ARG(highlightRule))
 }
+
+bool HighlightRuleManager::match(const Message &msg, const QString &currentNick, const QStringList &identityNicks)
+{
+    return _match(msg.contents(), msg.sender(), msg.type(), msg.flags(), msg.bufferInfo().bufferName(), currentNick, identityNicks);
+}

--- a/src/common/highlightrulemanager.cpp
+++ b/src/common/highlightrulemanager.cpp
@@ -33,6 +33,8 @@ HighlightRuleManager &HighlightRuleManager::operator=(const HighlightRuleManager
 
     SyncableObject::operator=(other);
     _highlightRuleList = other._highlightRuleList;
+    _nicksCaseSensitive = other._nicksCaseSensitive;
+    _highlightNick = other._highlightNick;
     return *this;
 }
 
@@ -69,6 +71,8 @@ QVariantMap HighlightRuleManager::initHighlightRuleList() const
     highlightRuleListMap["isCaseSensitive"] = isCaseSensitive;
     highlightRuleListMap["isEnabled"] = isActive;
     highlightRuleListMap["channel"] = channel;
+    highlightRuleListMap["highlightNick"] = _highlightNick;
+    highlightRuleListMap["nicksCaseSensitive"] = _nicksCaseSensitive;
     return highlightRuleListMap;
 }
 
@@ -93,6 +97,8 @@ void HighlightRuleManager::initSetHighlightRuleList(const QVariantMap &highlight
         _highlightRuleList << HighlightRule(name[i], isRegEx[i].toBool(), isCaseSensitive[i].toBool(),
                                             isActive[i].toBool(), channel[i]);
     }
+    _highlightNick = HighlightNickType(highlightRuleList["highlightNick"].toInt());
+    _nicksCaseSensitive = highlightRuleList["nicksCaseSensitive"].toBool();
 }
 
 void HighlightRuleManager::addHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive, bool isActive,

--- a/src/common/highlightrulemanager.h
+++ b/src/common/highlightrulemanager.h
@@ -1,0 +1,134 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2016 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#ifndef HIGHLIGHTRULELISTMANAGER_H
+#define HIGHLIGHTRULELISTMANAGER_H
+
+#include <QString>
+#include <QRegExp>
+
+#include "message.h"
+#include "syncableobject.h"
+
+class HighlightRuleManager : public SyncableObject
+{
+    SYNCABLE_OBJECT
+        Q_OBJECT
+public:
+    enum HighlightNickType {
+        NoNick = 0x00,
+        CurrentNick = 0x01,
+        AllNicks = 0x02
+    };
+
+    inline HighlightRuleManager(QObject *parent = nullptr) : SyncableObject(parent) { setAllowClientUpdates(true); }
+    HighlightRuleManager &operator=(const HighlightRuleManager &other);
+
+    struct HighlightRule {
+        QString name;
+        bool isRegEx = false;
+        bool isCaseSensitive = false;
+        bool isEnabled = true;
+        QString chanName;
+        HighlightRule() {}
+        HighlightRule(const QString &name_, bool isRegEx_, bool isCaseSensitive_,
+                       bool isEnabled_, const QString &chanName_)
+            : name(name_), isRegEx(isRegEx_), isCaseSensitive(isCaseSensitive_), isEnabled(isEnabled_), chanName(chanName_) {
+        }
+        bool operator!=(const HighlightRule &other)
+        {
+            return (name != other.name ||
+                    isRegEx != other.isRegEx ||
+                    isCaseSensitive != other.isCaseSensitive ||
+                    isEnabled != other.isEnabled ||
+                    chanName != other.chanName);
+        }
+    };
+    typedef QList<HighlightRule> HighlightRuleList;
+
+    int indexOf(const QString &rule) const;
+    inline bool contains(const QString &rule) const { return indexOf(rule) != -1; }
+    inline bool isEmpty() const { return _highlightRuleList.isEmpty(); }
+    inline int count() const { return _highlightRuleList.count(); }
+    inline void removeAt(int index) { _highlightRuleList.removeAt(index); }
+    inline HighlightRule &operator[](int i) { return _highlightRuleList[i]; }
+    inline const HighlightRule &operator[](int i) const { return _highlightRuleList.at(i); }
+    inline const HighlightRuleList &highlightRuleList() const { return _highlightRuleList; }
+
+    //! Check if a message matches the HighlightRule
+    /** This method checks if a message matches the users highlight rules.
+      * \param msg The Message that should be checked
+      */
+    inline bool match(const Message &msg, const QString &currentNick, const QStringList &identityNicks) { return _match(msg.contents(), msg.sender(), msg.type(), msg.flags(), msg.bufferInfo().bufferName(), currentNick, identityNicks); }
+
+public slots:
+    virtual QVariantMap initHighlightRuleList() const;
+    virtual void initSetHighlightRuleList(const QVariantMap &HighlightRuleList);
+
+    //! Request removal of an ignore rule based on the rule itself.
+    /** Use this method if you want to remove a single ignore rule
+      * and get that synced with the core immediately.
+      * \param highlightRule A valid ignore rule
+      */
+    virtual inline void requestRemoveHighlightRule(const QString &highlightRule) { REQUEST(ARG(highlightRule)) }
+    virtual void removeHighlightRule(const QString &highlightRule);
+
+    //! Request toggling of "isEnabled" flag of a given ignore rule.
+    /** Use this method if you want to toggle the "isEnabled" flag of a single ignore rule
+      * and get that synced with the core immediately.
+      * \param highlightRule A valid ignore rule
+      */
+    virtual inline void requestToggleHighlightRule(const QString &highlightRule) { REQUEST(ARG(highlightRule)) }
+    virtual void toggleHighlightRule(const QString &highlightRule);
+
+    //! Request an HighlightRule to be added to the ignore list
+    /** Items added to the list with this method, get immediately synced with the core
+      * \param name The rule
+      * \param isRegEx If the rule should be interpreted as a nickname, or a regex
+      * \param isCaseSensitive If the rule should be interpreted as case-sensitive
+      * \param isEnabled If the rule is active
+      * @param chanName The channel in which the rule should apply
+      */
+    virtual inline void requestAddHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive, bool isEnabled,
+                                                const QString &chanName)
+    {
+        REQUEST(ARG(name), ARG(isRegEx), ARG(isCaseSensitive), ARG(isEnabled), ARG(chanName))
+    }
+
+
+    virtual void addHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive,
+                                  bool isEnabled, const QString &chanName);
+
+protected:
+    void setHighlightRuleList(const QList<HighlightRule> &HighlightRuleList) { _highlightRuleList = HighlightRuleList; }
+
+    bool _match(const QString &msgContents, const QString &msgSender, Message::Type msgType, Message::Flags msgFlags, const QString &bufferName, const QString &currentNick, const QStringList identityNicks);
+
+signals:
+    void ruleAdded(QString name, bool isRegEx, bool isCaseSensitive, bool isEnabled, QString chanName);
+
+private:
+    HighlightRuleList _highlightRuleList;
+    HighlightNickType _highlightNick = HighlightNickType::CurrentNick;
+    bool _nicksCaseSensitive = false;
+};
+
+
+#endif // HIGHLIGHTRULELISTMANAGER_H

--- a/src/common/highlightrulemanager.h
+++ b/src/common/highlightrulemanager.h
@@ -80,7 +80,7 @@ public:
     /** This method checks if a message matches the users highlight rules.
       * \param msg The Message that should be checked
       */
-    inline bool match(const Message &msg, const QString &currentNick, const QStringList &identityNicks) { return _match(msg.contents(), msg.sender(), msg.type(), msg.flags(), msg.bufferInfo().bufferName(), currentNick, identityNicks); }
+    bool match(const Message &msg, const QString &currentNick, const QStringList &identityNicks);
 
 public slots:
     virtual QVariantMap initHighlightRuleList() const;

--- a/src/common/highlightrulemanager.h
+++ b/src/common/highlightrulemanager.h
@@ -38,7 +38,6 @@ public:
         CurrentNick = 0x01,
         AllNicks = 0x02
     };
-    Q_ENUM(HighlightNickType);
 
     inline HighlightRuleManager(QObject *parent = nullptr) : SyncableObject(parent) { setAllowClientUpdates(true); }
     HighlightRuleManager &operator=(const HighlightRuleManager &other);

--- a/src/common/highlightrulemanager.h
+++ b/src/common/highlightrulemanager.h
@@ -46,11 +46,13 @@ public:
         bool isRegEx = false;
         bool isCaseSensitive = false;
         bool isEnabled = true;
+        bool isInverse = false;
         QString chanName;
         HighlightRule() {}
         HighlightRule(const QString &name_, bool isRegEx_, bool isCaseSensitive_,
-                       bool isEnabled_, const QString &chanName_)
-            : name(name_), isRegEx(isRegEx_), isCaseSensitive(isCaseSensitive_), isEnabled(isEnabled_), chanName(chanName_) {
+                       bool isEnabled_, bool isInverse_, const QString &chanName_)
+            : name(name_), isRegEx(isRegEx_), isCaseSensitive(isCaseSensitive_), isEnabled(isEnabled_),
+              isInverse(isInverse_), chanName(chanName_) {
         }
         bool operator!=(const HighlightRule &other)
         {
@@ -58,6 +60,7 @@ public:
                     isRegEx != other.isRegEx ||
                     isCaseSensitive != other.isCaseSensitive ||
                     isEnabled != other.isEnabled ||
+                    isInverse != other.isInverse ||
                     chanName != other.chanName);
         }
     };
@@ -111,14 +114,14 @@ public slots:
       * @param chanName The channel in which the rule should apply
       */
     virtual inline void requestAddHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive, bool isEnabled,
-                                                const QString &chanName)
+                                                bool isInverse, const QString &chanName)
     {
-        REQUEST(ARG(name), ARG(isRegEx), ARG(isCaseSensitive), ARG(isEnabled), ARG(chanName))
+        REQUEST(ARG(name), ARG(isRegEx), ARG(isCaseSensitive), ARG(isEnabled), ARG(isInverse), ARG(chanName))
     }
 
 
     virtual void addHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive,
-                                  bool isEnabled, const QString &chanName);
+                                  bool isEnabled, bool isInverse, const QString &chanName);
 
     virtual inline void requestSetHighlightNick(HighlightNickType highlightNick)
     {
@@ -138,7 +141,7 @@ protected:
     bool _match(const QString &msgContents, const QString &msgSender, Message::Type msgType, Message::Flags msgFlags, const QString &bufferName, const QString &currentNick, const QStringList identityNicks);
 
 signals:
-    void ruleAdded(QString name, bool isRegEx, bool isCaseSensitive, bool isEnabled, QString chanName);
+    void ruleAdded(QString name, bool isRegEx, bool isCaseSensitive, bool isEnabled, bool isInverse, QString chanName);
 
 private:
     HighlightRuleList _highlightRuleList;

--- a/src/common/highlightrulemanager.h
+++ b/src/common/highlightrulemanager.h
@@ -120,6 +120,18 @@ public slots:
     virtual void addHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive,
                                   bool isEnabled, const QString &chanName);
 
+    virtual inline void requestSetHighlightNick(HighlightNickType highlightNick)
+    {
+        REQUEST(ARG(highlightNick))
+    }
+    inline void setHighlightNick(HighlightNickType highlightNick) { _highlightNick = highlightNick; }
+
+    virtual inline void requestSetNicksCaseSensitive(bool nicksCaseSensitive)
+    {
+        REQUEST(ARG(nicksCaseSensitive))
+    }
+    inline void setNicksCaseSensitive(bool nicksCaseSensitive) { _nicksCaseSensitive = nicksCaseSensitive; }
+
 protected:
     void setHighlightRuleList(const QList<HighlightRule> &HighlightRuleList) { _highlightRuleList = HighlightRuleList; }
 

--- a/src/common/highlightrulemanager.h
+++ b/src/common/highlightrulemanager.h
@@ -23,6 +23,7 @@
 
 #include <QString>
 #include <QRegExp>
+#include <utility>
 
 #include "message.h"
 #include "syncableobject.h"
@@ -47,12 +48,13 @@ public:
         bool isCaseSensitive = false;
         bool isEnabled = true;
         bool isInverse = false;
+        QString sender;
         QString chanName;
         HighlightRule() {}
-        HighlightRule(const QString &name_, bool isRegEx_, bool isCaseSensitive_,
-                       bool isEnabled_, bool isInverse_, const QString &chanName_)
-            : name(name_), isRegEx(isRegEx_), isCaseSensitive(isCaseSensitive_), isEnabled(isEnabled_),
-              isInverse(isInverse_), chanName(chanName_) {
+        HighlightRule(QString name_, bool isRegEx_, bool isCaseSensitive_, bool isEnabled_, bool isInverse_,
+                      QString sender_, QString chanName_)
+            : name(std::move(name_)), isRegEx(isRegEx_), isCaseSensitive(isCaseSensitive_), isEnabled(isEnabled_),
+              isInverse(isInverse_), sender(std::move(sender_)), chanName(std::move(chanName_)) {
         }
         bool operator!=(const HighlightRule &other)
         {
@@ -61,6 +63,7 @@ public:
                     isCaseSensitive != other.isCaseSensitive ||
                     isEnabled != other.isEnabled ||
                     isInverse != other.isInverse ||
+                    sender != other.sender ||
                     chanName != other.chanName);
         }
     };
@@ -114,14 +117,14 @@ public slots:
       * @param chanName The channel in which the rule should apply
       */
     virtual inline void requestAddHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive, bool isEnabled,
-                                                bool isInverse, const QString &chanName)
+                                                bool isInverse, const QString &sender, const QString &chanName)
     {
-        REQUEST(ARG(name), ARG(isRegEx), ARG(isCaseSensitive), ARG(isEnabled), ARG(isInverse), ARG(chanName))
+        REQUEST(ARG(name), ARG(isRegEx), ARG(isCaseSensitive), ARG(isEnabled), ARG(isInverse), ARG(sender), ARG(chanName))
     }
 
 
-    virtual void addHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive,
-                                  bool isEnabled, bool isInverse, const QString &chanName);
+    virtual void addHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive, bool isEnabled,
+                                  bool isInverse, const QString &sender, const QString &chanName);
 
     virtual inline void requestSetHighlightNick(HighlightNickType highlightNick)
     {
@@ -141,7 +144,7 @@ protected:
     bool _match(const QString &msgContents, const QString &msgSender, Message::Type msgType, Message::Flags msgFlags, const QString &bufferName, const QString &currentNick, const QStringList identityNicks);
 
 signals:
-    void ruleAdded(QString name, bool isRegEx, bool isCaseSensitive, bool isEnabled, bool isInverse, QString chanName);
+    void ruleAdded(QString name, bool isRegEx, bool isCaseSensitive, bool isEnabled, bool isInverse, QString sender, QString chanName);
 
 private:
     HighlightRuleList _highlightRuleList;

--- a/src/common/highlightrulemanager.h
+++ b/src/common/highlightrulemanager.h
@@ -38,6 +38,7 @@ public:
         CurrentNick = 0x01,
         AllNicks = 0x02
     };
+    Q_ENUM(HighlightNickType);
 
     inline HighlightRuleManager(QObject *parent = nullptr) : SyncableObject(parent) { setAllowClientUpdates(true); }
     HighlightRuleManager &operator=(const HighlightRuleManager &other);

--- a/src/common/highlightrulemanager.h
+++ b/src/common/highlightrulemanager.h
@@ -68,9 +68,13 @@ public:
     inline bool isEmpty() const { return _highlightRuleList.isEmpty(); }
     inline int count() const { return _highlightRuleList.count(); }
     inline void removeAt(int index) { _highlightRuleList.removeAt(index); }
+    inline void clear() { _highlightRuleList.clear(); }
     inline HighlightRule &operator[](int i) { return _highlightRuleList[i]; }
     inline const HighlightRule &operator[](int i) const { return _highlightRuleList.at(i); }
     inline const HighlightRuleList &highlightRuleList() const { return _highlightRuleList; }
+
+    inline HighlightNickType highlightNick() { return _highlightNick; }
+    inline bool  nicksCaseSensitive() { return _nicksCaseSensitive; }
 
     //! Check if a message matches the HighlightRule
     /** This method checks if a message matches the users highlight rules.

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -78,8 +78,9 @@ public:
         AwayFormatTimestamp = 0x0200,      /// Timestamp formatting in away (e.g. %%hh:mm%%)
         Authenticators = 0x0400,           /// Whether or not the core supports auth backends.
         BufferActivitySync = 0x0800,       /// Sync buffer activity status
+        CoreSideHighlights = 0x1000,       /// Core-Side highlight configuration and matching
 
-        NumFeatures = 0x0800
+        NumFeatures = 0x1000
     };
     Q_DECLARE_FLAGS(Features, Feature)
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     corebufferviewmanager.cpp
     corecoreinfo.cpp
     coredccconfig.cpp
+    corehighlightrulemanager.cpp
     coreidentity.cpp
     coreignorelistmanager.cpp
     coreircchannel.cpp

--- a/src/core/corehighlightrulemanager.cpp
+++ b/src/core/corehighlightrulemanager.cpp
@@ -1,0 +1,57 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2016 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include "corehighlightrulemanager.h"
+
+#include "core.h"
+#include "coresession.h"
+
+INIT_SYNCABLE_OBJECT(CoreHighlightRuleManager)
+CoreHighlightRuleManager::CoreHighlightRuleManager(CoreSession *parent)
+    : HighlightRuleManager(parent)
+{
+    CoreSession *session = qobject_cast<CoreSession*>(parent);
+    if (!session) {
+        qWarning() << "CoreHighlightRuleManager: unable to load HighlightRuleList. Parent is not a Coresession!";
+        //loadDefaults();
+        return;
+    }
+
+    initSetHighlightRuleList(Core::getUserSetting(session->user(), "HighlightRuleList").toMap());
+
+    // we store our settings whenever they change
+    connect(this, SIGNAL(updatedRemotely()), SLOT(save()));
+}
+
+void CoreHighlightRuleManager::save() const
+{
+    CoreSession *session = qobject_cast<CoreSession *>(parent());
+    if (!session) {
+        qWarning() << "CoreHighlightRuleManager: unable to save HighlightRuleList. Parent is not a Coresession!";
+        return;
+    }
+
+    Core::setUserSetting(session->user(), "HighlightRuleList", initHighlightRuleList());
+}
+
+bool CoreHighlightRuleManager::match(const RawMessage &msg, const QString &currentNick, const QStringList &identityNicks)
+{
+    return _match(msg.text, msg.sender, msg.type, msg.flags, msg.target, currentNick, identityNicks);
+}

--- a/src/core/corehighlightrulemanager.h
+++ b/src/core/corehighlightrulemanager.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2016 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#ifndef COREHIGHLIGHTRULEMANAHER_H
+#define COREHIGHLIGHTRULEMANAHER_H
+
+#include "highlightrulemanager.h"
+
+class CoreSession;
+struct RawMessage;
+
+class CoreHighlightRuleManager : public HighlightRuleManager
+{
+    SYNCABLE_OBJECT
+        Q_OBJECT
+
+public:
+    explicit CoreHighlightRuleManager(CoreSession *parent);
+
+    inline virtual const QMetaObject *syncMetaObject() const { return &HighlightRuleManager::staticMetaObject; }
+
+    bool match(const RawMessage &msg, const QString &currentNick, const QStringList &identityNicks);
+public slots:
+    virtual inline void requestToggleHighlightRule(const QString &highlightRule) { toggleHighlightRule(highlightRule); }
+    virtual inline void requestRemoveHighlightRule(const QString &highlightRule) { removeHighlightRule(highlightRule); }
+    virtual inline void requestAddHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive,
+                                                 bool isEnabled, const QString &chanName)
+    {
+        addHighlightRule(name, isRegEx, isCaseSensitive, isEnabled, chanName);
+    }
+
+
+private slots:
+    void save() const;
+};
+
+
+#endif //COREHIGHLIGHTRULEMANAHER_H

--- a/src/core/corehighlightrulemanager.h
+++ b/src/core/corehighlightrulemanager.h
@@ -40,10 +40,10 @@ public:
 public slots:
     virtual inline void requestToggleHighlightRule(const QString &highlightRule) { toggleHighlightRule(highlightRule); }
     virtual inline void requestRemoveHighlightRule(const QString &highlightRule) { removeHighlightRule(highlightRule); }
-    virtual inline void requestAddHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive,
-                                                 bool isEnabled, bool isInverse, const QString &chanName)
+    virtual inline void requestAddHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive, bool isEnabled,
+                                                bool isInverse, const QString &sender, const QString &chanName)
     {
-        addHighlightRule(name, isRegEx, isCaseSensitive, isEnabled, isInverse, chanName);
+        addHighlightRule(name, isRegEx, isCaseSensitive, isEnabled, isInverse, sender, chanName);
     }
 
 

--- a/src/core/corehighlightrulemanager.h
+++ b/src/core/corehighlightrulemanager.h
@@ -41,9 +41,9 @@ public slots:
     virtual inline void requestToggleHighlightRule(const QString &highlightRule) { toggleHighlightRule(highlightRule); }
     virtual inline void requestRemoveHighlightRule(const QString &highlightRule) { removeHighlightRule(highlightRule); }
     virtual inline void requestAddHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive,
-                                                 bool isEnabled, const QString &chanName)
+                                                 bool isEnabled, bool isInverse, const QString &chanName)
     {
-        addHighlightRule(name, isRegEx, isCaseSensitive, isEnabled, chanName);
+        addHighlightRule(name, isRegEx, isCaseSensitive, isEnabled, isInverse, chanName);
     }
 
 

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -31,6 +31,7 @@
 #include "protocol.h"
 #include "message.h"
 #include "storage.h"
+#include "corehighlightrulemanager.h"
 
 class CoreBacklogManager;
 class CoreBufferSyncer;
@@ -87,6 +88,7 @@ public:
     inline CoreIrcListHelper *ircListHelper() const { return _ircListHelper; }
 
     inline CoreIgnoreListManager *ignoreListManager() { return &_ignoreListManager; }
+    inline HighlightRuleManager *highlightRuleManager() { return &_highlightRuleManager; }
     inline CoreTransferManager *transferManager() const { return _transferManager; }
     inline CoreDccConfig *dccConfig() const { return _dccConfig; }
 
@@ -238,6 +240,7 @@ private:
     QList<RawMessage> _messageQueue;
     bool _processMessages;
     CoreIgnoreListManager _ignoreListManager;
+    CoreHighlightRuleManager _highlightRuleManager;
 };
 
 

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -27,6 +27,7 @@
 #include <QTableView>
 #include <QToolBar>
 #include <QInputDialog>
+#include <settingspages/corehighlightsettingspage.h>
 
 #ifdef HAVE_KDE4
 #  include <KHelpMenu>
@@ -1442,6 +1443,7 @@ void MainWin::showSettingsDlg()
     dlg->registerSettingsPage(new SonnetSettingsPage(dlg));
 #endif
     dlg->registerSettingsPage(new HighlightSettingsPage(dlg));
+    dlg->registerSettingsPage(new CoreHighlightSettingsPage(dlg));
     dlg->registerSettingsPage(new NotificationsSettingsPage(dlg));
     dlg->registerSettingsPage(new BacklogSettingsPage(dlg));
 

--- a/src/qtui/qtuimessageprocessor.cpp
+++ b/src/qtui/qtuimessageprocessor.cpp
@@ -57,7 +57,8 @@ void QtUiMessageProcessor::reset()
 
 void QtUiMessageProcessor::process(Message &msg)
 {
-    checkForHighlight(msg);
+    if (!Client::coreFeatures().testFlag(Quassel::Feature::CoreSideHighlights))
+        checkForHighlight(msg);
     preProcess(msg);
     Client::messageModel()->insertMessage(msg);
 }
@@ -68,7 +69,8 @@ void QtUiMessageProcessor::process(QList<Message> &msgs)
     QList<Message>::iterator msgIter = msgs.begin();
     QList<Message>::iterator msgIterEnd = msgs.end();
     while (msgIter != msgIterEnd) {
-        checkForHighlight(*msgIter);
+        if (!Client::coreFeatures().testFlag(Quassel::Feature::CoreSideHighlights))
+            checkForHighlight(*msgIter);
         preProcess(*msgIter);
         ++msgIter;
     }

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -1,0 +1,295 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2016 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include "corehighlightsettingspage.h"
+
+#include "qtui.h"
+#include "uisettings.h"
+
+#include <QHeaderView>
+#include <client.h>
+
+CoreHighlightSettingsPage::CoreHighlightSettingsPage(QWidget *parent)
+    : SettingsPage(tr("Interface"), tr("Core-Side Highlights"), parent)
+{
+    ui.setupUi(this);
+    ui.highlightTable->verticalHeader()->hide();
+    ui.highlightTable->setShowGrid(false);
+
+    ui.highlightTable->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->setToolTip("<b>RegEx</b>: This option determines if the highlight rule should be interpreted as a <b>regular expression</b> or just as a keyword.");
+    ui.highlightTable->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->setWhatsThis("<b>RegEx</b>: This option determines if the highlight rule should be interpreted as a <b>regular expression</b> or just as a keyword.");
+
+    ui.highlightTable->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->setToolTip("<b>CS</b>: This option determines if the highlight rule should be interpreted <b>case sensitive</b>.");
+    ui.highlightTable->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->setWhatsThis("<b>CS</b>: This option determines if the highlight rule should be interpreted <b>case sensitive</b>.");
+
+    ui.highlightTable->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->setToolTip("<b>Channel</b>: This regular expression determines for which <b>channels</b> the highlight rule works. Leave blank to match any channel. Put <b>!</b> in the beginning to negate. Case insensitive.");
+    ui.highlightTable->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->setWhatsThis("<b>Channel</b>: This regular expression determines for which <b>channels</b> the highlight rule works. Leave blank to match any channel. Put <b>!</b> in the beginning to negate. Case insensitive.");
+
+#if QT_VERSION < 0x050000
+    ui.highlightTable->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::NameColumn, QHeaderView::Stretch);
+    ui.highlightTable->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::RegExColumn, QHeaderView::ResizeToContents);
+    ui.highlightTable->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::CsColumn, QHeaderView::ResizeToContents);
+    ui.highlightTable->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::EnableColumn, QHeaderView::ResizeToContents);
+    ui.highlightTable->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::ChanColumn, QHeaderView::ResizeToContents);
+#else
+    ui.highlightTable->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::NameColumn, QHeaderView::Stretch);
+    ui.highlightTable->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::RegExColumn, QHeaderView::ResizeToContents);
+    ui.highlightTable->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::CsColumn, QHeaderView::ResizeToContents);
+    ui.highlightTable->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::EnableColumn, QHeaderView::ResizeToContents);
+    ui.highlightTable->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::ChanColumn, QHeaderView::ResizeToContents);
+#endif
+
+    connect(ui.add, SIGNAL(clicked(bool)), this, SLOT(addNewRow()));
+    connect(ui.remove, SIGNAL(clicked(bool)), this, SLOT(removeSelectedRows()));
+    //TODO: search for a better signal (one that emits everytime a selection has been changed for one item)
+    connect(ui.highlightTable, SIGNAL(itemClicked(QTableWidgetItem *)), this, SLOT(selectRow(QTableWidgetItem *)));
+
+    connect(ui.highlightAllNicks, SIGNAL(clicked(bool)), this, SLOT(widgetHasChanged()));
+    connect(ui.highlightCurrentNick, SIGNAL(clicked(bool)), this, SLOT(widgetHasChanged()));
+    connect(ui.highlightNoNick, SIGNAL(clicked(bool)), this, SLOT(widgetHasChanged()));
+    connect(ui.nicksCaseSensitive, SIGNAL(clicked(bool)), this, SLOT(widgetHasChanged()));
+    connect(ui.add, SIGNAL(clicked()), this, SLOT(widgetHasChanged()));
+    connect(ui.remove, SIGNAL(clicked()), this, SLOT(widgetHasChanged()));
+    connect(ui.highlightTable, SIGNAL(itemChanged(QTableWidgetItem *)), this, SLOT(tableChanged(QTableWidgetItem *)));
+
+    connect(Client::instance(), SIGNAL(connected()), this, SLOT(clientConnected()));
+}
+
+void CoreHighlightSettingsPage::clientConnected()
+{
+    connect(Client::highlightRuleManager(), SIGNAL(updated()), SLOT(revert()));
+}
+
+
+void CoreHighlightSettingsPage::revert()
+{
+    qWarning() << "revert()";
+
+    if (!hasChanged())
+        return;
+
+    setChangedState(false);
+    load();
+}
+
+
+bool CoreHighlightSettingsPage::hasDefaults() const
+{
+    return true;
+}
+
+
+void CoreHighlightSettingsPage::defaults()
+{
+    ui.highlightCurrentNick->setChecked(true);
+    ui.nicksCaseSensitive->setChecked(false);
+    emptyTable();
+
+    widgetHasChanged();
+}
+
+
+void CoreHighlightSettingsPage::addNewRow(QString name, bool regex, bool cs, bool enable, QString chanName, bool self)
+{
+    ui.highlightTable->setRowCount(ui.highlightTable->rowCount()+1);
+
+    auto *nameItem = new QTableWidgetItem(name);
+
+    auto *regexItem = new QTableWidgetItem("");
+    if (regex)
+        regexItem->setCheckState(Qt::Checked);
+    else
+        regexItem->setCheckState(Qt::Unchecked);
+    regexItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
+
+    auto *csItem = new QTableWidgetItem("");
+    if (cs)
+        csItem->setCheckState(Qt::Checked);
+    else
+        csItem->setCheckState(Qt::Unchecked);
+    csItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
+
+    auto *enableItem = new QTableWidgetItem("");
+    if (enable)
+        enableItem->setCheckState(Qt::Checked);
+    else
+        enableItem->setCheckState(Qt::Unchecked);
+    enableItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
+
+    auto *chanNameItem = new QTableWidgetItem(chanName);
+
+    int lastRow = ui.highlightTable->rowCount()-1;
+    ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::NameColumn, nameItem);
+    ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::RegExColumn, regexItem);
+    ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::CsColumn, csItem);
+    ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::EnableColumn, enableItem);
+    ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::ChanColumn, chanNameItem);
+
+    if (!self)
+        ui.highlightTable->setCurrentItem(nameItem);
+
+    highlightList << HighlightRuleManager::HighlightRule(name, regex, cs, enable, chanName);
+}
+
+
+void CoreHighlightSettingsPage::removeSelectedRows()
+{
+    QList<int> selectedRows;
+    QList<QTableWidgetItem *> selectedItemList = ui.highlightTable->selectedItems();
+    foreach(QTableWidgetItem *selectedItem, selectedItemList) {
+        selectedRows.append(selectedItem->row());
+    }
+    qSort(selectedRows.begin(), selectedRows.end(), qGreater<int>());
+    int lastRow = -1;
+    foreach(int row, selectedRows) {
+        if (row != lastRow) {
+            ui.highlightTable->removeRow(row);
+            highlightList.removeAt(row);
+        }
+        lastRow = row;
+    }
+}
+
+
+void CoreHighlightSettingsPage::selectRow(QTableWidgetItem *item)
+{
+    int row = item->row();
+    bool selected = item->isSelected();
+    ui.highlightTable->setRangeSelected(QTableWidgetSelectionRange(row, 0, row, CoreHighlightSettingsPage::ColumnCount-1), selected);
+}
+
+
+void CoreHighlightSettingsPage::emptyTable()
+{
+    // ui.highlight and highlightList should have the same size, but just to make sure.
+    if (ui.highlightTable->rowCount() != highlightList.size()) {
+        qDebug() << "something is wrong: ui.highlight and highlightList don't have the same size!";
+    }
+    while (ui.highlightTable->rowCount()) {
+        ui.highlightTable->removeRow(0);
+    }
+    while (highlightList.size()) {
+        highlightList.removeLast();
+    }
+}
+
+
+void CoreHighlightSettingsPage::tableChanged(QTableWidgetItem *item)
+{
+    if (item->row()+1 > highlightList.size())
+        return;
+
+    auto highlightRule = highlightList.value(item->row());
+
+
+    switch (item->column())
+    {
+    case CoreHighlightSettingsPage::NameColumn:
+        if (item->text() == "")
+            item->setText(tr("this shouldn't be empty"));
+        highlightRule.name = item->text();
+        break;
+    case CoreHighlightSettingsPage::RegExColumn:
+        highlightRule.isRegEx = (item->checkState() == Qt::Checked);
+        break;
+    case CoreHighlightSettingsPage::CsColumn:
+        highlightRule.isCaseSensitive = (item->checkState() == Qt::Checked);
+        break;
+    case CoreHighlightSettingsPage::EnableColumn:
+        highlightRule.isEnabled = (item->checkState() == Qt::Checked);
+        break;
+    case CoreHighlightSettingsPage::ChanColumn:
+        if (!item->text().isEmpty() && item->text().trimmed().isEmpty())
+            item->setText("");
+        highlightRule.chanName = item->text();
+        break;
+    }
+    highlightList[item->row()] = highlightRule;
+    emit widgetHasChanged();
+}
+
+
+void CoreHighlightSettingsPage::load()
+{
+    emptyTable();
+
+    auto ruleManager = Client::highlightRuleManager();
+    for (HighlightRuleManager::HighlightRule rule : ruleManager->highlightRuleList()) {
+        addNewRow(rule.name, rule.isRegEx, rule.isCaseSensitive, rule.isEnabled, rule.chanName);
+    }
+
+    switch (ruleManager->highlightNick())
+    {
+    case HighlightRuleManager::NoNick:
+        ui.highlightNoNick->setChecked(true);
+        break;
+    case HighlightRuleManager::CurrentNick:
+        ui.highlightCurrentNick->setChecked(true);
+        break;
+    case HighlightRuleManager::AllNicks:
+        ui.highlightAllNicks->setChecked(true);
+        break;
+    }
+    ui.nicksCaseSensitive->setChecked(ruleManager->nicksCaseSensitive());
+
+    setChangedState(false);
+    _initialized = true;
+}
+
+void CoreHighlightSettingsPage::save()
+{
+    if (!hasChanged())
+        return;
+
+    if (!_initialized)
+        return;
+
+    auto ruleManager = Client::highlightRuleManager();
+    if (ruleManager == nullptr)
+        return;
+
+    auto clonedManager = HighlightRuleManager();
+    clonedManager.fromVariantMap(ruleManager->toVariantMap());
+    clonedManager.clear();
+
+    for (const HighlightRuleManager::HighlightRule &rule : highlightList) {
+        clonedManager.addHighlightRule(rule.name, rule.isRegEx, rule.isCaseSensitive, rule.isRegEx, rule.chanName);
+    }
+
+    HighlightRuleManager::HighlightNickType highlightNickType = HighlightRuleManager::NoNick;
+    if (ui.highlightCurrentNick->isChecked())
+        highlightNickType = HighlightRuleManager::CurrentNick;
+    if (ui.highlightAllNicks->isChecked())
+        highlightNickType = HighlightRuleManager::AllNicks;
+
+
+    clonedManager.setHighlightNick(highlightNickType);
+    clonedManager.setNicksCaseSensitive(ui.nicksCaseSensitive->isChecked());
+
+    ruleManager->requestUpdate(clonedManager.toVariantMap());
+    setChangedState(false);
+    load();
+}
+
+
+void CoreHighlightSettingsPage::widgetHasChanged()
+{
+    setChangedState(true);
+}

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -107,7 +107,8 @@ void CoreHighlightSettingsPage::defaults()
 }
 
 
-void CoreHighlightSettingsPage::addNewRow(QString name, bool regex, bool cs, bool enable, bool inverse, QString chanName, bool self)
+void CoreHighlightSettingsPage::addNewRow(const QString &name, bool regex, bool cs, bool enable, bool inverse, const QString &sender,
+                                          const QString &chanName, bool self)
 {
     ui.highlightTable->setRowCount(ui.highlightTable->rowCount()+1);
 
@@ -143,18 +144,21 @@ void CoreHighlightSettingsPage::addNewRow(QString name, bool regex, bool cs, boo
 
     auto *chanNameItem = new QTableWidgetItem(chanName);
 
+    auto *senderItem = new QTableWidgetItem(sender);
+
     int lastRow = ui.highlightTable->rowCount()-1;
     ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::NameColumn, nameItem);
     ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::RegExColumn, regexItem);
     ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::CsColumn, csItem);
     ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::EnableColumn, enableItem);
     ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::InverseColumn, inverseItem);
+    ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::SenderColumn, senderItem);
     ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::ChanColumn, chanNameItem);
 
     if (!self)
         ui.highlightTable->setCurrentItem(nameItem);
 
-    highlightList << HighlightRuleManager::HighlightRule(name, regex, cs, enable, inverse, chanName);
+    highlightList << HighlightRuleManager::HighlightRule(name, regex, cs, enable, inverse, sender, chanName);
 }
 
 
@@ -227,6 +231,11 @@ void CoreHighlightSettingsPage::tableChanged(QTableWidgetItem *item)
     case CoreHighlightSettingsPage::InverseColumn:
         highlightRule.isInverse = (item->checkState() == Qt::Checked);
         break;
+        case CoreHighlightSettingsPage::SenderColumn:
+            if (!item->text().isEmpty() && item->text().trimmed().isEmpty())
+                item->setText("");
+            highlightRule.sender = item->text();
+            break;
     case CoreHighlightSettingsPage::ChanColumn:
         if (!item->text().isEmpty() && item->text().trimmed().isEmpty())
             item->setText("");
@@ -244,7 +253,7 @@ void CoreHighlightSettingsPage::load()
 
     auto ruleManager = Client::highlightRuleManager();
     for (HighlightRuleManager::HighlightRule rule : ruleManager->highlightRuleList()) {
-        addNewRow(rule.name, rule.isRegEx, rule.isCaseSensitive, rule.isEnabled, rule.isInverse, rule.chanName);
+        addNewRow(rule.name, rule.isRegEx, rule.isCaseSensitive, rule.isEnabled, rule.isInverse, rule.sender, rule.chanName);
     }
 
     switch (ruleManager->highlightNick())
@@ -282,7 +291,8 @@ void CoreHighlightSettingsPage::save()
     clonedManager.clear();
 
     for (const HighlightRuleManager::HighlightRule &rule : highlightList) {
-        clonedManager.addHighlightRule(rule.name, rule.isRegEx, rule.isCaseSensitive, rule.isEnabled, rule.isInverse, rule.chanName);
+        clonedManager.addHighlightRule(rule.name, rule.isRegEx, rule.isCaseSensitive, rule.isEnabled, rule.isInverse,
+                                       rule.sender, rule.chanName);
     }
 
     HighlightRuleManager::HighlightNickType highlightNickType = HighlightRuleManager::NoNick;

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -131,7 +131,8 @@ bool CoreHighlightSettingsPage::hasDefaults() const
 
 void CoreHighlightSettingsPage::defaults()
 {
-    int defaultIndex = ui.highlightNicksComboBox->findData(QVariant(HighlightRuleManager::HighlightNickType::CurrentNick));
+    int highlightNickType = HighlightRuleManager::HighlightNickType::CurrentNick;
+    int defaultIndex = ui.highlightNicksComboBox->findData(QVariant(highlightNickType));
     ui.highlightNicksComboBox->setCurrentIndex(defaultIndex);
     ui.nicksCaseSensitive->setChecked(false);
     emptyHighlightTable();
@@ -402,8 +403,8 @@ void CoreHighlightSettingsPage::load()
             }
         }
 
-        ui.highlightNicksComboBox
-            ->setCurrentIndex(ui.highlightNicksComboBox->findData(QVariant(ruleManager->highlightNick())));
+        int highlightNickType = ruleManager->highlightNick();
+        ui.highlightNicksComboBox->setCurrentIndex(ui.highlightNicksComboBox->findData(QVariant(highlightNickType)));
         ui.nicksCaseSensitive->setChecked(ruleManager->nicksCaseSensitive());
 
         setChangedState(false);
@@ -439,9 +440,9 @@ void CoreHighlightSettingsPage::save()
                                        rule.sender, rule.chanName);
     }
 
-    auto highlightNickType = ui.highlightNicksComboBox->currentData().value<HighlightRuleManager::HighlightNickType>();
+    auto highlightNickType = ui.highlightNicksComboBox->currentData().value<int>();
 
-    clonedManager.setHighlightNick(highlightNickType);
+    clonedManager.setHighlightNick(HighlightRuleManager::HighlightNickType(highlightNickType));
     clonedManager.setNicksCaseSensitive(ui.nicksCaseSensitive->isChecked());
 
     ruleManager->requestUpdate(clonedManager.toVariantMap());

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -33,9 +33,9 @@ CoreHighlightSettingsPage::CoreHighlightSettingsPage(QWidget *parent)
     setupRuleTable(ui.highlightTable);
     setupRuleTable(ui.ignoredTable);
 
-    ui.highlightNicksComboBox->addItem(tr("All Nicks from Identity"), HighlightRuleManager::AllNicks);
-    ui.highlightNicksComboBox->addItem(tr("Current Nick"), HighlightRuleManager::CurrentNick);
-    ui.highlightNicksComboBox->addItem(tr("None"), HighlightRuleManager::NoNick);
+    ui.highlightNicksComboBox->addItem(tr("All Nicks from Identity"), QVariant(HighlightRuleManager::AllNicks));
+    ui.highlightNicksComboBox->addItem(tr("Current Nick"), QVariant(HighlightRuleManager::CurrentNick));
+    ui.highlightNicksComboBox->addItem(tr("None"), QVariant(HighlightRuleManager::NoNick));
 
     connect(ui.highlightAdd, SIGNAL(clicked(bool)), this, SLOT(addNewHighlightRow()));
     connect(ui.highlightRemove, SIGNAL(clicked(bool)), this, SLOT(removeSelectedHighlightRows()));
@@ -80,19 +80,19 @@ void CoreHighlightSettingsPage::setupRuleTable(QTableWidget *table) const
     table->verticalHeader()->hide();
     table->setShowGrid(false);
 
-    table->horizontalHeaderItem(RegExColumn)->setToolTip(
+    table->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->setToolTip(
         tr("<b>RegEx</b>: This option determines if the highlight rule should be interpreted as a <b>regular expression</b> or just as a keyword."));
-    table->horizontalHeaderItem(RegExColumn)->setWhatsThis(
+    table->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->setWhatsThis(
         tr("<b>RegEx</b>: This option determines if the highlight rule should be interpreted as a <b>regular expression</b> or just as a keyword."));
 
-    table->horizontalHeaderItem(CsColumn)->setToolTip(
+    table->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->setToolTip(
         tr("<b>CS</b>: This option determines if the highlight rule should be interpreted <b>case sensitive</b>."));
-    table->horizontalHeaderItem(CsColumn)->setWhatsThis(
+    table->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->setWhatsThis(
         tr("<b>CS</b>: This option determines if the highlight rule should be interpreted <b>case sensitive</b>."));
 
-    table->horizontalHeaderItem(ChanColumn)->setToolTip(
+    table->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->setToolTip(
         tr("<b>Channel</b>: This regular expression determines for which <b>channels</b> the highlight rule works. Leave blank to match any channel. Put <b>!</b> in the beginning to negate. Case insensitive."));
-    table->horizontalHeaderItem(ChanColumn)->setWhatsThis(
+    table->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->setWhatsThis(
         tr("<b>Channel</b>: This regular expression determines for which <b>channels</b> the highlight rule works. Leave blank to match any channel. Put <b>!</b> in the beginning to negate. Case insensitive."));
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
@@ -102,11 +102,11 @@ void CoreHighlightSettingsPage::setupRuleTable(QTableWidget *table) const
     table->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::CsColumn, QHeaderView::ResizeToContents);
     table->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::ChanColumn, QHeaderView::ResizeToContents);
 #else
-    table->horizontalHeader()->setSectionResizeMode(EnableColumn, QHeaderView::ResizeToContents);
-    table->horizontalHeader()->setSectionResizeMode(NameColumn, QHeaderView::Stretch);
-    table->horizontalHeader()->setSectionResizeMode(RegExColumn, QHeaderView::ResizeToContents);
-    table->horizontalHeader()->setSectionResizeMode(CsColumn, QHeaderView::ResizeToContents);
-    table->horizontalHeader()->setSectionResizeMode(ChanColumn, QHeaderView::ResizeToContents);
+    table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::EnableColumn, QHeaderView::ResizeToContents);
+    table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::NameColumn, QHeaderView::Stretch);
+    table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::RegExColumn, QHeaderView::ResizeToContents);
+    table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::CsColumn, QHeaderView::ResizeToContents);
+    table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::ChanColumn, QHeaderView::ResizeToContents);
 #endif
 }
 
@@ -131,8 +131,8 @@ bool CoreHighlightSettingsPage::hasDefaults() const
 
 void CoreHighlightSettingsPage::defaults()
 {
-    ui.highlightNicksComboBox->setCurrentIndex(ui.highlightNicksComboBox
-                                                   ->findData(QVariant(HighlightRuleManager::HighlightNickType::CurrentNick)));
+    int defaultIndex = ui.highlightNicksComboBox->findData(QVariant(HighlightRuleManager::HighlightNickType::CurrentNick));
+    ui.highlightNicksComboBox->setCurrentIndex(defaultIndex);
     ui.nicksCaseSensitive->setChecked(false);
     emptyHighlightTable();
     emptyIgnoredTable();
@@ -292,7 +292,7 @@ void CoreHighlightSettingsPage::emptyHighlightTable()
     if (ui.highlightTable->rowCount() != highlightList.size()) {
         qDebug() << "something is wrong: ui.highlight and highlightList don't have the same size!";
     }
-    ui.highlightTable->clear();
+    ui.highlightTable->clearContents();
     highlightList.clear();
 }
 
@@ -302,7 +302,7 @@ void CoreHighlightSettingsPage::emptyIgnoredTable()
     if (ui.ignoredTable->rowCount() != ignoredList.size()) {
         qDebug() << "something is wrong: ui.highlight and highlightList don't have the same size!";
     }
-    ui.ignoredTable->clear();
+    ui.ignoredTable->clearContents();
     ignoredList.clear();
 }
 
@@ -408,6 +408,8 @@ void CoreHighlightSettingsPage::load()
 
         setChangedState(false);
         _initialized = true;
+    } else {
+        defaults();
     }
 }
 

--- a/src/qtui/settingspages/corehighlightsettingspage.h
+++ b/src/qtui/settingspages/corehighlightsettingspage.h
@@ -47,7 +47,7 @@ public slots:
 
 private slots:
     void widgetHasChanged();
-    void addNewRow(QString name = tr("highlight rule"), bool regex = false, bool cs = false, bool enable = true, QString chanName = "", bool self = false);
+    void addNewRow(QString name = tr("highlight rule"), bool regex = false, bool cs = false, bool enable = true, bool inverse = false, QString chanName = "", bool self = false);
     void removeSelectedRows();
     void selectRow(QTableWidgetItem *item);
     void tableChanged(QTableWidgetItem *item);
@@ -60,8 +60,9 @@ private:
         RegExColumn = 1,
         CsColumn = 2,
         EnableColumn = 3,
-        ChanColumn = 4,
-        ColumnCount = 5
+        InverseColumn = 4,
+        ChanColumn = 5,
+        ColumnCount = 6
     };
 
     void emptyTable();

--- a/src/qtui/settingspages/corehighlightsettingspage.h
+++ b/src/qtui/settingspages/corehighlightsettingspage.h
@@ -47,7 +47,8 @@ public slots:
 
 private slots:
     void widgetHasChanged();
-    void addNewRow(QString name = tr("highlight rule"), bool regex = false, bool cs = false, bool enable = true, bool inverse = false, QString chanName = "", bool self = false);
+    void addNewRow(const QString &name = tr("highlight rule"), bool regex = false, bool cs = false, bool enable = true,
+                   bool inverse = false, const QString &sender = "", const QString &chanName = "", bool self = false);
     void removeSelectedRows();
     void selectRow(QTableWidgetItem *item);
     void tableChanged(QTableWidgetItem *item);
@@ -61,8 +62,9 @@ private:
         CsColumn = 2,
         EnableColumn = 3,
         InverseColumn = 4,
-        ChanColumn = 5,
-        ColumnCount = 6
+        SenderColumn = 5,
+        ChanColumn = 6,
+        ColumnCount = 7
     };
 
     void emptyTable();

--- a/src/qtui/settingspages/corehighlightsettingspage.h
+++ b/src/qtui/settingspages/corehighlightsettingspage.h
@@ -24,10 +24,9 @@
 #include <QVariantList>
 #include <QTableWidgetItem>
 #include <highlightrulemanager.h>
-#include <ui_corehighlightsettingspage.h>
 
 #include "settingspage.h"
-#include "ui_highlightsettingspage.h"
+#include "ui_corehighlightsettingspage.h"
 
 class CoreHighlightSettingsPage : public SettingsPage
 {

--- a/src/qtui/settingspages/corehighlightsettingspage.h
+++ b/src/qtui/settingspages/corehighlightsettingspage.h
@@ -34,40 +34,49 @@ class CoreHighlightSettingsPage : public SettingsPage
     Q_OBJECT
 
 public:
-    CoreHighlightSettingsPage(QWidget *parent = 0);
+    explicit CoreHighlightSettingsPage(QWidget *parent = nullptr);
 
-    bool hasDefaults() const;
+    bool hasDefaults() const override;
 
 public slots:
-    void save();
-    void load();
-    void defaults();
+    void save() override;
+    void load() override;
+    void defaults() override;
     void revert();
     void clientConnected();
 
 private slots:
     void widgetHasChanged();
-    void addNewRow(const QString &name = tr("highlight rule"), bool regex = false, bool cs = false, bool enable = true,
-                   bool inverse = false, const QString &sender = "", const QString &chanName = "", bool self = false);
-    void removeSelectedRows();
-    void selectRow(QTableWidgetItem *item);
-    void tableChanged(QTableWidgetItem *item);
+    void addNewHighlightRow(bool enable = true, const QString &name = tr("highlight rule"), bool regex = false,
+                            bool cs = false, const QString &sender = "", const QString &chanName = "",
+                            bool self = false);
+    void addNewIgnoredRow(bool enable = true, const QString &name = tr("highlight rule"), bool regex = false,
+                          bool cs = false, const QString &sender = "", const QString &chanName = "", bool self = false);
+    void removeSelectedHighlightRows();
+    void removeSelectedIgnoredRows();
+    void selectHighlightRow(QTableWidgetItem *item);
+    void selectIgnoredRow(QTableWidgetItem *item);
+    void highlightTableChanged(QTableWidgetItem *item);
+    void ignoredTableChanged(QTableWidgetItem *item);
 
 private:
     Ui::CoreHighlightSettingsPage ui;
     HighlightRuleManager::HighlightRuleList highlightList;
+    HighlightRuleManager::HighlightRuleList ignoredList;
     enum column {
-        NameColumn = 0,
-        RegExColumn = 1,
-        CsColumn = 2,
-        EnableColumn = 3,
-        InverseColumn = 4,
-        SenderColumn = 5,
-        ChanColumn = 6,
-        ColumnCount = 7
+        EnableColumn = 0,
+        NameColumn = 1,
+        RegExColumn = 2,
+        CsColumn = 3,
+        SenderColumn = 4,
+        ChanColumn = 5,
+        ColumnCount = 6
     };
 
-    void emptyTable();
+    void emptyHighlightTable();
+    void emptyIgnoredTable();
+
+    void setupRuleTable(QTableWidget *highlightTable) const;
 
     bool _initialized;
 };

--- a/src/qtui/settingspages/corehighlightsettingspage.h
+++ b/src/qtui/settingspages/corehighlightsettingspage.h
@@ -1,0 +1,73 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2016 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#ifndef _COREHIGHLIGHTSETTINGSPAGE_H_
+#define _COREHIGHLIGHTSETTINGSPAGE_H_
+
+#include <QVariantList>
+#include <QTableWidgetItem>
+#include <highlightrulemanager.h>
+#include <ui_corehighlightsettingspage.h>
+
+#include "settingspage.h"
+#include "ui_highlightsettingspage.h"
+
+class CoreHighlightSettingsPage : public SettingsPage
+{
+    Q_OBJECT
+
+public:
+    CoreHighlightSettingsPage(QWidget *parent = 0);
+
+    bool hasDefaults() const;
+
+public slots:
+    void save();
+    void load();
+    void defaults();
+    void revert();
+    void clientConnected();
+
+private slots:
+    void widgetHasChanged();
+    void addNewRow(QString name = tr("highlight rule"), bool regex = false, bool cs = false, bool enable = true, QString chanName = "", bool self = false);
+    void removeSelectedRows();
+    void selectRow(QTableWidgetItem *item);
+    void tableChanged(QTableWidgetItem *item);
+
+private:
+    Ui::CoreHighlightSettingsPage ui;
+    HighlightRuleManager::HighlightRuleList highlightList;
+    enum column {
+        NameColumn = 0,
+        RegExColumn = 1,
+        CsColumn = 2,
+        EnableColumn = 3,
+        ChanColumn = 4,
+        ColumnCount = 5
+    };
+
+    void emptyTable();
+
+    bool _initialized;
+};
+
+
+#endif

--- a/src/qtui/settingspages/corehighlightsettingspage.ui
+++ b/src/qtui/settingspages/corehighlightsettingspage.ui
@@ -55,6 +55,11 @@
         </column>
         <column>
          <property name="text">
+          <string>Sender</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
           <string>Channel</string>
          </property>
         </column>

--- a/src/qtui/settingspages/corehighlightsettingspage.ui
+++ b/src/qtui/settingspages/corehighlightsettingspage.ui
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CoreHighlightSettingsPage</class>
+ <widget class="QWidget" name="CoreHighlightSettingsPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>438</width>
+    <height>404</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Custom Highlights</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QTableWidget" name="highlightTable">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="styleSheet">
+         <string notr="true"/>
+        </property>
+        <column>
+         <property name="text">
+          <string>Highlight</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>RegEx</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>CS</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Enable</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Channel</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QPushButton" name="add">
+          <property name="text">
+           <string>Add</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="remove">
+          <property name="text">
+           <string>Remove</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Highlight Nicks</string>
+     </property>
+     <layout class="QVBoxLayout">
+      <item>
+       <widget class="QRadioButton" name="highlightAllNicks">
+        <property name="text">
+         <string>All nicks from identity</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="highlightCurrentNick">
+        <property name="text">
+         <string>Current nick</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="highlightNoNick">
+        <property name="text">
+         <string>None</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="nicksCaseSensitive">
+        <property name="text">
+         <string>Case sensitive</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>highlightNoNick</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>nicksCaseSensitive</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>64</x>
+     <y>350</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>69</x>
+     <y>381</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qtui/settingspages/corehighlightsettingspage.ui
+++ b/src/qtui/settingspages/corehighlightsettingspage.ui
@@ -15,158 +15,245 @@
   </property>
   <layout class="QVBoxLayout">
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Custom Highlights</string>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QTableWidget" name="highlightTable">
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="styleSheet">
-         <string notr="true"/>
-        </property>
-        <column>
-         <property name="text">
-          <string>Highlight</string>
+     <widget class="QWidget" name="highlightTab">
+      <attribute name="title">
+       <string>Highlight Rules</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QGroupBox" name="nickBox">
+         <property name="title">
+          <string>Highlight Nicks</string>
          </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>RegEx</string>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QComboBox" name="highlightNicksComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="currentIndex">
+             <number>-1</number>
+            </property>
+            <property name="sizeAdjustPolicy">
+             <enum>QComboBox::AdjustToContents</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="nicksCaseSensitive">
+            <property name="text">
+             <string>Case sensitive</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="rulesBox">
+         <property name="title">
+          <string>Custom Highlights</string>
          </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>CS</string>
+         <layout class="QVBoxLayout" name="highlightLayout">
+          <item>
+           <widget class="QTableWidget" name="highlightTable">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="styleSheet">
+             <string notr="true"/>
+            </property>
+            <column>
+             <property name="text">
+              <string>Enabled</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Rule</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>RegEx</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>CS</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Sender</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Channel</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="highlightButtonBarLayout">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QPushButton" name="highlightAdd">
+              <property name="text">
+               <string>Add</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="highlightRemove">
+              <property name="text">
+               <string>Remove</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="highlightButtonBarSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="ignoredTab">
+      <attribute name="title">
+       <string>Highlight Ignore Rules</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="ignoredLayout">
+       <item>
+        <widget class="QTableWidget" name="ignoredTable">
+         <property name="toolTip">
+          <string/>
          </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Enable</string>
+         <property name="styleSheet">
+          <string notr="true"/>
          </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Inverse</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Sender</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Channel</string>
-         </property>
-        </column>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QPushButton" name="add">
+         <column>
           <property name="text">
-           <string>Add</string>
+           <string>Enabled</string>
           </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="remove">
+         </column>
+         <column>
           <property name="text">
-           <string>Remove</string>
+           <string>Rule</string>
           </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+         </column>
+         <column>
+          <property name="text">
+           <string>RegEx</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
+         </column>
+         <column>
+          <property name="text">
+           <string>CS</string>
           </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Highlight Nicks</string>
-     </property>
-     <layout class="QVBoxLayout">
-      <item>
-       <widget class="QRadioButton" name="highlightAllNicks">
-        <property name="text">
-         <string>All nicks from identity</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="highlightCurrentNick">
-        <property name="text">
-         <string>Current nick</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="highlightNoNick">
-        <property name="text">
-         <string>None</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="nicksCaseSensitive">
-        <property name="text">
-         <string>Case sensitive</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
+         </column>
+         <column>
+          <property name="text">
+           <string>Sender</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Channel</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="ignoredButtonBarLayout">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="ignoredAdd">
+           <property name="text">
+            <string>Add</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="ignoredRemove">
+           <property name="text">
+            <string>Remove</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="ignoredButtonBarSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>highlightNoNick</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>nicksCaseSensitive</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>64</x>
-     <y>350</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>69</x>
-     <y>381</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/qtui/settingspages/corehighlightsettingspage.ui
+++ b/src/qtui/settingspages/corehighlightsettingspage.ui
@@ -50,6 +50,11 @@
         </column>
         <column>
          <property name="text">
+          <string>Inverse</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
           <string>Channel</string>
          </property>
         </column>

--- a/src/qtui/settingspages/settingspages.cmake
+++ b/src/qtui/settingspages/settingspages.cmake
@@ -12,6 +12,7 @@ set(SETTINGSPAGES
     connection
     coreconnection
     coreaccount
+    corehighlight
     dcc
     highlight
     identities


### PR DESCRIPTION
## In Short
* Store highlight rules in a highlight manager on the core
* Search for highlights in messages on the core
* Transmit this status to the client by setting the highlight flag already on the core
* Implement sender-based highlight rules
* Implement inverse highlight rules (which negate a match)

## Status
- [x] Implement a highlight manager
- [x] Implement core-side highlight parsing
- [x] Implement a UI for configuring core-side highlights
- [x] Assign a CoreFeatures flag for core-side highlights
- [x] Implement inverse highlight rules
- [x] Implement better UI for inverse highlight rules
- [x] Implement sender-based highlight (or ignore highlight) rules?
- [ ] Implement a button to migrate client-side highlight rules to core-side

## Rationale
Currently a client needs to request backlog for all channels, to know if highlights have occured on that channel (and color it differently in the UI, etc). Long term we want to solve that with a notification system, for which this provides the first step, by moving highlight parsing to the core.

## Drawbacks
The core can not re-parse the entire backlog whenever the highlight rules are changed (the client does this), so it can always only take into account the highlight rules at the time that a message was sent.

## Screenshots
[![Example showing inverse and sender-based highlight rules in action](https://i.imgur.com/pkPI31N.png)](https://i.imgur.com/pkPI31N.png)