### PR TITLE
Implement Client Feature Flags and Sender Prefixmodes in Protocol and UI

### DIFF
--- a/src/client/clientauthhandler.cpp
+++ b/src/client/clientauthhandler.cpp
@@ -288,7 +288,7 @@ void ClientAuthHandler::startRegistration()
     useSsl = _account.useSsl();
 #endif
 
-    _peer->dispatch(RegisterClient(Quassel::buildInfo().fancyVersionString, Quassel::buildInfo().commitDate, useSsl));
+    _peer->dispatch(RegisterClient(Quassel::buildInfo().fancyVersionString, Quassel::buildInfo().commitDate, useSsl, Quassel::features()));
 }
 
 
@@ -305,7 +305,8 @@ void ClientAuthHandler::handle(const ClientRegistered &msg)
     _backendInfo = msg.backendInfo;
     _authenticatorInfo = msg.authenticatorInfo;
 
-    Client::setCoreFeatures(static_cast<Quassel::Features>(msg.coreFeatures));
+    Client::setCoreFeatures(Quassel::Features(msg.coreFeatures));
+    SignalProxy::current()->sourcePeer()->setFeatures(Quassel::Features(msg.coreFeatures));
 
     // The legacy protocol enables SSL at this point
     if(_legacy && _account.useSsl())

--- a/src/common/peer.cpp
+++ b/src/common/peer.cpp
@@ -57,6 +57,14 @@ void Peer::setClientVersion(const QString &clientVersion) {
     _clientVersion = clientVersion;
 }
 
+Quassel::Features Peer::features() const {
+    return _features;
+}
+
+void Peer::setFeatures(Quassel::Features features) {
+    _features = features;
+}
+
 int Peer::id() const {
     return _id;
 }

