### PR TITLE
Only show the disconnect button in the client list if the client supports it

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -160,6 +160,8 @@ void Client::init()
     p->attachSignal(this, SIGNAL(requestPasswordChange(PeerPtr,QString,QString,QString)), SIGNAL(changePassword(PeerPtr,QString,QString,QString)));
     p->attachSlot(SIGNAL(passwordChanged(PeerPtr,bool)), this, SLOT(corePasswordChanged(PeerPtr,bool)));
 
+    p->attachSignal(this, SIGNAL(requestKickClient(int)), SIGNAL(kickClient(int)));
+
     //connect(mainUi(), SIGNAL(connectToCore(const QVariantMap &)), this, SLOT(connectToCore(const QVariantMap &)));
     connect(mainUi(), SIGNAL(disconnectFromCore()), this, SLOT(disconnectFromCore()));
     connect(this, SIGNAL(connected()), mainUi(), SLOT(connectedToCore()));
@@ -674,6 +676,11 @@ void Client::changePassword(const QString &oldPassword, const QString &newPasswo
     account.setPassword(newPassword);
     coreAccountModel()->createOrUpdateAccount(account);
     emit instance()->requestPasswordChange(nullptr, account.user(), oldPassword, newPassword);
+}
+
+
+void Client::kickClient(int peerId) {
+    emit instance()->requestKickClient(peerId);
 }
 
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -161,6 +161,7 @@ void Client::init()
     p->attachSlot(SIGNAL(passwordChanged(PeerPtr,bool)), this, SLOT(corePasswordChanged(PeerPtr,bool)));
 
     p->attachSignal(this, SIGNAL(requestKickClient(int)), SIGNAL(kickClient(int)));
+    p->attachSlot(SIGNAL(disconnectFromCore()), this, SLOT(disconnectFromCore()));
 
     //connect(mainUi(), SIGNAL(connectToCore(const QVariantMap &)), this, SLOT(connectToCore(const QVariantMap &)));
     connect(mainUi(), SIGNAL(disconnectFromCore()), this, SLOT(disconnectFromCore()));
@@ -679,7 +680,8 @@ void Client::changePassword(const QString &oldPassword, const QString &newPasswo
 }
 
 
-void Client::kickClient(int peerId) {
+void Client::kickClient(int peerId)
+{
     emit instance()->requestKickClient(peerId);
 }
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -147,6 +147,7 @@ public:
     static void purgeKnownBufferIds();
 
     static void changePassword(const QString &oldPassword, const QString &newPassword);
+    static void kickClient(int peerId);
 
 #if QT_VERSION < 0x050000
     static void logMessage(QtMsgType type, const char *msg);
@@ -199,6 +200,8 @@ signals:
 
     //! Requests a password change (user name must match the currently logged in user)
     void requestPasswordChange(PeerPtr peer, const QString &userName, const QString &oldPassword, const QString &newPassword);
+
+    void requestKickClient(int peerId);
     void passwordChanged(bool success);
 
 public slots:

--- a/src/client/clientauthhandler.cpp
+++ b/src/client/clientauthhandler.cpp
@@ -288,7 +288,7 @@ void ClientAuthHandler::startRegistration()
     useSsl = _account.useSsl();
 #endif
 
-    _peer->dispatch(RegisterClient(Quassel::buildInfo().fancyVersionString, Quassel::buildInfo().commitDate, useSsl));
+    _peer->dispatch(RegisterClient(Quassel::buildInfo().fancyVersionString, Quassel::buildInfo().commitDate, useSsl, Quassel::features()));
 }
 
 
@@ -306,6 +306,7 @@ void ClientAuthHandler::handle(const ClientRegistered &msg)
     _authenticatorInfo = msg.authenticatorInfo;
 
     Client::setCoreFeatures(static_cast<Quassel::Features>(msg.coreFeatures));
+    SignalProxy::current()->_sourcePeer->_features = Quassel::Features(msg.coreFeatures);
 
     // The legacy protocol enables SSL at this point
     if(_legacy && _account.useSsl())

--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -395,7 +395,7 @@ void BufferItem::setLastSeenMsgId(MsgId msgId)
     _lastSeenMsgId = msgId;
 
     // FIXME remove with core protocol v11
-    if (!(Client::coreFeatures() & Quassel::SynchronizedMarkerLine)) {
+    if (!(Client::coreFeatures() & Quassel::Feature::SynchronizedMarkerLine)) {
         if (!isCurrentBuffer())
             _markerLineMsgId = msgId;
     }

--- a/src/common/internalpeer.cpp
+++ b/src/common/internalpeer.cpp
@@ -58,6 +58,15 @@ QString InternalPeer::description() const
     return tr("internal connection");
 }
 
