### PR TITLE
core: Add SQLite backlog idx: bufferid, messageid

### DIFF
--- a/src/core/SQL/SQLite/setup_110_backlog_idx3.sql
+++ b/src/core/SQL/SQLite/setup_110_backlog_idx3.sql
@@ -1,0 +1,1 @@
+CREATE INDEX backlog_buffer_msg_idx ON backlog (bufferid, messageid)

--- a/src/core/SQL/SQLite/version/26/upgrade_000_create_buffer_idx.sql
+++ b/src/core/SQL/SQLite/version/26/upgrade_000_create_buffer_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX backlog_buffer_msg_idx ON backlog (bufferid, messageid)

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -182,6 +182,7 @@
     <file>./SQL/SQLite/setup_080_ircservers.sql</file>
     <file>./SQL/SQLite/setup_090_backlog_idx.sql</file>
     <file>./SQL/SQLite/setup_100_backlog_idx2.sql</file>
+    <file>./SQL/SQLite/setup_110_backlog_idx3.sql</file>
     <file>./SQL/SQLite/setup_110_buffer_user_idx.sql</file>
     <file>./SQL/SQLite/setup_120_user_setting.sql</file>
     <file>./SQL/SQLite/setup_130_identity.sql</file>
@@ -291,5 +292,6 @@
     <file>./SQL/SQLite/version/23/upgrade_000_alter_quasseluser_add_authenticator.sql</file>
     <file>./SQL/SQLite/version/24/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/SQLite/version/25/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
+    <file>./SQL/SQLite/version/26/upgrade_000_create_buffer_idx.sql</file>
 </qresource>
 </RCC>


### PR DESCRIPTION
## In short
* Add `backlog` index over `(bufferid, messageid)` for SQLite
  * Speeds up connection due to SQL queries making use of those fields
  * Uses some extra space

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing, speeds up connection on SQLite
Risk | ★★☆ *2/3* | Extra disk space, could slow down odd configurations
Intrusiveness | ★★☆ *2/3* | Trivial SQL schema change, easy to rebase

## Rationale
Connecting to the core with a big SQLite storage (>500MB) can become extremely slow or even time out.  Adding an index over the tuples `(bufferid, messageid)` speeds up the connection significantly, because at connection time a lot of queries over these two values are processed.

*This was modified by @digitalcircuit from [pull request #244](https://github.com/quassel/quassel/pull/244 ) to add a new schema upgrade.  Thanks to @ansiwen for all of the original work!*

## Implementation
* When setting up new database or upgrading an existing one, add the index
  * Contained in `setup_110_backlog_idx3.sql` and `upgrade_000_create_buffer_idx.sql`

```sql
CREATE INDEX backlog_buffer_msg_idx ON backlog (bufferid, messageid)
```

## Testing
---

# Overview - 2017-9-22
## Summary
* SQLite setup success
* Skipped Postgres, client/core mismatches
* **Performance untested**, I don't have the same setup to verify changes

## Steps for a successful test
1.  Initialize or upgrade Quassel core (*completing first run wizard if needed*)
2.  Verify networks intact
3.  Connect to a network, verify message sends
4.  Restart the core
5.  Verify networks intact

## Notes
* Anything regarding Postgres was skipped as this only modifies SQLite
* Any core/client version mismatches were skipped as this only affects the database engine
* I did not try to verify performance gains as I do not have an active SQLite core

# Test results - ✅ pass
## Linux - ✅ pass
### Fresh configuration - ✅ pass
*Quassel core from this PR set up without any initial data*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite, new core, new client | ✅ *pass* |
SQLite, new core, old client | ❓ *skipped* |
SQLite, old core, new client | ❓ *skipped* |
SQLite, new monolithic | ✅ *pass* |
Postgres, new core, new client | ❓ *skipped* |
Postgres, new core, old client | ❓ *skipped* |
Postgres, old core, new client | ❓ *skipped* |

### Migration - ❓ skipped
*Quassel core from this PR set up without any initial data, then migrated*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite → Postgres, new core, new client | ❓ *skipped* |

### Upgrading existing - ✅ pass
*Quassel core 0.12.2 set up (0.13-git-master for monolithic), then upgraded to this PR*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite, old → new core | ✅ *pass* |
SQLite, old monolithic → new monolithic | ✅ *pass* |
Postgres, old → new core | ❓ *skipped* |

## Windows - ✅ pass
### Fresh configuration - ✅ pass
*Quassel core from this PR set up without any initial data*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite, new core, new client | ✅ *pass* |
SQLite, new core, old client | ❓ *skipped* |
SQLite, old core, new client | ❓ *skipped* |
SQLite, new monolithic | ✅ *pass* |

### Migration - ❓ N/A
*Without Postgres on Windows, migration could not be tested*

### Upgrading existing - ✅ pass
*Quassel core 0.12.4 set up, then upgraded to this PR*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite, old → new core | ✅ *pass* |
SQLite, old monolithic → new monolithic | ✅ *pass* |

## Failed cases
None found!