### PR TITLE
Package bearer plugin on OSX

### DIFF
--- a/scripts/build/macosx_makePackage.sh
+++ b/scripts/build/macosx_makePackage.sh
@@ -64,7 +64,7 @@ mkdir $PACKAGETMPDIR
 case $BUILDTYPE in
 "Client")
 	cp -r ${WORKINGDIR}Quassel\ Client.app ${PACKAGETMPDIR}/
-	${SCRIPTDIR}/macosx_DeployApp.py --plugins=qcocoa${ADDITIONAL_PLUGINS} "${PACKAGETMPDIR}/Quassel Client.app"
+	${SCRIPTDIR}/macosx_DeployApp.py --plugins=qcocoa,qgenericbearer,qcorewlanbearer${ADDITIONAL_PLUGINS} "${PACKAGETMPDIR}/Quassel Client.app"
 	;;
 "Core")
 	cp ${WORKINGDIR}quasselcore ${PACKAGETMPDIR}/
@@ -72,7 +72,7 @@ case $BUILDTYPE in
 	;;
 "Mono")
 	cp -r ${WORKINGDIR}Quassel.app ${PACKAGETMPDIR}/
-	${SCRIPTDIR}/macosx_DeployApp.py --plugins=qsqlite,qsqlpsql,qcocoa${ADDITIONAL_PLUGINS} "${PACKAGETMPDIR}/Quassel.app"
+	${SCRIPTDIR}/macosx_DeployApp.py --plugins=qsqlite,qsqlpsql,qcocoa,qgenericbearer,qcorewlanbearer${ADDITIONAL_PLUGINS} "${PACKAGETMPDIR}/Quassel.app"
 	;;
 *)
 	echo >&2 "Valid parameters are \"Client\", \"Core\", or \"Mono\"."


### PR DESCRIPTION
Related to #319 
Adds 2 dylib's … about 160KB …
Fixes Automatic Network Status Detection on OSX

For packaging to work properly #304 needs to be merged too…

Builds to test:
https://github.com/romibi/quassel/releases/tag/build-fix-autoconnect-osx-tag

Fixes Bug #1442
https://bugs.quassel-irc.org/issues/1442