+QString InternalPeer::address() const
+{
+    return tr("internal connection");
+}
+
+quint16 InternalPeer::port() const
+{
+    return 0;
+}
 
 bool InternalPeer::isOpen() const
 {

--- a/src/common/internalpeer.h
+++ b/src/common/internalpeer.h
@@ -45,6 +45,9 @@ public:
     Protocol::Type protocol() const { return Protocol::InternalProtocol; }
     QString description() const;
 
+    virtual QString address() const;
+    virtual quint16 port() const;
+
     SignalProxy *signalProxy() const;
     void setSignalProxy(SignalProxy *proxy);
 

--- a/src/common/message.cpp
+++ b/src/common/message.cpp
@@ -58,7 +58,7 @@ QDataStream &operator<<(QDataStream &out, const Message &msg)
     out << msg.bufferInfo();
     out << msg.sender().toUtf8();
 
-    if (SignalProxy::current()->_targetPeer->_features.testFlag(Quassel::Feature::SenderPrefixes))
+    if (SignalProxy::current()->_targetPeer->_features.testFlag(Quassel::Feature::ClientFeatures))
         out << msg.senderPrefixes().toUtf8();
 
     out << msg.contents().toUtf8();
@@ -81,7 +81,7 @@ QDataStream &operator>>(QDataStream &in, Message &msg)
     in >> s;
 
     // We do not serialize the sender prefixes until we have a new protocol or client-features implemented
-    if (SignalProxy::current()->_sourcePeer->_features.testFlag(Quassel::Feature::SenderPrefixes))
+    if (SignalProxy::current()->_sourcePeer->_features.testFlag(Quassel::Feature::ClientFeatures))
         in >> p;
 
     in >> m;

--- a/src/common/peer.h
+++ b/src/common/peer.h
@@ -50,8 +50,12 @@ public:
 
     virtual int lag() const = 0;
 
+    virtual QString address() const = 0;
+    virtual quint16 port() const = 0;
+
     int _id = -1;
 
+    QDateTime _connectedSince;
     QString _buildDate;
     QString _clientVersion;
 

--- a/src/common/peer.h
+++ b/src/common/peer.h
@@ -50,6 +50,11 @@ public:
 
     virtual int lag() const = 0;
 
+    int _id = -1;
+
+    QString _buildDate;
+    QString _clientVersion;
+
 public slots:
     /* Handshake messages */
     virtual void dispatch(const Protocol::RegisterClient &) = 0;

--- a/src/common/peer.h
+++ b/src/common/peer.h
@@ -28,6 +28,7 @@
 #include "authhandler.h"
 #include "protocol.h"
 #include "signalproxy.h"
+#include "quassel.h"
 
 class Peer : public QObject
 {
@@ -58,6 +59,7 @@ public:
     QDateTime _connectedSince;
     QString _buildDate;
     QString _clientVersion;
+    Quassel::Features _features;
 
 public slots:
     /* Handshake messages */
@@ -106,7 +108,7 @@ template<typename T> inline
 void Peer::handle(const T &protoMessage)
 {
     switch(protoMessage.handler()) {
-        case Protocol::SignalProxy:
+        case Protocol::Handler::SignalProxy:
             if (!signalProxy()) {
                 qWarning() << Q_FUNC_INFO << "Cannot handle message without a SignalProxy!";
                 return;
@@ -114,7 +116,7 @@ void Peer::handle(const T &protoMessage)
             signalProxy()->handle(this, protoMessage);
             break;
 
-        case Protocol::AuthHandler:
+        case Protocol::Handler::AuthHandler:
             if (!authHandler()) {
                 qWarning() << Q_FUNC_INFO << "Cannot handle auth messages without an active AuthHandler!";
                 return;

--- a/src/common/protocol.h
+++ b/src/common/protocol.h
@@ -42,7 +42,7 @@ enum Feature {
 };
 
 
-enum Handler {
+enum class Handler {
     SignalProxy,
     AuthHandler
 };
@@ -51,22 +51,24 @@ enum Handler {
 /*** Handshake, handled by AuthHandler ***/
 
 struct HandshakeMessage {
-    inline Handler handler() const { return AuthHandler; }
+    inline Handler handler() const { return Handler::AuthHandler; }
 };
 
 
 struct RegisterClient : public HandshakeMessage
 {
-    inline RegisterClient(const QString &clientVersion, const QString &buildDate, bool sslSupported = false)
+    inline RegisterClient(const QString &clientVersion, const QString &buildDate, bool sslSupported = false, int32_t features = 0)
     : clientVersion(clientVersion)
     , buildDate(buildDate)
-    , sslSupported(sslSupported) {}
+    , sslSupported(sslSupported)
+    , clientFeatures(features){}
 
     QString clientVersion;
     QString buildDate;
 
     // this is only used by the LegacyProtocol in compat mode
     bool sslSupported;
+    int32_t clientFeatures;
 };
 
 
@@ -179,7 +181,7 @@ struct SessionState : public HandshakeMessage
 
 struct SignalProxyMessage
 {
-    inline Handler handler() const { return SignalProxy; }
+    inline Handler handler() const { return Handler::SignalProxy; }
 };
 
 

--- a/src/common/protocols/datastream/datastreampeer.cpp
+++ b/src/common/protocols/datastream/datastreampeer.cpp
@@ -116,7 +116,7 @@ void DataStreamPeer::handleHandshakeMessage(const QVariantList &mapData)
     }
 
     if (msgType == "ClientInit") {
-        handle(RegisterClient(m["ClientVersion"].toString(), m["ClientDate"].toString(), false)); // UseSsl obsolete
+        handle(RegisterClient(m["ClientVersion"].toString(), m["ClientDate"].toString(), false, m["Features"].toInt())); // UseSsl obsolete
     }
 
     else if (msgType == "ClientInitReject") {
@@ -168,6 +168,7 @@ void DataStreamPeer::dispatch(const RegisterClient &msg) {
     m["MsgType"] = "ClientInit";
     m["ClientVersion"] = msg.clientVersion;
     m["ClientDate"] = msg.buildDate;
+    m["Features"] = msg.clientFeatures;
 
     writeMessage(m);
 }

--- a/src/common/protocols/legacy/legacypeer.cpp
+++ b/src/common/protocols/legacy/legacypeer.cpp
@@ -151,7 +151,7 @@ void LegacyPeer::handleHandshakeMessage(const QVariant &msg)
             socket()->setProperty("UseCompression", true);
         }
 #endif
-        handle(RegisterClient(m["ClientVersion"].toString(), m["ClientDate"].toString(), m["UseSsl"].toBool()));
+        handle(RegisterClient(m["ClientVersion"].toString(), m["ClientDate"].toString(), m["UseSsl"].toBool(), m["Features"].toInt()));
     }
 
     else if (msgType == "ClientInitReject") {
@@ -218,6 +218,7 @@ void LegacyPeer::dispatch(const RegisterClient &msg) {
     // FIXME only in compat mode
     m["ProtocolVersion"] = protocolVersion;
     m["UseSsl"] = msg.sslSupported;
+    m["Features"] = msg.clientFeatures;
 #ifndef QT_NO_COMPRESS
     m["UseCompression"] = true;
 #else

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -79,7 +79,8 @@ public:
         // Whether or not the core supports auth backends.
         Authenticators = 0x0400,
 
-        SenderPrefixes = 0x1000,
+        SenderPrefixes = 0x1000,           /// Indicates that this peer supports sender-prefixes, client-dependent
+                                           /// serialization, and being disconnected remotely (to save flags)
 
         NumFeatures = 0x1000
     };

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -79,7 +79,7 @@ public:
         // Whether or not the core supports auth backends.
         Authenticators = 0x0400,
 
-        SenderPrefixes = 0x1000,           /// Indicates that this peer supports sender-prefixes, client-dependent
+        ClientFeatures = 0x1000,           /// Indicates that this peer supports sender-prefixes, client-dependent
                                            /// serialization, and being disconnected remotely (to save flags)
 
         NumFeatures = 0x1000

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -58,8 +58,8 @@ public:
         QString organizationDomain;
     };
 
-    //! A list of features that are optional in core and/or client, but need runtime checking
-    /** Some features require an uptodate counterpart, but don't justify a protocol break.
+    //! A list of features that are optional in core, but need runtime checking
+    /** Some features require an up-to-date counterpart, but don't justify a protocol break.
      *  This is what we use this enum for. Add such features to it and check at runtime on the other
      *  side for their existence.
      *
@@ -79,7 +79,9 @@ public:
         // Whether or not the core supports auth backends.
         Authenticators = 0x0400,
 
-        NumFeatures = 0x0400
+        SenderPrefixes = 0x1000,
+
+        NumFeatures = 0x1000
     };
     Q_DECLARE_FLAGS(Features, Feature)
 

--- a/src/common/remotepeer.cpp
+++ b/src/common/remotepeer.cpp
@@ -208,8 +208,15 @@ void RemotePeer::close(const QString &reason)
 void RemotePeer::onReadyRead()
 {
     QByteArray msg;
-    while (readMessage(msg))
+    while (readMessage(msg)) {
+        if (SignalProxy::current())
+            SignalProxy::current()->_sourcePeer = this;
+
         processMessage(msg);
+
+        if (SignalProxy::current())
+            SignalProxy::current()->_sourcePeer = nullptr;
+    }
 }
 
 

--- a/src/common/remotepeer.cpp
+++ b/src/common/remotepeer.cpp
@@ -91,6 +91,22 @@ QString RemotePeer::description() const
     return QString();
 }
 
+QString RemotePeer::address() const
+{
+    if (socket())
+        return socket()->peerAddress().toString();
+
+    return QString();
+}
+
+quint16 RemotePeer::port() const
+{
+    if (socket())
+        return socket()->peerPort();
+
+    return 0;
+}
+
 
 ::SignalProxy *RemotePeer::signalProxy() const
 {

--- a/src/common/remotepeer.h
+++ b/src/common/remotepeer.h
@@ -49,6 +49,9 @@ public:
     virtual QString description() const;
     virtual quint16 enabledFeatures() const { return 0; }
 
+    virtual QString address() const;
+    virtual quint16 port() const;
+
     bool isOpen() const;
     bool isSecure() const;
     bool isLocal() const;

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -838,12 +838,12 @@ Peer *SignalProxy::peerById(int peerId) {
     return _peerMap[peerId];
 }
 
-void SignalProxy::restrictTargetPeers(std::initializer_list<Peer *> peers, std::function<void()> closure)
+void SignalProxy::restrictTargetPeers(QSet<Peer*> peers, std::function<void()> closure)
 {
     auto previousRestrictMessageTarget = _restrictMessageTarget;
     auto previousRestrictedTargets = _restrictedTargets;
     _restrictMessageTarget = true;
-    _restrictedTargets = QSet<Peer*>(peers);
+    _restrictedTargets = peers;
 
     closure();
 

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -290,6 +290,7 @@ bool SignalProxy::addPeer(Peer *peer)
 
     if (peer->_id < 0) {
         peer->_id = nextPeerId();
+        peer->_connectedSince = QDateTime::currentDateTimeUtc();
     }
 
     _peers.insert(peer);
@@ -821,9 +822,10 @@ QVariantList SignalProxy::peerData() {
     for (auto peer : _peers) {
         QVariantMap data;
         data["id"] = peer->_id;
-        data["buildData"] = peer->_buildDate;
         data["clientVersion"] = peer->_clientVersion;
-        data["description"] = peer->description();
+        data["clientVersionDate"] = peer->_buildDate;
+        data["remoteAddress"] = peer->address();
+        data["connectedSince"] = peer->_connectedSince;
         data["secure"] = peer->isSecure();
         result << data;
     }

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -825,6 +825,8 @@ QVariantList SignalProxy::peerData() {
         QVariantMap data;
         data["id"] = peer->_id;
         data["clientVersion"] = peer->_clientVersion;
+        // We explicitly rename this, as, due to the Debian reproducability changes, buildDate isn’t actually the build
+        // date anymore, but on newer clients the date of the last git commit
         data["clientVersionDate"] = peer->_buildDate;
         data["remoteAddress"] = peer->address();
         data["connectedSince"] = peer->_connectedSince;

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -288,7 +288,12 @@ bool SignalProxy::addPeer(Peer *peer)
     if (!peer->parent())
         peer->setParent(this);
 
+    if (peer->_id < 0) {
+        peer->_id = nextPeerId();
+    }
+
     _peers.insert(peer);
+    _peerMap[peer->_id] = peer;
 
     peer->setSignalProxy(this);
 
@@ -331,6 +336,7 @@ void SignalProxy::removePeer(Peer *peer)
     disconnect(peer, 0, this, 0);
     peer->setSignalProxy(0);
 
+    _peerMap.remove(peer->_id);
     _peers.remove(peer);
     emit peerRemoved(peer);
 
@@ -808,6 +814,24 @@ void SignalProxy::updateSecureState()
 
     if (wasSecure != _secure)
         emit secureStateChanged(_secure);
+}
+
+QVariantList SignalProxy::peerData() {
+    QVariantList result;
+    for (auto peer : _peers) {
+        QVariantMap data;
+        data["id"] = peer->_id;
+        data["buildData"] = peer->_buildDate;
+        data["clientVersion"] = peer->_clientVersion;
+        data["description"] = peer->description();
+        data["secure"] = peer->isSecure();
+        result << data;
+    }
+    return result;
+}
+
+Peer *SignalProxy::peerById(int peerId) {
+    return _peerMap[peerId];
 }
 
 

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -221,6 +221,7 @@ void SignalProxy::setProxyMode(ProxyMode mode)
         initClient();
 }
 
+thread_local SignalProxy *SignalProxy::_current = nullptr;
 
 void SignalProxy::init()
 {
@@ -230,6 +231,7 @@ void SignalProxy::init()
     setHeartBeatInterval(30);
     setMaxHeartBeatCount(2);
     _secure = false;
+    _current = this;
     updateSecureState();
 }
 
@@ -515,22 +517,29 @@ void SignalProxy::stopSynchronize(SyncableObject *obj)
 template<class T>
 void SignalProxy::dispatch(const T &protoMessage)
 {
-    foreach (Peer *peer, _peers) {
+    for (Peer *peer : _peers) {
+        _targetPeer = peer;
+
         if (peer->isOpen())
             peer->dispatch(protoMessage);
         else
             QCoreApplication::postEvent(this, new ::RemovePeerEvent(peer));
     }
+    _targetPeer = nullptr;
 }
 
 
 template<class T>
 void SignalProxy::dispatch(Peer *peer, const T &protoMessage)
 {
+    _targetPeer = peer;
+
     if (peer && peer->isOpen())
         peer->dispatch(protoMessage);
     else
         QCoreApplication::postEvent(this, new ::RemovePeerEvent(peer));
+
+    _targetPeer = nullptr;
 }
 
 
@@ -573,7 +582,9 @@ void SignalProxy::handle(Peer *peer, const SyncMessage &syncMessage)
         if (eMeta->argTypes(receiverId).count() > 1)
             returnParams << syncMessage.params;
         returnParams << returnValue;
+        _targetPeer = peer;
         peer->dispatch(SyncMessage(syncMessage.className, syncMessage.objectName, eMeta->methodName(receiverId), returnParams));
+        _targetPeer = nullptr;
     }
 
     // send emit update signal
@@ -596,7 +607,9 @@ void SignalProxy::handle(Peer *peer, const InitRequest &initRequest)
     }
 
     SyncableObject *obj = _syncSlave[initRequest.className][initRequest.objectName];
+    _targetPeer = peer;
     peer->dispatch(InitData(initRequest.className, initRequest.objectName, initData(obj)));
+    _targetPeer = nullptr;
 }
 
 

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -844,6 +844,7 @@ QVariantList SignalProxy::peerData() {
         data["remoteAddress"] = peer->address();
         data["connectedSince"] = peer->_connectedSince;
         data["secure"] = peer->isSecure();
+        data["features"] = (int32_t) peer->_features;
         result << data;
     }
     return result;

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -24,6 +24,8 @@
 #include <QEvent>
 #include <QSet>
 
+#include <functional>
+
 #include "protocol.h"
 
 struct QMetaObject;

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -83,7 +83,21 @@ public:
      * @param peerIds A list of peers that should receive it
      * @param closure Code you want to execute within of that restricted environment
      */
-    void restrictTargetPeers(std::initializer_list<Peer *> peerIds, std::function<void()> closure);
+    void restrictTargetPeers(QSet<Peer*> peers, std::function<void()> closure);
+    void restrictTargetPeers(Peer *peer, std::function<void()> closure) {
+        QSet<Peer*> set;
+        set.insert(peer);
+        restrictTargetPeers(set, std::move(closure));
+    }
+
+    //A better version, but only implemented on Qt5 if Initializer Lists exist
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#ifdef Q_COMPILER_INITIALIZER_LISTS
+    void restrictTargetPeers(std::initializer_list<Peer*> peers, std::function<void()> closure) {
+        restrictTargetPeers(QSet(peers), std::move(closure));
+    }
+#endif
+#endif
 
     inline int peerCount() const { return _peers.size(); }
     QVariantList peerData();

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -78,6 +78,7 @@ public:
     void dumpProxyStats();
     void dumpSyncMap(SyncableObject *object);
 
+    /**@{*/
     /**
      * This method allows to send a signal only to a limited set of peers
      * @param peerIds A list of peers that should receive it
@@ -94,10 +95,11 @@ public:
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #ifdef Q_COMPILER_INITIALIZER_LISTS
     void restrictTargetPeers(std::initializer_list<Peer*> peers, std::function<void()> closure) {
-        restrictTargetPeers(QSet(peers), std::move(closure));
+        restrictTargetPeers(QSet<Peer*>(peers), std::move(closure));
     }
 #endif
 #endif
+    /**}@*/
 
     inline int peerCount() const { return _peers.size(); }
     QVariantList peerData();

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -77,6 +77,9 @@ public:
     bool isSecure() const { return _secure; }
     void dumpProxyStats();
     void dumpSyncMap(SyncableObject *object);
+
+    void restrictTargetPeers(std::initializer_list<Peer *> peerIds, std::function<void()> closure);
+
     inline int peerCount() const { return _peers.size(); }
     QVariantList peerData();
 
@@ -171,6 +174,9 @@ private:
     bool _secure; // determines if all connections are in a secured state (using ssl or internal connections)
 
     int _lastPeerId = 0;
+
+    QSet<Peer *> _restrictedTargets;
+    bool _restrictMessageTarget = false;
 
     friend class SignalRelay;
     friend class SyncableObject;

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -78,6 +78,9 @@ public:
     void dumpProxyStats();
     void dumpSyncMap(SyncableObject *object);
     inline int peerCount() const { return _peers.size(); }
+    QVariantList peerData();
+
+    Peer *peerById(int peerId);
 
 public slots:
     void detachObject(QObject *obj);
@@ -117,6 +120,10 @@ private:
     void removePeer(Peer *peer);
     void removeAllPeers();
 
+    int nextPeerId() {
+        return _lastPeerId++;
+    }
+
     template<class T>
     void dispatch(const T &protoMessage);
     template<class T>
@@ -140,6 +147,7 @@ private:
     static void disconnectDevice(QIODevice *dev, const QString &reason = QString());
 
     QSet<Peer *> _peers;
+    QHash<int, Peer*> _peerMap;
 
     // containg a list of argtypes for fast access
     QHash<const QMetaObject *, ExtendedMetaObject *> _extendedMetaObjects;
@@ -161,6 +169,8 @@ private:
     int _maxHeartBeatCount;
 
     bool _secure; // determines if all connections are in a secured state (using ssl or internal connections)
+
+    int _lastPeerId = 0;
 
     friend class SignalRelay;
     friend class SyncableObject;

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -23,8 +23,10 @@
 
 #include <QEvent>
 #include <QSet>
+#include <QtCore/QThreadStorage>
 
 #include <functional>
+#include <memory>
 
 #include "protocol.h"
 
@@ -80,6 +82,10 @@ public:
     void dumpProxyStats();
     void dumpSyncMap(SyncableObject *object);
 
+    static SignalProxy *current() {
+        return _current;
+    }
+
     /**@{*/
     /**
      * This method allows to send a signal only to a limited set of peers
@@ -111,7 +117,8 @@ public:
     /**
      * @return If handling a signal, the Peer from which the current signal originates
      */
-    Peer *sourcePeer() { return _sourcePeer; }
+    Peer *_sourcePeer;
+    Peer *_targetPeer;
 
 public slots:
     void detachObject(QObject *obj);
@@ -206,7 +213,7 @@ private:
     QSet<Peer *> _restrictedTargets;
     bool _restrictMessageTarget = false;
 
-    Peer *_sourcePeer;
+    thread_local static SignalProxy *_current;
 
     friend class SignalRelay;
     friend class SyncableObject;

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -78,12 +78,22 @@ public:
     void dumpProxyStats();
     void dumpSyncMap(SyncableObject *object);
 
+    /**
+     * This method allows to send a signal only to a limited set of peers
+     * @param peerIds A list of peers that should receive it
+     * @param closure Code you want to execute within of that restricted environment
+     */
     void restrictTargetPeers(std::initializer_list<Peer *> peerIds, std::function<void()> closure);
 
     inline int peerCount() const { return _peers.size(); }
     QVariantList peerData();
 
     Peer *peerById(int peerId);
+
+    /**
+     * @return If handling a signal, the Peer from which the current signal originates
+     */
+    Peer *sourcePeer() { return _sourcePeer; }
 
 public slots:
     void detachObject(QObject *obj);
@@ -177,6 +187,8 @@ private:
 
     QSet<Peer *> _restrictedTargets;
     bool _restrictMessageTarget = false;
+
+    Peer *_sourcePeer;
 
     friend class SignalRelay;
     friend class SyncableObject;

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -185,6 +185,7 @@ void CoreAuthHandler::handle(const RegisterClient &msg)
 
     _peer->_buildDate = msg.buildDate;
     _peer->_clientVersion = msg.clientVersion;
+    _peer->_features = Quassel::Features(msg.clientFeatures);
 
     if (_legacy && useSsl)
         startSsl();

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -183,6 +183,9 @@ void CoreAuthHandler::handle(const RegisterClient &msg)
     // XXX: FIXME: use client features here: we cannot pass authenticators if the client is too old!
     _peer->dispatch(ClientRegistered(Quassel::features(), configured, backends, useSsl, authenticators));
 
+    _peer->_buildDate = msg.buildDate;
+    _peer->_clientVersion = msg.clientVersion;
+
     if (_legacy && useSsl)
         startSsl();
 

--- a/src/core/corecoreinfo.cpp
+++ b/src/core/corecoreinfo.cpp
@@ -40,5 +40,6 @@ QVariantMap CoreCoreInfo::coreData() const
     data["quasselBuildDate"] = Quassel::buildInfo().commitDate; // "BuildDate" for compatibility
     data["startTime"] = Core::instance()->startTime();
     data["sessionConnectedClients"] = _coreSession->signalProxy()->peerCount();
+    data["sessionConnectedClientData"] = _coreSession->signalProxy()->peerData();
     return data;
 }

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -718,19 +718,18 @@ void CoreSession::changePassword(PeerPtr peer, const QString &userName, const QS
     if (uid.isValid() && uid == user())
         success = Core::changeUserPassword(uid, newPassword);
 
-    emit passwordChanged(peer, success);
+    signalProxy()->restrictTargetPeers({signalProxy()->sourcePeer()}, [&]{
+        emit passwordChanged(nullptr, success);
+    });
 }
 
 void CoreSession::kickClient(int peerId) {
-    qWarning() << "kickClient(" << peerId << ")";
-
     auto peer = signalProxy()->peerById(peerId);
     if (peer == nullptr) {
         qWarning() << "Invalid peer Id: " << peerId;
         return;
     }
     signalProxy()->restrictTargetPeers({peer}, [&]{
-        qWarning() << "executing closure";
         emit disconnectFromCore();
     });
 }

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -105,6 +105,8 @@ CoreSession::CoreSession(UserId uid, bool restoreState, QObject *parent)
     p->attachSlot(SIGNAL(changePassword(PeerPtr,QString,QString,QString)), this, SLOT(changePassword(PeerPtr,QString,QString,QString)));
     p->attachSignal(this, SIGNAL(passwordChanged(PeerPtr,bool)));
 
+    p->attachSlot(SIGNAL(kickClient(int)), this, SLOT(kickClient(int)));
+
     loadSettings();
     initScriptEngine();
 
@@ -716,4 +718,12 @@ void CoreSession::changePassword(PeerPtr peer, const QString &userName, const QS
         success = Core::changeUserPassword(uid, newPassword);
 
     emit passwordChanged(peer, success);
+}
+
+void CoreSession::kickClient(int peerId) {
+    auto peer = signalProxy()->peerById(peerId);
+    if (!peer) {
+        qWarning() << "Invalid peer Id: " << peerId;
+    }
+    peer->close("Terminated by user action");
 }

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -718,7 +718,7 @@ void CoreSession::changePassword(PeerPtr peer, const QString &userName, const QS
     if (uid.isValid() && uid == user())
         success = Core::changeUserPassword(uid, newPassword);
 
-    signalProxy()->restrictTargetPeers({signalProxy()->sourcePeer()}, [&]{
+    signalProxy()->restrictTargetPeers(signalProxy()->sourcePeer(), [&]{
         emit passwordChanged(nullptr, success);
     });
 }
@@ -729,7 +729,7 @@ void CoreSession::kickClient(int peerId) {
         qWarning() << "Invalid peer Id: " << peerId;
         return;
     }
-    signalProxy()->restrictTargetPeers({peer}, [&]{
+    signalProxy()->restrictTargetPeers(peer, [&]{
         emit disconnectFromCore();
     });
 }

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -718,7 +718,7 @@ void CoreSession::changePassword(PeerPtr peer, const QString &userName, const QS
     if (uid.isValid() && uid == user())
         success = Core::changeUserPassword(uid, newPassword);
 
-    signalProxy()->restrictTargetPeers(signalProxy()->sourcePeer(), [&]{
+    signalProxy()->restrictTargetPeers(signalProxy()->_sourcePeer, [&]{
         emit passwordChanged(nullptr, success);
     });
 }

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -171,6 +171,8 @@ signals:
 
     void passwordChanged(PeerPtr peer, bool success);
 
+    void disconnectFromCore();
+
 protected:
     virtual void customEvent(QEvent *event);
 

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -131,6 +131,8 @@ public slots:
 
     void changePassword(PeerPtr peer, const QString &userName, const QString &oldPassword, const QString &newPassword);
 
+    void kickClient(int peerId);
+
     QHash<QString, QString> persistentChannels(NetworkId) const;
 
     /**

--- a/src/qtui/CMakeLists.txt
+++ b/src/qtui/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SOURCES
     coreconnectdlg.cpp
     coreconnectionstatuswidget.cpp
     coreinfodlg.cpp
+        coresessionwidget.cpp
     debugbufferviewoverlay.cpp
     debugconsole.cpp
     debuglogwidget.cpp
@@ -66,6 +67,7 @@ set(FORMS
     coreconfigwizardsyncpage.ui
     coreconnectauthdlg.ui
     coreconnectionstatuswidget.ui
+        coresessionwidget.ui
     coreinfodlg.ui
     debugbufferviewoverlay.ui
     debugconsole.ui

--- a/src/qtui/CMakeLists.txt
+++ b/src/qtui/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SOURCES
     coreconnectdlg.cpp
     coreconnectionstatuswidget.cpp
     coreinfodlg.cpp
-        coresessionwidget.cpp
+    coresessionwidget.cpp
     debugbufferviewoverlay.cpp
     debugconsole.cpp
     debuglogwidget.cpp

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -43,8 +43,6 @@ void CoreInfoDlg::coreInfoAvailable()
     ui.labelCoreVersionDate->setText(_coreInfo["quasselBuildDate"].toString()); // "BuildDate" for compatibility
     ui.labelClientCount->setNum(_coreInfo["sessionConnectedClients"].toInt());
 
-    qWarning() << _coreInfo["sessionConnectedClientData"];
-
     for (const auto &peerData : _coreInfo["sessionConnectedClientData"].toList()) {
         auto coreSessionWidget = new CoreSessionWidget(ui.coreSessionScrollContainer);
         coreSessionWidget->setData(peerData.toMap());

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -40,6 +40,23 @@ void CoreInfoDlg::coreInfoAvailable()
     ui.labelCoreVersion->setText(_coreInfo["quasselVersion"].toString());
     ui.labelCoreVersionDate->setText(_coreInfo["quasselBuildDate"].toString()); // "BuildDate" for compatibility
     ui.labelClientCount->setNum(_coreInfo["sessionConnectedClients"].toInt());
+
+    /*
+    qWarning() << _coreInfo["sessionConnectedClientData"];
+
+    int lastPeerId = -1;
+    QMap<QString, QVariant> lastPeerData;
+    for (const auto &peerData : _coreInfo["sessionConnectedClientData"].toList()) {
+        lastPeerData = peerData.toMap();
+        lastPeerId = lastPeerData["id"].toInt();
+    }
+
+    if (lastPeerId != -1) {
+        qWarning() << "Kicking client " << lastPeerId;
+        Client::kickClient(lastPeerId);
+    }
+    */
+
     updateUptime();
     startTimer(1000);
 }

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -43,12 +43,17 @@ void CoreInfoDlg::coreInfoAvailable()
     ui.labelCoreVersionDate->setText(_coreInfo["quasselBuildDate"].toString()); // "BuildDate" for compatibility
     ui.labelClientCount->setNum(_coreInfo["sessionConnectedClients"].toInt());
 
+    auto coreSessionSupported = false;
     for (const auto &peerData : _coreInfo["sessionConnectedClientData"].toList()) {
+        coreSessionSupported = true;
+
         auto coreSessionWidget = new CoreSessionWidget(ui.coreSessionScrollContainer);
         coreSessionWidget->setData(peerData.toMap());
         ui.coreSessionContainer->addWidget(coreSessionWidget);
         connect(coreSessionWidget, SIGNAL(disconnectClicked(int)), this, SLOT(disconnectClicked(int)));
     }
+
+    ui.coreSessionScrollArea->setVisible(coreSessionSupported);
 
     ui.coreSessionContainer->addStretch(1);
 

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -24,6 +24,8 @@
 
 #include "client.h"
 #include "signalproxy.h"
+#include "bufferwidget.h"
+#include "coresessionwidget.h"
 
 CoreInfoDlg::CoreInfoDlg(QWidget *parent)
     : QDialog(parent),
@@ -41,21 +43,15 @@ void CoreInfoDlg::coreInfoAvailable()
     ui.labelCoreVersionDate->setText(_coreInfo["quasselBuildDate"].toString()); // "BuildDate" for compatibility
     ui.labelClientCount->setNum(_coreInfo["sessionConnectedClients"].toInt());
 
-    /*
     qWarning() << _coreInfo["sessionConnectedClientData"];
 
-    int lastPeerId = -1;
-    QMap<QString, QVariant> lastPeerData;
     for (const auto &peerData : _coreInfo["sessionConnectedClientData"].toList()) {
-        lastPeerData = peerData.toMap();
-        lastPeerId = lastPeerData["id"].toInt();
+        auto coreSessionWidget = new CoreSessionWidget(ui.coreSessionScrollContainer);
+        coreSessionWidget->setData(peerData.toMap());
+        ui.coreSessionContainer->addWidget(coreSessionWidget);
     }
 
-    if (lastPeerId != -1) {
-        qWarning() << "Kicking client " << lastPeerId;
-        Client::kickClient(lastPeerId);
-    }
-    */
+    ui.coreSessionContainer->addStretch(1);
 
     updateUptime();
     startTimer(1000);

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -49,6 +49,7 @@ void CoreInfoDlg::coreInfoAvailable()
         auto coreSessionWidget = new CoreSessionWidget(ui.coreSessionScrollContainer);
         coreSessionWidget->setData(peerData.toMap());
         ui.coreSessionContainer->addWidget(coreSessionWidget);
+        connect(coreSessionWidget, SIGNAL(disconnectClicked(int)), this, SLOT(disconnectClicked(int)));
     }
 
     ui.coreSessionContainer->addStretch(1);
@@ -70,4 +71,8 @@ void CoreInfoDlg::updateUptime()
     QString uptimeText = tr("%n Day(s)", "", updays)
                          + tr(" %1:%2:%3 (since %4)").arg(uphours, 2, 10, QChar('0')).arg(upmins, 2, 10, QChar('0')).arg(uptime, 2, 10, QChar('0')).arg(startTime.toLocalTime().toString(Qt::TextDate));
     ui.labelUptime->setText(uptimeText);
+}
+void CoreInfoDlg::disconnectClicked(int peerId)
+{
+    Client::kickClient(peerId);
 }

--- a/src/qtui/coreinfodlg.h
+++ b/src/qtui/coreinfodlg.h
@@ -42,6 +42,7 @@ protected:
 private slots:
     void on_closeButton_clicked() { reject(); }
     void updateUptime();
+    void disconnectClicked(int peerId);
 
 private:
     Ui::CoreInfoDlg ui;

--- a/src/qtui/coresessionwidget.cpp
+++ b/src/qtui/coresessionwidget.cpp
@@ -46,6 +46,9 @@ void CoreSessionWidget::setData(QMap<QString, QVariant> map)
         ui.labelLocation->hide();
         ui.labelLocationTitle->hide();
     }
+    if (!Quassel::Features(map["features"].toInt()).testFlag(Quassel::Feature::ClientFeatures)) {
+        ui.disconnectButton->hide();
+    }
 
     bool success = false;
     _peerId = map["id"].toInt(&success);

--- a/src/qtui/coresessionwidget.cpp
+++ b/src/qtui/coresessionwidget.cpp
@@ -1,3 +1,23 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2016 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
 #include "coresessionwidget.h"
 #include <QtCore/QDateTime>
 #include <client.h>

--- a/src/qtui/coresessionwidget.cpp
+++ b/src/qtui/coresessionwidget.cpp
@@ -1,10 +1,6 @@
 #include "coresessionwidget.h"
-#include <QLayout>
-#include <QVariant>
-#include <QtCore/QMap>
-#include <QtWidgets/QLabel>
-#include <QtWidgets/QPushButton>
 #include <QtCore/QDateTime>
+#include <client.h>
 
 
 CoreSessionWidget::CoreSessionWidget(QWidget *parent)
@@ -13,12 +9,12 @@ CoreSessionWidget::CoreSessionWidget(QWidget *parent)
     ui.setupUi(this);
     layout()->setContentsMargins(0, 0, 0, 0);
     layout()->setSpacing(0);
+    connect(ui.disconnectButton, SIGNAL(released()), this, SLOT(disconnectClicked()));
 }
 
 void CoreSessionWidget::setData(QMap<QString, QVariant> map)
 {
     QLabel *iconSecure = ui.iconSecure;
-    QPushButton *disconnectButton = ui.disconnectButton;
 
     ui.labelRemoteAddress->setText(map["remoteAddress"].toString());
     ui.labelLocation->setText(map["location"].toString());
@@ -30,4 +26,13 @@ void CoreSessionWidget::setData(QMap<QString, QVariant> map)
         ui.labelLocation->hide();
         ui.labelLocationTitle->hide();
     }
+
+    bool success = false;
+    _peerId = map["id"].toInt(&success);
+    if (!success) _peerId = -1;
+}
+
+void CoreSessionWidget::disconnectClicked()
+{
+    emit disconnectClicked(_peerId);
 }

--- a/src/qtui/coresessionwidget.cpp
+++ b/src/qtui/coresessionwidget.cpp
@@ -1,0 +1,33 @@
+#include "coresessionwidget.h"
+#include <QLayout>
+#include <QVariant>
+#include <QtCore/QMap>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QPushButton>
+#include <QtCore/QDateTime>
+
+
+CoreSessionWidget::CoreSessionWidget(QWidget *parent)
+    : QWidget(parent)
+{
+    ui.setupUi(this);
+    layout()->setContentsMargins(0, 0, 0, 0);
+    layout()->setSpacing(0);
+}
+
+void CoreSessionWidget::setData(QMap<QString, QVariant> map)
+{
+    QLabel *iconSecure = ui.iconSecure;
+    QPushButton *disconnectButton = ui.disconnectButton;
+
+    ui.labelRemoteAddress->setText(map["remoteAddress"].toString());
+    ui.labelLocation->setText(map["location"].toString());
+    ui.labelClient->setText(map["clientVersion"].toString());
+    ui.labelVersionDate->setText(map["clientVersionDate"].toString());
+    ui.labelUptime
+        ->setText(map["connectedSince"].toDateTime().toLocalTime().toString(Qt::DateFormat::SystemLocaleShortDate));
+    if (map["location"].toString().isEmpty()) {
+        ui.labelLocation->hide();
+        ui.labelLocationTitle->hide();
+    }
+}

--- a/src/qtui/coresessionwidget.h
+++ b/src/qtui/coresessionwidget.h
@@ -1,0 +1,25 @@
+//
+// Created by kuschku on 27.08.17.
+//
+
+#ifndef CORESESSIONWIDGET_H
+#define CORESESSIONWIDGET_H
+
+#include <QtWidgets/QWidget>
+#include <ui_coresessionwidget.h>
+#include <QtCore/QMap>
+
+class CoreSessionWidget: public QWidget
+{
+Q_OBJECT
+
+public:
+    explicit CoreSessionWidget(QWidget *);
+
+    void setData(QMap<QString, QVariant>);
+
+private:
+    Ui::CoreSessionWidget ui;
+};
+
+#endif //CORESESSIONWIDGET_H

--- a/src/qtui/coresessionwidget.h
+++ b/src/qtui/coresessionwidget.h
@@ -18,8 +18,15 @@ public:
 
     void setData(QMap<QString, QVariant>);
 
+signals:
+    void disconnectClicked(int);
+
+private slots:
+    void disconnectClicked();
+
 private:
     Ui::CoreSessionWidget ui;
+    int _peerId;
 };
 
 #endif //CORESESSIONWIDGET_H

--- a/src/qtui/coresessionwidget.h
+++ b/src/qtui/coresessionwidget.h
@@ -1,13 +1,29 @@
-//
-// Created by kuschku on 27.08.17.
-//
+/***************************************************************************
+ *   Copyright (C) 2005-2016 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
 
 #ifndef CORESESSIONWIDGET_H
 #define CORESESSIONWIDGET_H
 
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include <ui_coresessionwidget.h>
-#include <QtCore/QMap>
+#include <QMap>
 
 class CoreSessionWidget: public QWidget
 {

--- a/src/qtui/ui/coreinfodlg.ui
+++ b/src/qtui/ui/coreinfodlg.ui
@@ -1,145 +1,158 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>CoreInfoDlg</class>
-    <widget class="QDialog" name="CoreInfoDlg">
-        <property name="geometry">
+ <widget class="QDialog" name="CoreInfoDlg">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-       <width>566</width>
-       <height>349</height>
+    <width>566</width>
+    <height>349</height>
    </rect>
   </property>
-        <property name="windowTitle">
+  <property name="windowTitle">
    <string>Core Information</string>
   </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0,0">
    <item>
-       <layout class="QGridLayout" name="gridLayout">
-           <item row="0" column="0">
-               <widget class="QLabel" name="label_2">
-                   <property name="text">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelCoreVersionTitle">
+       <property name="text">
         <string>Version:</string>
        </property>
       </widget>
      </item>
-           <item row="0" column="1">
-               <widget class="QLabel" name="labelCoreVersion">
-                   <property name="text">
-                       <string>&lt;core version&gt;</string>
+     <item row="0" column="1">
+      <widget class="QLabel" name="labelCoreVersion">
+       <property name="text">
+        <string notr="true">&lt;core version&gt;</string>
        </property>
       </widget>
      </item>
-           <item row="2" column="0">
-               <widget class="QLabel" name="label_4">
-                   <property name="text">
-        <string>Uptime:</string>
-       </property>
-      </widget>
-     </item>
-           <item row="3" column="0">
-               <widget class="QLabel" name="label_3">
-                   <property name="text">
-        <string>Connected Clients:</string>
-       </property>
-      </widget>
-     </item>
-           <item row="3" column="1">
-               <widget class="QLabel" name="labelClientCount">
-                   <property name="text">
-                       <string>&lt;connected clients&gt;</string>
-       </property>
-      </widget>
-     </item>
-           <item row="2" column="1">
-               <widget class="QLabel" name="labelUptime">
-                   <property name="text">
-                       <string>&lt;core uptime&gt;</string>
-       </property>
-      </widget>
-     </item>
-           <item row="1" column="0">
-               <widget class="QLabel" name="label">
-                   <property name="text">
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelCoreVersionDateTitle">
+       <property name="text">
         <string>Version date:</string>
        </property>
       </widget>
      </item>
-           <item row="1" column="1">
-               <widget class="QLabel" name="labelCoreVersionDate">
-                   <property name="text">
-                       <string>&lt;version date&gt;</string>
+     <item row="1" column="1">
+      <widget class="QLabel" name="labelCoreVersionDate">
+       <property name="text">
+        <string notr="true">&lt;version date&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelUptimeTitle">
+       <property name="text">
+        <string>Uptime:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="labelUptime">
+       <property name="text">
+        <string notr="true">&lt;core uptime&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelClientCountTitle">
+       <property name="text">
+        <string>Connected Clients:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLabel" name="labelClientCount">
+       <property name="text">
+        <string notr="true">&lt;connected clients&gt;</string>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
-       <widget class="QScrollArea" name="coreSessionScrollArea">
-           <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-               </sizepolicy>
+    <widget class="QScrollArea" name="coreSessionScrollArea">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignHCenter|Qt::AlignTop</set>
+     </property>
+     <widget class="QWidget" name="coreSessionScrollContainer">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>550</width>
+        <height>187</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QVBoxLayout" name="coreSessionContainer">
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
            </property>
-           <property name="widgetResizable">
-               <bool>true</bool>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
            </property>
-           <property name="alignment">
-               <set>Qt::AlignHCenter|Qt::AlignTop</set>
-           </property>
-           <widget class="QWidget" name="coreSessionScrollContainer">
-               <property name="geometry">
-                   <rect>
-                       <x>0</x>
-                       <y>0</y>
-                       <width>550</width>
-                       <height>193</height>
-                   </rect>
-               </property>
-               <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                   </sizepolicy>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_3">
-                   <item>
-                       <layout class="QVBoxLayout" name="coreSessionContainer">
-                           <item>
-                               <spacer name="verticalSpacer">
-                                   <property name="orientation">
-                                       <enum>Qt::Vertical</enum>
-                                   </property>
-                                   <property name="sizeHint" stdset="0">
-                                       <size>
-                                           <width>20</width>
-                                           <height>40</height>
-                                       </size>
-                                   </property>
-                               </spacer>
-                           </item>
-                       </layout>
-                   </item>
-               </layout>
-           </widget>
-       </widget>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
-            <item>
-                <layout class="QGridLayout" name="gridLayout_2">
-                    <item row="1" column="1">
-                        <widget class="QPushButton" name="closeButton">
-                            <property name="text">
+   <item>
+    <spacer name="mainSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="1" column="1">
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
         <string>Close</string>
        </property>
       </widget>
      </item>
-                    <item row="1" column="0">
-                        <spacer name="horizontalSpacer">
-                            <property name="orientation">
+     <item row="1" column="0">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-                            <property name="sizeHint" stdset="0">
+       <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>
@@ -147,12 +160,12 @@
        </property>
       </spacer>
      </item>
-                    <item row="1" column="2">
-                        <spacer name="horizontalSpacer_2">
-                            <property name="orientation">
+     <item row="1" column="2">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-                            <property name="sizeHint" stdset="0">
+       <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>

--- a/src/qtui/ui/coreinfodlg.ui
+++ b/src/qtui/ui/coreinfodlg.ui
@@ -1,93 +1,145 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>CoreInfoDlg</class>
- <widget class="QDialog" name="CoreInfoDlg" >
-  <property name="geometry" >
+    <widget class="QDialog" name="CoreInfoDlg">
+        <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>282</width>
-    <height>126</height>
+       <width>566</width>
+       <height>349</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+        <property name="windowTitle">
    <string>Core Information</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" >
+        <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout" >
-     <item row="0" column="0" >
-      <widget class="QLabel" name="label_2" >
-       <property name="text" >
+       <layout class="QGridLayout" name="gridLayout">
+           <item row="0" column="0">
+               <widget class="QLabel" name="label_2">
+                   <property name="text">
         <string>Version:</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1" >
-      <widget class="QLabel" name="labelCoreVersion" >
-       <property name="text" >
-        <string>&lt;core version></string>
+           <item row="0" column="1">
+               <widget class="QLabel" name="labelCoreVersion">
+                   <property name="text">
+                       <string>&lt;core version&gt;</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0" >
-      <widget class="QLabel" name="label_4" >
-       <property name="text" >
+           <item row="2" column="0">
+               <widget class="QLabel" name="label_4">
+                   <property name="text">
         <string>Uptime:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0" >
-      <widget class="QLabel" name="label_3" >
-       <property name="text" >
+           <item row="3" column="0">
+               <widget class="QLabel" name="label_3">
+                   <property name="text">
         <string>Connected Clients:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1" >
-      <widget class="QLabel" name="labelClientCount" >
-       <property name="text" >
-        <string>&lt;connected clients></string>
+           <item row="3" column="1">
+               <widget class="QLabel" name="labelClientCount">
+                   <property name="text">
+                       <string>&lt;connected clients&gt;</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1" >
-      <widget class="QLabel" name="labelUptime" >
-       <property name="text" >
-        <string>&lt;core uptime></string>
+           <item row="2" column="1">
+               <widget class="QLabel" name="labelUptime">
+                   <property name="text">
+                       <string>&lt;core uptime&gt;</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0" >
-      <widget class="QLabel" name="label" >
-       <property name="text" >
+           <item row="1" column="0">
+               <widget class="QLabel" name="label">
+                   <property name="text">
         <string>Version date:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1" >
-      <widget class="QLabel" name="labelCoreVersionDate" >
-       <property name="text" >
-        <string>&lt;version date></string>
+           <item row="1" column="1">
+               <widget class="QLabel" name="labelCoreVersionDate">
+                   <property name="text">
+                       <string>&lt;version date&gt;</string>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
-    <layout class="QGridLayout" name="gridLayout_2" >
-     <item row="0" column="1" >
-      <widget class="QPushButton" name="closeButton" >
-       <property name="text" >
+       <widget class="QScrollArea" name="coreSessionScrollArea">
+           <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+               </sizepolicy>
+           </property>
+           <property name="widgetResizable">
+               <bool>true</bool>
+           </property>
+           <property name="alignment">
+               <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           </property>
+           <widget class="QWidget" name="coreSessionScrollContainer">
+               <property name="geometry">
+                   <rect>
+                       <x>0</x>
+                       <y>0</y>
+                       <width>550</width>
+                       <height>193</height>
+                   </rect>
+               </property>
+               <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                   </sizepolicy>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_3">
+                   <item>
+                       <layout class="QVBoxLayout" name="coreSessionContainer">
+                           <item>
+                               <spacer name="verticalSpacer">
+                                   <property name="orientation">
+                                       <enum>Qt::Vertical</enum>
+                                   </property>
+                                   <property name="sizeHint" stdset="0">
+                                       <size>
+                                           <width>20</width>
+                                           <height>40</height>
+                                       </size>
+                                   </property>
+                               </spacer>
+                           </item>
+                       </layout>
+                   </item>
+               </layout>
+           </widget>
+       </widget>
+   </item>
+            <item>
+                <layout class="QGridLayout" name="gridLayout_2">
+                    <item row="1" column="1">
+                        <widget class="QPushButton" name="closeButton">
+                            <property name="text">
         <string>Close</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="0" >
-      <spacer name="horizontalSpacer" >
-       <property name="orientation" >
+                    <item row="1" column="0">
+                        <spacer name="horizontalSpacer">
+                            <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint" stdset="0" >
+                            <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>
@@ -95,12 +147,12 @@
        </property>
       </spacer>
      </item>
-     <item row="0" column="2" >
-      <spacer name="horizontalSpacer_2" >
-       <property name="orientation" >
+                    <item row="1" column="2">
+                        <spacer name="horizontalSpacer_2">
+                            <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint" stdset="0" >
+                            <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>
@@ -109,19 +161,6 @@
       </spacer>
      </item>
     </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer" >
-     <property name="orientation" >
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0" >
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/qtui/ui/coresessionwidget.ui
+++ b/src/qtui/ui/coresessionwidget.ui
@@ -1,198 +1,198 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-    <class>CoreSessionWidget</class>
-    <widget class="QWidget" name="CoreSessionWidget">
-        <property name="geometry">
-            <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>509</width>
-                <height>204</height>
-            </rect>
-        </property>
-        <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-            </sizepolicy>
-        </property>
-        <property name="minimumSize">
-            <size>
-                <width>480</width>
-                <height>0</height>
-            </size>
-        </property>
-        <property name="maximumSize">
-            <size>
-                <width>16777215</width>
-                <height>16777215</height>
-            </size>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_4">
-            <item row="0" column="0">
-                <layout class="QGridLayout" name="mainLayout" rowstretch="0,0,0">
-                    <item row="0" column="0">
-                        <layout class="QHBoxLayout" name="titleLayout">
-                            <item>
-                                <widget class="QLabel" name="labelRemoteAddress">
-                                    <property name="font">
-                                        <font>
-                                            <pointsize>13</pointsize>
-                                            <weight>75</weight>
-                                            <bold>true</bold>
-                                        </font>
-                                    </property>
-                                    <property name="text">
-                                        <string>86.103.223.212</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item>
-                                <widget class="QLabel" name="iconSecure">
-                                    <property name="sizePolicy">
-                                        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                                            <horstretch>0</horstretch>
-                                            <verstretch>0</verstretch>
-                                        </sizepolicy>
-                                    </property>
-                                    <property name="minimumSize">
-                                        <size>
-                                            <width>32</width>
-                                            <height>32</height>
-                                        </size>
-                                    </property>
-                                    <property name="text">
-                                        <string/>
-                                    </property>
-                                    <property name="alignment">
-                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                    </property>
-                                    <property name="textInteractionFlags">
-                                        <set>Qt::NoTextInteraction</set>
-                                    </property>
-                                </widget>
-                            </item>
-                        </layout>
-                    </item>
-                    <item row="1" column="0">
-                        <layout class="QGridLayout" name="contentLayout" columnstretch="1,3">
-                            <item row="0" column="0">
-                                <widget class="QLabel" name="labelClientTitle">
-                                    <property name="styleSheet">
-                                        <string notr="true">color: rgb(119, 119, 119);</string>
-                                    </property>
-                                    <property name="text">
-                                        <string>Client:</string>
-                                    </property>
-                                    <property name="alignment">
-                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="0" column="1">
-                                <widget class="QLabel" name="labelClient">
-                                    <property name="text">
-                                        <string>v0.13-pre (0.12.0+372 git-12df418)</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="2" column="0">
-                                <widget class="QLabel" name="labelLocationTitle">
-                                    <property name="styleSheet">
-                                        <string notr="true">color: rgb(119, 119, 119);</string>
-                                    </property>
-                                    <property name="text">
-                                        <string>Location:</string>
-                                    </property>
-                                    <property name="alignment">
-                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="2" column="1">
-                                <widget class="QLabel" name="labelLocation">
-                                    <property name="text">
-                                        <string>Kiel, Germany</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="1" column="1">
-                                <widget class="QLabel" name="labelVersionDate">
-                                    <property name="text">
-                                        <string>Sun Aug 27 04:29:53 2017</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="1" column="0">
-                                <widget class="QLabel" name="labelVersionDateTitle">
-                                    <property name="styleSheet">
-                                        <string notr="true">color: rgb(119, 119, 119);</string>
-                                    </property>
-                                    <property name="text">
-                                        <string>Version Date:</string>
-                                    </property>
-                                    <property name="alignment">
-                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="3" column="1">
-                                <widget class="QLabel" name="labelUptime">
-                                    <property name="text">
-                                        <string>Sun Aug 27 15:03:10 2017</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item row="3" column="0">
-                                <widget class="QLabel" name="labelUptimeTitle">
-                                    <property name="styleSheet">
-                                        <string notr="true">color: rgb(119, 119, 119);</string>
-                                    </property>
-                                    <property name="text">
-                                        <string>Connected Since:</string>
-                                    </property>
-                                    <property name="alignment">
-                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                    </property>
-                                </widget>
-                            </item>
-                        </layout>
-                    </item>
-                    <item row="2" column="0">
-                        <layout class="QHBoxLayout" name="actionsLayout">
-                            <item>
-                                <spacer name="horizontalSpacer">
-                                    <property name="orientation">
-                                        <enum>Qt::Horizontal</enum>
-                                    </property>
-                                    <property name="sizeHint" stdset="0">
-                                        <size>
-                                            <width>40</width>
-                                            <height>20</height>
-                                        </size>
-                                    </property>
-                                </spacer>
-                            </item>
-                            <item>
-                                <widget class="QPushButton" name="disconnectButton">
-                                    <property name="text">
-                                        <string>End Session</string>
-                                    </property>
-                                </widget>
-                            </item>
-                        </layout>
-                    </item>
-                </layout>
-            </item>
-            <item row="2" column="0">
-                <widget class="Line" name="line">
-                    <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                    </property>
-                </widget>
-            </item>
-        </layout>
+ <class>CoreSessionWidget</class>
+ <widget class="QWidget" name="CoreSessionWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>509</width>
+    <height>204</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>480</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_4">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="mainLayout" rowstretch="0,0,0">
+     <item row="0" column="0">
+      <layout class="QHBoxLayout" name="titleLayout">
+       <item>
+        <widget class="QLabel" name="labelRemoteAddress">
+         <property name="font">
+          <font>
+           <pointsize>13</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string notr="true">10.104.241.277</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="iconSecure">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+         <property name="text">
+          <string />
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::NoTextInteraction</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="0">
+      <layout class="QGridLayout" name="contentLayout" columnstretch="1,3">
+       <item row="0" column="0">
+        <widget class="QLabel" name="labelClientTitle">
+         <property name="styleSheet">
+          <string notr="true">opacity: 0.66;</string>
+         </property>
+         <property name="text">
+          <string>Client:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="labelClient">
+         <property name="text">
+          <string notr="true">v0.13-pre (0.12.0+372 git-12df418)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="labelVersionDateTitle">
+         <property name="styleSheet">
+          <string notr="true">color: rgb(119, 119, 119);</string>
+         </property>
+         <property name="text">
+          <string>Version Date:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="labelVersionDate">
+         <property name="text">
+          <string notr="true">Sun Aug 27 04:29:53 2017</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="labelLocationTitle">
+         <property name="styleSheet">
+          <string notr="true">opacity: 0.66;</string>
+         </property>
+         <property name="text">
+          <string>Location:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="labelLocation">
+         <property name="text">
+          <string notr="true">Kiel, Germany</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="labelUptimeTitle">
+         <property name="styleSheet">
+          <string notr="true">color: rgb(119, 119, 119);</string>
+         </property>
+         <property name="text">
+          <string>Connected Since:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="labelUptime">
+         <property name="text">
+          <string notr="true">Sun Aug 27 15:03:10 2017</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="2" column="0">
+      <layout class="QHBoxLayout" name="actionsLayout">
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="disconnectButton">
+         <property name="text">
+          <string>End Session</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
     </widget>
-    <resources/>
-    <connections/>
+   </item>
+  </layout>
+ </widget>
+ <resources />
+ <connections />
 </ui>

--- a/src/qtui/ui/coresessionwidget.ui
+++ b/src/qtui/ui/coresessionwidget.ui
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+    <class>CoreSessionWidget</class>
+    <widget class="QWidget" name="CoreSessionWidget">
+        <property name="geometry">
+            <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>509</width>
+                <height>204</height>
+            </rect>
+        </property>
+        <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+            </sizepolicy>
+        </property>
+        <property name="minimumSize">
+            <size>
+                <width>480</width>
+                <height>0</height>
+            </size>
+        </property>
+        <property name="maximumSize">
+            <size>
+                <width>16777215</width>
+                <height>16777215</height>
+            </size>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
+            <item row="0" column="0">
+                <layout class="QGridLayout" name="mainLayout" rowstretch="0,0,0">
+                    <item row="0" column="0">
+                        <layout class="QHBoxLayout" name="titleLayout">
+                            <item>
+                                <widget class="QLabel" name="labelRemoteAddress">
+                                    <property name="font">
+                                        <font>
+                                            <pointsize>13</pointsize>
+                                            <weight>75</weight>
+                                            <bold>true</bold>
+                                        </font>
+                                    </property>
+                                    <property name="text">
+                                        <string>86.103.223.212</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item>
+                                <widget class="QLabel" name="iconSecure">
+                                    <property name="sizePolicy">
+                                        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                            <horstretch>0</horstretch>
+                                            <verstretch>0</verstretch>
+                                        </sizepolicy>
+                                    </property>
+                                    <property name="minimumSize">
+                                        <size>
+                                            <width>32</width>
+                                            <height>32</height>
+                                        </size>
+                                    </property>
+                                    <property name="text">
+                                        <string/>
+                                    </property>
+                                    <property name="alignment">
+                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                                    </property>
+                                    <property name="textInteractionFlags">
+                                        <set>Qt::NoTextInteraction</set>
+                                    </property>
+                                </widget>
+                            </item>
+                        </layout>
+                    </item>
+                    <item row="1" column="0">
+                        <layout class="QGridLayout" name="contentLayout" columnstretch="1,3">
+                            <item row="0" column="0">
+                                <widget class="QLabel" name="labelClientTitle">
+                                    <property name="styleSheet">
+                                        <string notr="true">color: rgb(119, 119, 119);</string>
+                                    </property>
+                                    <property name="text">
+                                        <string>Client:</string>
+                                    </property>
+                                    <property name="alignment">
+                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="0" column="1">
+                                <widget class="QLabel" name="labelClient">
+                                    <property name="text">
+                                        <string>v0.13-pre (0.12.0+372 git-12df418)</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="2" column="0">
+                                <widget class="QLabel" name="labelLocationTitle">
+                                    <property name="styleSheet">
+                                        <string notr="true">color: rgb(119, 119, 119);</string>
+                                    </property>
+                                    <property name="text">
+                                        <string>Location:</string>
+                                    </property>
+                                    <property name="alignment">
+                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="2" column="1">
+                                <widget class="QLabel" name="labelLocation">
+                                    <property name="text">
+                                        <string>Kiel, Germany</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="1" column="1">
+                                <widget class="QLabel" name="labelVersionDate">
+                                    <property name="text">
+                                        <string>Sun Aug 27 04:29:53 2017</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="1" column="0">
+                                <widget class="QLabel" name="labelVersionDateTitle">
+                                    <property name="styleSheet">
+                                        <string notr="true">color: rgb(119, 119, 119);</string>
+                                    </property>
+                                    <property name="text">
+                                        <string>Version Date:</string>
+                                    </property>
+                                    <property name="alignment">
+                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="3" column="1">
+                                <widget class="QLabel" name="labelUptime">
+                                    <property name="text">
+                                        <string>Sun Aug 27 15:03:10 2017</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item row="3" column="0">
+                                <widget class="QLabel" name="labelUptimeTitle">
+                                    <property name="styleSheet">
+                                        <string notr="true">color: rgb(119, 119, 119);</string>
+                                    </property>
+                                    <property name="text">
+                                        <string>Connected Since:</string>
+                                    </property>
+                                    <property name="alignment">
+                                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                                    </property>
+                                </widget>
+                            </item>
+                        </layout>
+                    </item>
+                    <item row="2" column="0">
+                        <layout class="QHBoxLayout" name="actionsLayout">
+                            <item>
+                                <spacer name="horizontalSpacer">
+                                    <property name="orientation">
+                                        <enum>Qt::Horizontal</enum>
+                                    </property>
+                                    <property name="sizeHint" stdset="0">
+                                        <size>
+                                            <width>40</width>
+                                            <height>20</height>
+                                        </size>
+                                    </property>
+                                </spacer>
+                            </item>
+                            <item>
+                                <widget class="QPushButton" name="disconnectButton">
+                                    <property name="text">
+                                        <string>End Session</string>
+                                    </property>
+                                </widget>
+                            </item>
+                        </layout>
+                    </item>
+                </layout>
+            </item>
+            <item row="2" column="0">
+                <widget class="Line" name="line">
+                    <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                    </property>
+                </widget>
+            </item>
+        </layout>
+    </widget>
+    <resources/>
+    <connections/>
+</ui>

--- a/src/uisupport/uistyle.cpp
+++ b/src/uisupport/uistyle.cpp
@@ -911,12 +911,12 @@ QString UiStyle::StyledMessage::decoratedSender() const
     switch (type()) {
     case Message::Plain:
         if (_showSenderBrackets)
-            return QString("<%1>").arg(plainSender());
+            return QString("<%1%2>").arg(senderPrefixes(), plainSender());
         else
-            return QString("%1").arg(plainSender());
+            return QString("%1%2").arg(senderPrefixes(), plainSender());
         break;
     case Message::Notice:
-        return QString("[%1]").arg(plainSender()); break;
+        return QString("[%1%2]").arg(senderPrefixes(), plainSender()); break;
     case Message::Action:
         return "-*-"; break;
     case Message::Nick:
@@ -950,7 +950,7 @@ QString UiStyle::StyledMessage::decoratedSender() const
     case Message::Invite:
         return "->"; break;
     default:
-        return QString("%1").arg(plainSender());
+        return QString("%1%2").arg(senderPrefixes(), plainSender());
     }
 }
 


### PR DESCRIPTION
## In Short
* Via the coreinfo sync, transmit the peer features of each client.
* Hide the disconnect button if the "ClientFeatures" flag isn’t set

## Dependencies
- This depends on the client features and peer-dependent sync introduced in #309 
- Transitively, this depends on #302

## Rationale
This reduces potential confusion