### PR TITLE
Make /list open the Channel List dialog

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -167,6 +167,7 @@ signals:
     void requestNetworkStates();
 
     void showConfigWizard(const QVariantMap &coredata);
+    void showChannelList(NetworkId networkId);
     void showIgnoreList(QString ignoreRule);
 
     void connected();

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -163,6 +163,10 @@ public:
 #endif
     static inline const QString &debugLog() { return instance()->_debugLogBuffer; }
 
+    void displayChannelList(NetworkId networkId) {
+        emit showChannelList(networkId);
+    }
+
 signals:
     void requestNetworkStates();
 

--- a/src/client/clientuserinputhandler.cpp
+++ b/src/client/clientuserinputhandler.cpp
@@ -140,6 +140,11 @@ void ClientUserInputHandler::handleIgnore(const BufferInfo &bufferInfo, const QS
     );
 }
 
+void ClientUserInputHandler::handleList(const BufferInfo &bufferInfo, const QString &text)
+{
+    emit Client::instance()->showChannelList(bufferInfo.networkId());
+}
+
 
 void ClientUserInputHandler::switchBuffer(const NetworkId &networkId, const QString &bufferName)
 {

--- a/src/client/clientuserinputhandler.cpp
+++ b/src/client/clientuserinputhandler.cpp
@@ -142,7 +142,7 @@ void ClientUserInputHandler::handleIgnore(const BufferInfo &bufferInfo, const QS
 
 void ClientUserInputHandler::handleList(const BufferInfo &bufferInfo, const QString &text)
 {
-    emit Client::instance()->showChannelList(bufferInfo.networkId());
+    Client::instance()->displayChannelList(bufferInfo.networkId());
 }
 
 

--- a/src/client/clientuserinputhandler.h
+++ b/src/client/clientuserinputhandler.h
@@ -46,6 +46,7 @@ private slots:
     void handleJoin(const BufferInfo &bufferInfo, const QString &text);
     void handleQuery(const BufferInfo &bufferInfo, const QString &text);
     void handleIgnore(const BufferInfo &bufferInfo, const QString &text);
+    void handleList(const BufferInfo &bufferInfo, const QString &text);
     void defaultHandler(const QString &cmd, const BufferInfo &bufferInfo, const QString &text);
 
 private:

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -203,6 +203,7 @@ void MainWin::init()
     connect(Client::messageModel(), SIGNAL(rowsInserted(const QModelIndex &, int, int)),
         SLOT(messagesInserted(const QModelIndex &, int, int)));
     connect(GraphicalUi::contextMenuActionProvider(), SIGNAL(showChannelList(NetworkId)), SLOT(showChannelList(NetworkId)));
+    connect(Client::instance(), SIGNAL(showChannelList(NetworkId)), SLOT(showChannelList(NetworkId)));
     connect(GraphicalUi::contextMenuActionProvider(), SIGNAL(showIgnoreList(QString)), SLOT(showIgnoreList(QString)));
     connect(Client::instance(), SIGNAL(showIgnoreList(QString)), SLOT(showIgnoreList(QString)));
 


### PR DESCRIPTION
## In Short

When a user runs /list, the channel list dialog is opened for the current network.

## Rationale

This was previously requested in several issues

## Impact

This shadows the actual /list command, but that command can still be accessed with /RAW LIST or /QUOTE LIST.