--- a/src/common/peer.h
+++ b/src/common/peer.h
@@ -119,7 +119,7 @@ template<typename T> inline
 void Peer::handle(const T &protoMessage)
 {
     switch(protoMessage.handler()) {
-        case Protocol::SignalProxy:
+        case Protocol::Handler::SignalProxy:
             if (!signalProxy()) {
                 qWarning() << Q_FUNC_INFO << "Cannot handle message without a SignalProxy!";
                 return;
@@ -127,7 +127,7 @@ void Peer::handle(const T &protoMessage)
             signalProxy()->handle(this, protoMessage);
             break;
 
-        case Protocol::AuthHandler:
+        case Protocol::Handler::AuthHandler:
             if (!authHandler()) {
                 qWarning() << Q_FUNC_INFO << "Cannot handle auth messages without an active AuthHandler!";
                 return;

--- a/src/common/peer.h
+++ b/src/common/peer.h
@@ -28,6 +28,7 @@
 #include "authhandler.h"
 #include "protocol.h"
 #include "signalproxy.h"
+#include "quassel.h"
 
 class Peer : public QObject
 {
@@ -50,6 +51,9 @@ public:
 
     QString clientVersion() const;
     void setClientVersion(const QString &clientVersion);
+
+    Quassel::Features features() const;
+    void setFeatures(Quassel::Features features);
 
     int id() const;
     void setId(int id);
@@ -102,6 +106,7 @@ private:
 
     QString _buildDate;
     QString _clientVersion;
+    Quassel::Features _features;
 
     int _id = -1;
 };

--- a/src/common/protocol.h
+++ b/src/common/protocol.h
@@ -42,7 +42,7 @@ enum Feature {
 };
 
 
-enum Handler {
+enum class Handler {
     SignalProxy,
     AuthHandler
 };
@@ -51,7 +51,7 @@ enum Handler {
 /*** Handshake, handled by AuthHandler ***/
 
 struct HandshakeMessage {
-    inline Handler handler() const { return AuthHandler; }
+    inline Handler handler() const { return Handler::AuthHandler; }
 };
 
 
@@ -179,7 +179,7 @@ struct SessionState : public HandshakeMessage
 
 struct SignalProxyMessage
 {
-    inline Handler handler() const { return SignalProxy; }
+    inline Handler handler() const { return Handler::SignalProxy; }
 };
 
 

--- a/src/common/protocol.h
+++ b/src/common/protocol.h
@@ -57,16 +57,18 @@ struct HandshakeMessage {
 
 struct RegisterClient : public HandshakeMessage
 {
-    inline RegisterClient(const QString &clientVersion, const QString &buildDate, bool sslSupported = false)
+    inline RegisterClient(const QString &clientVersion, const QString &buildDate, bool sslSupported = false, int32_t features = 0)
     : clientVersion(clientVersion)
     , buildDate(buildDate)
-    , sslSupported(sslSupported) {}
+    , sslSupported(sslSupported)
+    , clientFeatures(features) {}
 
     QString clientVersion;
     QString buildDate;
 
     // this is only used by the LegacyProtocol in compat mode
     bool sslSupported;
+    int32_t clientFeatures;
 };
 
 

--- a/src/common/protocols/datastream/datastreampeer.cpp
+++ b/src/common/protocols/datastream/datastreampeer.cpp
@@ -116,7 +116,7 @@ void DataStreamPeer::handleHandshakeMessage(const QVariantList &mapData)
     }
 
     if (msgType == "ClientInit") {
-        handle(RegisterClient(m["ClientVersion"].toString(), m["ClientDate"].toString(), false)); // UseSsl obsolete
+        handle(RegisterClient(m["ClientVersion"].toString(), m["ClientDate"].toString(), false, m["Features"].toInt())); // UseSsl obsolete
     }
 
     else if (msgType == "ClientInitReject") {
@@ -168,6 +168,7 @@ void DataStreamPeer::dispatch(const RegisterClient &msg) {
     m["MsgType"] = "ClientInit";
     m["ClientVersion"] = msg.clientVersion;
     m["ClientDate"] = msg.buildDate;
+    m["Features"] = msg.clientFeatures;
 
     writeMessage(m);
 }

--- a/src/common/protocols/legacy/legacypeer.cpp
+++ b/src/common/protocols/legacy/legacypeer.cpp
@@ -151,7 +151,7 @@ void LegacyPeer::handleHandshakeMessage(const QVariant &msg)
             socket()->setProperty("UseCompression", true);
         }
 #endif
-        handle(RegisterClient(m["ClientVersion"].toString(), m["ClientDate"].toString(), m["UseSsl"].toBool()));
+        handle(RegisterClient(m["ClientVersion"].toString(), m["ClientDate"].toString(), m["UseSsl"].toBool(), m["Features"].toInt()));
     }
 
     else if (msgType == "ClientInitReject") {
@@ -214,6 +214,7 @@ void LegacyPeer::dispatch(const RegisterClient &msg) {
     m["MsgType"] = "ClientInit";
     m["ClientVersion"] = msg.clientVersion;
     m["ClientDate"] = msg.buildDate;
+    m["Features"] = msg.clientFeatures;
 
     // FIXME only in compat mode
     m["ProtocolVersion"] = protocolVersion;

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -78,8 +78,9 @@ public:
         AwayFormatTimestamp = 0x0200,      /// Timestamp formatting in away (e.g. %%hh:mm%%)
         Authenticators = 0x0400,           /// Whether or not the core supports auth backends.
         BufferActivitySync = 0x0800,       /// Sync buffer activity status
+        SenderPrefixes = 0x2000,           /// Show prefixes for senders in backlog
 
-        NumFeatures = 0x0800
+        NumFeatures = 0x2000
     };
     Q_DECLARE_FLAGS(Features, Feature)
 

--- a/src/common/remotepeer.cpp
+++ b/src/common/remotepeer.cpp
@@ -208,8 +208,16 @@ void RemotePeer::close(const QString &reason)
 void RemotePeer::onReadyRead()
 {
     QByteArray msg;
-    while (readMessage(msg))
+    while (readMessage(msg)) {
+        if (SignalProxy::current())
+            SignalProxy::current()->setSourcePeer(this);
+
         processMessage(msg);
+
+
+        if (SignalProxy::current())
+            SignalProxy::current()->setSourcePeer(nullptr);
+    }
 }
 
 

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -23,8 +23,10 @@
 
 #include <QEvent>
 #include <QSet>
+#include <QThreadStorage>
 
 #include <functional>
+#include <memory>
 
 #include "protocol.h"
 
@@ -80,6 +82,10 @@ public:
     void dumpProxyStats();
     void dumpSyncMap(SyncableObject *object);
 
+    static SignalProxy *current() {
+        return _current;
+    }
+
     /**@{*/
     /**
      * This method allows to send a signal only to a limited set of peers
@@ -111,7 +117,14 @@ public:
     /**
      * @return If handling a signal, the Peer from which the current signal originates
      */
-    Peer *sourcePeer() { return _sourcePeer; }
+    Peer *sourcePeer();
+    void setSourcePeer(Peer *sourcePeer);
+
+    /**
+     * @return If sending a signal, the Peer to which the current signal is directed
+     */
+    Peer *targetPeer();
+    void setTargetPeer(Peer *targetPeer);
 
 public slots:
     void detachObject(QObject *obj);
@@ -206,6 +219,9 @@ private:
     bool _restrictMessageTarget = false;
 
     Peer *_sourcePeer = nullptr;
+    Peer *_targetPeer = nullptr;
+
+    thread_local static SignalProxy *_current;
 
     friend class SignalRelay;
     friend class SyncableObject;

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -185,6 +185,7 @@ void CoreAuthHandler::handle(const RegisterClient &msg)
 
     _peer->setBuildDate(msg.buildDate);
     _peer->setClientVersion(msg.clientVersion);
+    _peer->setFeatures(Quassel::Features(msg.clientFeatures));
 
     if (_legacy && useSsl)
         startSsl();

--- a/src/qtui/chatviewsettings.h
+++ b/src/qtui/chatviewsettings.h
@@ -74,6 +74,13 @@ public:
     inline void setTimestampFormatString(const QString &format) { setLocalValue("TimestampFormat", format); }
 
     /**
+     * Gets if prefixmodes are shown before sender names
+     *
+     * @returns True if sender prefixmodes enabled, otherwise false
+     */
+    inline bool showSenderPrefixes() { return localValue("ShowSenderPrefixes", false).toBool(); }
+
+    /**
      * Gets if brackets are shown around sender names
      *
      * @returns True if sender brackets enabled, otherwise false

--- a/src/qtui/qtuistyle.cpp
+++ b/src/qtui/qtuistyle.cpp
@@ -32,6 +32,8 @@ QtUiStyle::QtUiStyle(QObject *parent) : UiStyle(parent)
     updateUseCustomTimestampFormat();
     s.notify("TimestampFormat", this, SLOT(updateTimestampFormatString()));
     updateTimestampFormatString();
+    s.notify("ShowSenderPrefixes", this, SLOT(updateShowSenderPrefixes()));
+    updateShowSenderPrefixes();
     s.notify("ShowSenderBrackets", this, SLOT(updateShowSenderBrackets()));
     updateShowSenderBrackets();
 
@@ -52,6 +54,12 @@ void QtUiStyle::updateTimestampFormatString()
 {
     ChatViewSettings s;
     setTimestampFormatString(s.timestampFormatString());
+}
+
+void QtUiStyle::updateShowSenderPrefixes()
+{
+    ChatViewSettings s;
+    enableSenderPrefixes(s.showSenderPrefixes());
 }
 
 void QtUiStyle::updateShowSenderBrackets()

--- a/src/qtui/qtuistyle.h
+++ b/src/qtui/qtuistyle.h
@@ -59,6 +59,11 @@ private slots:
      * Updates knowledge of the current timestamp format
      */
     void updateTimestampFormatString();
+    
+    /**
+     * Updates knowledge of whether or not to show sender prefixmodes
+     */
+    void updateShowSenderPrefixes();
 
     /**
      * Updates knowledge of whether or not to show sender brackets

--- a/src/qtui/settingspages/chatviewsettingspage.ui
+++ b/src/qtui/settingspages/chatviewsettingspage.ui
@@ -93,6 +93,25 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="showSenderPrefixes">
+     <property name="toolTip">
+      <string>Shows the modes of senders before their name (e.g. @, +)</string>
+     </property>
+     <property name="text">
+      <string>Show sendermodes in front of nicknames:</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="defaultValue" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="settingsKey" stdset="0">
+      <string notr="true">ShowSenderPrefixes</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QCheckBox" name="customChatViewFont">

--- a/src/uisupport/uistyle.cpp
+++ b/src/uisupport/uistyle.cpp
@@ -32,6 +32,7 @@ QHash<QString, UiStyle::FormatType> UiStyle::_formatCodes;
 bool UiStyle::_useCustomTimestampFormat;       /// If true, use the custom timestamp format
 QString UiStyle::_timestampFormatString;       /// Timestamp format
 QString UiStyle::_systemTimestampFormatString; /// Cached copy of system locale timestamp format
+bool UiStyle::_showSenderPrefixes;             /// If true, show prefixmodes before sender names
 bool UiStyle::_showSenderBrackets;             /// If true, show brackets around sender names
 
 UiStyle::UiStyle(QObject *parent)
@@ -74,6 +75,7 @@ UiStyle::UiStyle(QObject *parent)
     // in there.
     setUseCustomTimestampFormat(false);
     setTimestampFormatString(" hh:mm:ss");
+    enableSenderPrefixes(false);
     enableSenderBrackets(true);
 
     // BufferView / NickView settings
@@ -221,6 +223,13 @@ void UiStyle::setTimestampFormatString(const QString &format)
 {
     if (_timestampFormatString != format) {
         _timestampFormatString = format;
+    }
+}
+
+void UiStyle::enableSenderPrefixes(bool enabled)
+{
+    if (_showSenderPrefixes != enabled) {
+        _showSenderPrefixes = enabled;
     }
 }
 
@@ -908,15 +917,20 @@ QString UiStyle::StyledMessage::plainSender() const
 
 QString UiStyle::StyledMessage::decoratedSender() const
 {
+    QString _senderPrefixes;
+    if (_showSenderPrefixes) {
+        _senderPrefixes = senderPrefixes();
+    }
+
     switch (type()) {
     case Message::Plain:
         if (_showSenderBrackets)
-            return QString("<%1>").arg(plainSender());
+            return QString("<%1%2>").arg(_senderPrefixes, plainSender());
         else
-            return QString("%1").arg(plainSender());
+            return QString("%1%2").arg(_senderPrefixes, plainSender());
         break;
     case Message::Notice:
-        return QString("[%1]").arg(plainSender()); break;
+        return QString("[%1%2]").arg(_senderPrefixes, plainSender()); break;
     case Message::Action:
         return "-*-"; break;
     case Message::Nick:
@@ -950,7 +964,7 @@ QString UiStyle::StyledMessage::decoratedSender() const
     case Message::Invite:
         return "->"; break;
     default:
-        return QString("%1").arg(plainSender());
+        return QString("%1%2").arg(_senderPrefixes, plainSender());
     }
 }
 

--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -284,6 +284,12 @@ protected:
      * @param[in] format   Timestamp format string
      */
     static void setTimestampFormatString(const QString &format);
+    /**
+     * Updates the local setting cache of whether or not to show sender prefixmodes
+     *
+     * @param[in] enabled  If true, sender prefixmodes are enabled, otherwise false.
+     */
+    static void enableSenderPrefixes(bool enabled);
 
     /**
      * Updates the local setting cache of whether or not to show sender brackets
@@ -309,6 +315,7 @@ private:
     static bool _useCustomTimestampFormat;        /// If true, use the custom timestamp format
     static QString _systemTimestampFormatString;  /// Cached copy of system locale timestamp format
     static QString _timestampFormatString;        /// Timestamp format string
+    static bool _showSenderPrefixes;              /// If true, show prefixmodes before sender names
     static bool _showSenderBrackets;              /// If true, show brackets around sender names
 
     QIcon _channelJoinedIcon;


### PR DESCRIPTION
## In short
- Transmit in the RegisterClient message the client features as int32
- Make the current SignalProxy available within of the thread for the
  current user
- Store the features of a peer in a flag in it
- Use Peer features to determine how to serialize or deserialize a
  message
- Add the prefixes to the UI when formatting the sender

## Dependencies
- Due to the dependency on being able to query the source peer of a message, and the target peer, this PR depends on #302

## Status
- [x] Implement Protocol
- [x] Implement UI
- [x] Implement backwards-compatible (de-)serialization

## Rationale
There have been multiple feature requests made asking to support sender modes, and displaying them in the client.