### PR TITLE
client: Fix Chat Monitor missing sender brackets

### DIFF
--- a/src/qtui/chatmonitorview.cpp
+++ b/src/qtui/chatmonitorview.cpp
@@ -43,6 +43,9 @@ ChatMonitorView::ChatMonitorView(ChatMonitorFilter *filter, QWidget *parent)
     _filter(filter)
 {
     scene()->setSenderCutoffMode(ChatScene::CutoffLeft);
+    // The normal message prefixes get replaced by the network and buffer name.  Re-add brackets for
+    // all message types.
+    scene()->setAlwaysBracketSender(true);
     connect(Client::instance(), SIGNAL(coreConnectionStateChanged(bool)), this, SLOT(coreConnectionStateChanged(bool)));
 }
 

--- a/src/qtui/chatscene.cpp
+++ b/src/qtui/chatscene.cpp
@@ -75,6 +75,7 @@ ChatScene::ChatScene(QAbstractItemModel *model, const QString &idString, qreal w
     _markerLineValid(false),
     _markerLineJumpPending(false),
     _cutoffMode(CutoffRight),
+    _alwaysBracketSender(false),
     _selectingItem(0),
     _selectionStart(-1),
     _isSelecting(false),
@@ -1050,9 +1051,14 @@ QString ChatScene::selection() const
             }
             if (_selectionMinCol <= ChatLineModel::SenderColumn) {
                 ChatItem *item = _lines[l]->item(ChatLineModel::SenderColumn);
-                if (!_showSenderBrackets && item->chatLine()->msgType() == Message::Plain) {
-                    // Copying to plain-text.  Only re-add the sender brackets if they're normally
-                    // hidden.
+                if (!_showSenderBrackets && (_alwaysBracketSender
+                                             || item->chatLine()->msgType() == Message::Plain)) {
+                    // Copying to plain-text.  Re-add the sender brackets if they're normally hidden
+                    // for...
+                    // * Plain messages
+                    // * All messages in the Chat Monitor
+                    //
+                    // The Chat Monitor sets alwaysBracketSender() to true.
                     result += QString("<%1> ").arg(item->data(MessageModel::DisplayRole)
                                                    .toString());
                 } else {

--- a/src/qtui/chatscene.h
+++ b/src/qtui/chatscene.h
@@ -116,6 +116,23 @@ public:
     inline CutoffMode senderCutoffMode() const { return _cutoffMode; }
     inline void setSenderCutoffMode(CutoffMode mode) { _cutoffMode = mode; }
 
+    /**
+     * Gets whether to re-add hidden brackets around sender for all message types
+     *
+     * Used within the Chat Monitor as the normal message prefixes are overridden.
+     *
+     * @return Whether to re-add hidden brackets around sender for all message types
+     */
+    inline bool alwaysBracketSender() const { return _alwaysBracketSender; }
+    /**
+     * Sets whether to re-add hidden brackets around sender for all message types
+     *
+     * @see ChatScene::alwaysBracketSender()
+     *
+     * @param brackets Sets whether to re-add hidden brackets around sender for all message types
+     */
+    inline void setAlwaysBracketSender(bool alwaysBracket) { _alwaysBracketSender = alwaysBracket; }
+
     QString selection() const;
     bool hasSelection() const;
     bool hasGlobalSelection() const;
@@ -234,6 +251,8 @@ private:
     qreal _firstColHandlePos, _secondColHandlePos;
     int _defaultFirstColHandlePos, _defaultSecondColHandlePos;
     CutoffMode _cutoffMode;
+    /// Whether to re-add hidden brackets around sender for all message types
+    bool _alwaysBracketSender;
 
     ChatItem *_selectingItem;
     int _selectionStartCol, _selectionMinCol;


### PR DESCRIPTION
## In short
* When hidden, re-add sender brackets to all messages for Chat Monitor
  * Chat Monitor overrides the normal sender prefixes, thus needing the sender brackets
  * Does not affect GUI, only the text when copy-pasting

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing corner case for Chat Monitor copy-paste
Risk | ★☆☆ *1/3* | Might add or remove brackets at the wrong times
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other PRs

## Examples
### Sender brackets shown
**Copy-pasted**
```
Channel:      -*- digitalcircuit does things
Chat Monitor: <Bitlbee:#channel> digitalcircuit does things
```

### Before
**Copy-pasted with sender brackets hidden (wrong)**
```
Channel:      -*- digitalcircuit does things
Chat Monitor: Bitlbee:#channel digitalcircuit does things
```

### After
**Copy-pasted with sender brackets hidden (correct)**
```
Channel:      -*- digitalcircuit does things
Chat Monitor: <Bitlbee:#channel> digitalcircuit does things
```