### PR TITLE
Re-enable Trayicon blinking with Snore

### DIFF
--- a/src/qtui/snorenotificationbackend.cpp
+++ b/src/qtui/snorenotificationbackend.cpp
@@ -110,17 +110,9 @@ SettingsPage *SnoreNotificationBackend::createConfigWidget()const
 void SnoreNotificationBackend::setTraybackend(const QVariant &b)
 {
 #ifndef HAVE_KDE
-    if (!b.toBool()) {
-        if (m_systrayBackend == nullptr) {
-            m_systrayBackend = new SystrayNotificationBackend(this);
-            QtUi::registerNotificationBackend(m_systrayBackend);
-        }
-    } else {
-        if (m_systrayBackend != nullptr) {
-            QtUi::unregisterNotificationBackend(m_systrayBackend);
-            m_systrayBackend->deleteLater();
-            m_systrayBackend = nullptr;
-        }
+    if (m_systrayBackend == nullptr) {
+        m_systrayBackend = new SystrayNotificationBackend(this);
+        QtUi::registerNotificationBackend(m_systrayBackend);
     }
 #endif
     if (b.toBool()) {


### PR DESCRIPTION
With the change from PR #139 the update to the new Snore Notification Backend modified the behaviour of loading the SystrayNotificationBackend if Snore is enabled.

See: https://github.com/quassel/quassel/commit/79ef34a9495187b296dd554cf57983019001c38b#diff-cfff7c7c664d451740ea7bda9372fc10L83

Although it makes sense to not show a message bubble if snore is enabled, the tray icon animation is handled by SystrayNotificationBackend too.

This might have been overlooked because the tray animation is not en/disabled in the notification settings:
[![https://gyazo.com/68b1aa6d8dd93c5e42f67afb3eb6e7e6](https://i.gyazo.com/68b1aa6d8dd93c5e42f67afb3eb6e7e6.png)](https://gyazo.com/68b1aa6d8dd93c5e42f67afb3eb6e7e6)

With this PR the animation works again but the message bubble has to be disabled manually again:
[![https://gyazo.com/17bf819e32f3a7df8a5c9309210097f8](https://i.gyazo.com/17bf819e32f3a7df8a5c9309210097f8.png)](https://gyazo.com/17bf819e32f3a7df8a5c9309210097f8)
This is how it was before …

It might make sense to auto toggle off the bubble when snore gets enabled, but i didn't find an easy way to do that. (And I'm not completely sure if that's something needed/wanted)

~Now https://bugs.quassel-irc.org/issues/1383 should be fixed … a second time …~
But … Issue 13830 may still not be fixed completely …