### PR TITLE
Improve channel navigation shortcut in some cases

### DIFF
--- a/src/uisupport/bufferview.cpp
+++ b/src/uisupport/bufferview.cpp
@@ -510,6 +510,8 @@ void BufferView::changeBuffer(Direction direction)
     QModelIndex currentIndex = selectionModel()->currentIndex();
     QModelIndex resultingIndex;
 
+    QModelIndex lastNetIndex = model()->index(model()->rowCount() - 1, 0, QModelIndex());
+
     if (currentIndex.parent().isValid()) {
         //If we are a child node just switch among siblings unless it's the first/last child
         resultingIndex = currentIndex.sibling(currentIndex.row() + direction, 0);
@@ -526,6 +528,8 @@ void BufferView::changeBuffer(Direction direction)
         //If we have a toplevel node, try and get an adjacent child
         if (direction == Backward) {
             QModelIndex newParent = currentIndex.sibling(currentIndex.row() - 1, 0);
+            if (currentIndex.row() == 0)
+                newParent = lastNetIndex;
             if (model()->hasChildren(newParent))
                 resultingIndex = newParent.child(model()->rowCount(newParent) - 1, 0);
             else
@@ -539,8 +543,12 @@ void BufferView::changeBuffer(Direction direction)
         }
     }
 
-    if (!resultingIndex.isValid())
-        return;
+    if (!resultingIndex.isValid()) {
+        if (direction == Forward)
+            resultingIndex = model()->index(0, 0, QModelIndex());
+        else
+            resultingIndex = lastNetIndex.child(model()->rowCount(lastNetIndex) - 1, 0);
+    }
 
     selectionModel()->setCurrentIndex(resultingIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
     selectionModel()->select(resultingIndex, QItemSelectionModel::ClearAndSelect);


### PR DESCRIPTION
**Navigation in the Channel List via Alt+Up/Down did not work if:**
  * Client freshly started
  * Selected Chat List does not contain currently open Buffer

***Changed:***
Select first/last if nothing selected yet

**Wrap around Navigation was only partially possible previously.**
It was only possible to go from top Entry to the last Network's Status Buffer, but not from the last Buffer to the top.
This was probably a side effect and not planned.
Normally if we try to go back from a Status Buffer (Network) we want to get to the last Child of the previous Network.
But getting the childs of network wich comes before the first gives us the list of networks … for some unknown reason

***Changed:***
Going up from top most Entry now goes to last buffer. Going down from last Buffer now goes to top Status Buffer.
