### PR TITLE
Fix OSX compile and deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os:
   - linux
-  - osx
 
 sudo: required
 dist: trusty
@@ -17,12 +16,12 @@ env:
   - QT_VERSION=qt5
 
 matrix:
+  include:
+    - os: osx
+      compiler: gcc
+      env: QT_VERSION=qt5
   exclude:
     - compiler: clang
-      env: QT_VERSION=qt4
-    - os: osx
-      compiler: clang
-    - os: osx
       env: QT_VERSION=qt4
 
 install: |-
@@ -50,13 +49,12 @@ script: |-
     make
   elif [ "$TRAVIS_OS_NAME" == "osx" ]
   then
+    PATH=$PATH:/usr/local/opt/qt5/bin
     if [[ "$TRAVIS_TAG" != "" && "$GH_TOKEN" != "" ]]
     then
-      PATH=$PATH:/usr/local/opt/qt5/bin
-      # The LDAP headers found in OSX Frameworks seem to be broken
-      cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DDEPLOY=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5 -DLDAP_INCLUDE_DIR=/usr/include/
+      cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DDEPLOY=ON
     else
-      cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5 -DLDAP_INCLUDE_DIR=/usr/include/
+      cmake -G"Ninja" .. -DCMAKE_BUILD_TYPE=Release
     fi
     ninja install
   fi

--- a/cmake/FindLdap.cmake
+++ b/cmake/FindLdap.cmake
@@ -15,7 +15,22 @@ endif(LDAP_INCLUDE_DIR AND LDAP_LIBRARIES)
 
 # Attempt to link against ldap.h regardless of platform!
 FIND_PATH(LDAP_INCLUDE_DIR ldap.h)
+
+# If we detect path to invalid ldap.h on osx, try /usr/include/
+# This might also be achievable with additional parameters to FIND_PATH.
+string(TOLOWER ${LDAP_INCLUDE_DIR} ldapincludelower)
+if("${ldapincludelower}" MATCHES "\\/system\\/library\\/frameworks\\/ldap\\.framework\\/headers")
+  set(LDAP_INCLUDE_DIR "/usr/include/")
+endif()
+
 FIND_LIBRARY(LDAP_LIBRARIES NAMES ldap)
+
+# On osx remove invalid ldap.h
+string(TOLOWER ${LDAP_LIBRARIES} ldaplower)
+if("${ldaplower}" MATCHES "\\/system\\/library\\/frameworks\\/ldap\\.framework")
+  set(LDAP_LIBRARIES FALSE)
+endif()
+
 FIND_LIBRARY(LBER_LIBRARIES NAMES lber)
 
 # It'd be nice to link against winldap on Windows, unfortunately

--- a/cmake/QuasselCompileSettings.cmake
+++ b/cmake/QuasselCompileSettings.cmake
@@ -80,6 +80,5 @@ endif()
 # Mac build stuff
 if (APPLE AND DEPLOY)
     set(CMAKE_OSX_ARCHITECTURES "x86_64")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.9")
-    set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.9 -stdlib=libc++")
 endif()

--- a/scripts/build/macosx_makePackage.sh
+++ b/scripts/build/macosx_makePackage.sh
@@ -80,5 +80,6 @@ case $BUILDTYPE in
 	exit 1
 	;;
 esac
-hdiutil create -srcfolder ${PACKAGETMPDIR} -format UDBZ -volname "Quassel ${BUILDTYPE} - ${QUASSEL_VERSION}" "${WORKINGDIR}${QUASSEL_DMG}" >/dev/null
+PACKAGESIZE=$(echo "$(du -ms ${PACKAGETMPDIR} | cut -f1) * 1.1" | bc)
+hdiutil create -srcfolder ${PACKAGETMPDIR} -format UDBZ -size ${PACKAGESIZE}M -volname "Quassel ${BUILDTYPE} - ${QUASSEL_VERSION}" "${WORKINGDIR}${QUASSEL_DMG}" >/dev/null
 rm -rf ${PACKAGETMPDIR}


### PR DESCRIPTION
- Set additional stdlib compile flag
   I get compile errors otherwise, at least locally.
- Fix FindLdap.cmake for OSX
  I hope the way I did it is ok. But I know it can be improved!
- ~~Use older OSX image on travis.
  I don't want to upgrade my old MacBook to an newer OSX version … and with the few pushs to update the scripts for newer xcode to build on travis I didn't get deploy to work, yet.
  I might give this a try later again … maybe even with a new macbook …~~
- Fix DMG creation
  hdiutil sometimes fails if no volume size is provided.
  Fixed by taking the size of the contents (and slightly increasing it to be safe)
- cleaned up travis.yml a bit

**New since 2017-12-23:**
- Stop manually overriding CMAKE_OSX_SYSROOT
  This was the main reason why it broke if compiled on a different OSX version.
  CMake should have this variable correctly set already!
- (modified Fix for FindLdap.cmake)

**Things which still can be improved:**
To support KF5 stuff being deployed the deploy script needs to be modified to also rewrite absolute paths to relative paths in the linking inside ".dylib" packages in addition to ".framework" packages.
This can be done in a later PR but until that is done we can ship KF5 stuff with the OSX app.
(At least not automatically.)