### PR TITLE
common: Fix isChannelName crash on empty string

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -64,6 +64,8 @@ QString hostFromMask(const QString &mask)
 
 bool isChannelName(const QString &str)
 {
+    if (str.isEmpty())
+        return false;
     static constexpr std::array<quint8, 4> prefixes{{'#', '&', '!', '+'}};
     return std::any_of(prefixes.cbegin(), prefixes.cend(), [&str](quint8 c) { return c == str[0]; });
 }


### PR DESCRIPTION
Add check to `isChannelName` for an empty string; return false if so and don't try to index it.  This avoids crashing on connect for some situations.

*Trivial change, may not be the most performance-friendly way.  Just filing this as a handy reminder for @Sput42.  I can expand it to a proper pull request if desired; feel free to close without concern, too.*