### PR TITLE
Implement /ignore functionality

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -152,6 +152,10 @@ public:
     static void changePassword(const QString &oldPassword, const QString &newPassword);
     static void kickClient(int peerId);
 
+    void displayIgnoreList(QString ignoreRule) {
+        emit showIgnoreList(ignoreRule);
+    }
+
 #if QT_VERSION < 0x050000
     static void logMessage(QtMsgType type, const char *msg);
 #else

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -163,6 +163,7 @@ signals:
     void requestNetworkStates();
 
     void showConfigWizard(const QVariantMap &coredata);
+    void showIgnoreList(QString ignoreRule);
 
     void connected();
     void disconnected();

--- a/src/client/clientuserinputhandler.cpp
+++ b/src/client/clientuserinputhandler.cpp
@@ -121,7 +121,7 @@ void ClientUserInputHandler::handleQuery(const BufferInfo &bufferInfo, const QSt
 void ClientUserInputHandler::handleIgnore(const BufferInfo &bufferInfo, const QString &text)
 {
     if (text.isEmpty()) {
-        emit Client::instance()->showIgnoreList("");
+        emit Client::instance()->displayIgnoreList("");
         return;
     }
     // If rule contains no ! or @, we assume it is just a nickname, and turn it into an ignore rule for that nick

--- a/src/client/clientuserinputhandler.cpp
+++ b/src/client/clientuserinputhandler.cpp
@@ -20,18 +20,20 @@
 
 #include "clientuserinputhandler.h"
 
+#include "bufferinfo.h"
 #include "buffermodel.h"
 #include "client.h"
 #include "clientaliasmanager.h"
-#include "clientsettings.h"
-#include "execwrapper.h"
-#include "ircuser.h"
-#include "network.h"
-#include "types.h"
-#include "bufferinfo.h"
 #include "clientbufferviewconfig.h"
 #include "clientbufferviewmanager.h"
+#include "clientignorelistmanager.h"
+#include "clientsettings.h"
+#include "execwrapper.h"
+#include "ignorelistmanager.h"
+#include "ircuser.h"
 #include "messagemodel.h"
+#include "network.h"
+#include "types.h"
 
 #include <QDateTime>
 
@@ -113,6 +115,29 @@ void ClientUserInputHandler::handleQuery(const BufferInfo &bufferInfo, const QSt
     switchBuffer(bufferInfo.networkId(), text.section(' ', 0, 0));
     // send to core
     defaultHandler("QUERY", bufferInfo, text);
+}
+
+
+void ClientUserInputHandler::handleIgnore(const BufferInfo &bufferInfo, const QString &text)
+{
+    if (text.isEmpty()) {
+        emit Client::instance()->showIgnoreList("");
+        return;
+    }
+    // If rule contains no ! or @, we assume it is just a nickname, and turn it into an ignore rule for that nick
+    QString rule = (text.contains('!') || text.contains('@')) ? text : text + "!*@*";
+
+    Client::ignoreListManager()->requestAddIgnoreListItem(
+            IgnoreListManager::IgnoreType::SenderIgnore,
+            rule,
+            false,
+            // Use a dynamic ignore rule, for reversibility
+            IgnoreListManager::StrictnessType::SoftStrictness,
+            // Use current network as scope
+            IgnoreListManager::ScopeType::NetworkScope,
+            Client::network(bufferInfo.networkId())->networkName(),
+            true
+    );
 }
 
 

--- a/src/client/clientuserinputhandler.h
+++ b/src/client/clientuserinputhandler.h
@@ -45,6 +45,7 @@ private slots:
     void handleExec(const BufferInfo &bufferInfo, const QString &execString);
     void handleJoin(const BufferInfo &bufferInfo, const QString &text);
     void handleQuery(const BufferInfo &bufferInfo, const QString &text);
+    void handleIgnore(const BufferInfo &bufferInfo, const QString &text);
     void defaultHandler(const QString &cmd, const BufferInfo &bufferInfo, const QString &text);
 
 private:

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -204,6 +204,7 @@ void MainWin::init()
         SLOT(messagesInserted(const QModelIndex &, int, int)));
     connect(GraphicalUi::contextMenuActionProvider(), SIGNAL(showChannelList(NetworkId)), SLOT(showChannelList(NetworkId)));
     connect(GraphicalUi::contextMenuActionProvider(), SIGNAL(showIgnoreList(QString)), SLOT(showIgnoreList(QString)));
+    connect(Client::instance(), SIGNAL(showIgnoreList(QString)), SLOT(showIgnoreList(QString)));
 
     connect(Client::coreConnection(), SIGNAL(startCoreSetup(QVariantList, QVariantList)), SLOT(showCoreConfigWizard(QVariantList, QVariantList)));
     connect(Client::coreConnection(), SIGNAL(connectionErrorPopup(QString)), SLOT(handleCoreConnectionError(QString)));


### PR DESCRIPTION
## Overview

- If /ignore <nickname> is used, a new rule for nickname!*@* is added,
  with dynamic strictness, limited to the current network.
- If /ignore <rule> (where rule contains ! or @) is used, that rule is
  added, with dynamic strictness, limited to the current network.
- If /ignore with no parameters is used, the ignore list is shown

## Impact

This change only impacts the client, by adding a command. Possible side effects include shadowing a server-side IGNORE command, but as many clients implement that already, it’s unlikely to be used by any server (and alternatively, /RAW IGNORE and /QUOTE IGNORE are still available).

This brings Quassel closer to most other IRC clients, and resolves the request from [#628](https://bugs.quassel-irc.org/issues/628), where a /ignore command was promised.