### PR TITLE
Fix the Persistent Modes reset

### DIFF
--- a/src/core/coreuserinputhandler.cpp
+++ b/src/core/coreuserinputhandler.cpp
@@ -477,15 +477,16 @@ void CoreUserInputHandler::handleMode(const BufferInfo &bufferInfo, const QStrin
     QStringList params = msg.split(' ', QString::SkipEmptyParts);
     // if the first argument is neither a channel nor us (user modes are only to oneself) the current buffer is assumed to be the target
     if (!params.isEmpty()) {
+        if (params[0] == "-reset" && params.count() == 1) {
+            network()->resetPersistentModes();
+            emit displayMsg(Message::Info, BufferInfo::StatusBuffer, "",
+                            tr("Your persistent modes have been reset."));
+            return;
+        }
         if (!network()->isChannelName(params[0]) && !network()->isMyNick(params[0]))
             params.prepend(bufferInfo.bufferName());
         if (network()->isMyNick(params[0]) && params.count() == 2)
             network()->updateIssuedModes(params[1]);
-        if (params[0] == "-reset" && params.count() == 1) {
-            // FIXME: give feedback to the user (I don't want to add new strings right now)
-            network()->resetPersistentModes();
-            return;
-        }
     }
 
     // TODO handle correct encoding for buffer modes (channelEncode())


### PR DESCRIPTION
It is intended that `/mode -reset` will reset the Persistent Modes but this always fails to function due to having a buffer name always prepended to the string. Fix this by moving the '-reset' check to be first.   Also add a reply to the client, not sure if there's more I need to do for "adding a string" in terms of translations and so forth.

#### Use-Case:
- Sometimes you end up with persistent modes that you can't seem to get rid of (likely a bug to dig more into, but this at least gives you existing functionality to use)
- Simply to clear your persistent modes for other various reasons

#### Impact:
- Minor: using existing functionality, new success message shown to client when used

#### Testing:
- Tested with latest master core and client, sending `/mode -reset` works as expected with the new success message shown. Other `/mode` functionality remained proper.