### PR TITLE
(Re-)enable Trayicon blinking with Snore (still not working with KDE)

### DIFF
--- a/src/qtui/CMakeLists.txt
+++ b/src/qtui/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SOURCES
     settingspagedlg.cpp
     simplenetworkeditor.cpp
     systemtray.cpp
+    systrayanimationnotificationbackend.cpp
     systraynotificationbackend.cpp
     taskbarnotificationbackend.cpp
     titlesetter.cpp

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -114,6 +114,7 @@
 #else /* HAVE_KDE */
 #  include "knotificationbackend.h"
 #endif /* HAVE_KDE */
+#include "systrayanimationnotificationbackend.h"
 
 
 #ifdef HAVE_LIBSNORE
@@ -253,6 +254,9 @@ void MainWin::init()
 #endif /* HAVE_KDE */
 
 
+#ifndef QT_NO_SYSTEMTRAYICON
+    QtUi::registerNotificationBackend(new SystrayAnimationNotificationBackend(this));
+#endif
 #ifdef HAVE_LIBSNORE
     QtUi::registerNotificationBackend(new SnoreNotificationBackend(this));
 #elif !defined(QT_NO_SYSTEMTRAYICON) && !defined(HAVE_KDE)

--- a/src/qtui/settingspages/appearancesettingspage.ui
+++ b/src/qtui/settingspages/appearancesettingspage.ui
@@ -210,38 +210,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <spacer name="horizontalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="1" column="1">
-      <widget class="QCheckBox" name="animateSystrayIcon">
-       <property name="styleSheet">
-        <string notr="true"/>
-       </property>
-       <property name="text">
-        <string>Enable animations</string>
-       </property>
-       <property name="settingsKey" stdset="0">
-        <string notr="true">/Notification/Systray/Animate</string>
-       </property>
-       <property name="defaultValue" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item>

--- a/src/qtui/systrayanimationnotificationbackend.cpp
+++ b/src/qtui/systrayanimationnotificationbackend.cpp
@@ -18,59 +18,52 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#pragma once
+#include <QApplication>
+#include <QCheckBox>
+#include <QGroupBox>
+#include <QIcon>
+#include <QHBoxLayout>
 
-#include "abstractnotificationbackend.h"
-#include "settingspage.h"
+#include "systrayanimationnotificationbackend.h"
+
+#include "client.h"
+#include "clientsettings.h"
+#include "mainwin.h"
+#include "networkmodel.h"
+#include "qtui.h"
 #include "systemtray.h"
 
-class QCheckBox;
-
-class SystrayNotificationBackend : public AbstractNotificationBackend
+SystrayAnimationNotificationBackend::SystrayAnimationNotificationBackend(QObject *parent)
+    : AbstractNotificationBackend(parent)
 {
-    Q_OBJECT
-
-public:
-    SystrayNotificationBackend(QObject *parent = 0);
-
-    void notify(const Notification &);
-    void close(uint notificationId);
-    virtual SettingsPage *createConfigWidget() const;
-
-protected:
-    virtual bool eventFilter(QObject *obj, QEvent *event);
-
-private slots:
-    void notificationActivated(uint notificationId);
-    void notificationActivated(SystemTray::ActivationReason);
-
-    void showBubbleChanged(const QVariant &);
-    void updateToolTip();
-
-private:
-    class ConfigWidget;
-
-    bool _showBubble;
-    QList<Notification> _notifications;
-    bool _blockActivation;
-};
+    NotificationSettings notificationSettings;
+    notificationSettings.initAndNotify("Systray/Animate", this, SLOT(animateChanged(QVariant)), true);
+}
 
 
-class SystrayNotificationBackend::ConfigWidget : public SettingsPage
+void SystrayAnimationNotificationBackend::notify(const Notification &n)
 {
-    Q_OBJECT
+    if (n.type != Highlight && n.type != PrivMsg)
+        return;
 
-public:
-    ConfigWidget(QWidget *parent = 0);
-    void save();
-    void load();
-    bool hasDefaults() const;
-    void defaults();
+    if (_animate)
+        QtUi::mainWindow()->systemTray()->setAlert(true);
+}
 
-private slots:
-    void widgetChanged();
 
-private:
-    QCheckBox *_showBubbleBox;
-    bool _showBubble;
-};
+void SystrayAnimationNotificationBackend::close(uint notificationId)
+{
+    QtUi::mainWindow()->systemTray()->setAlert(false);
+}
+
+
+void SystrayAnimationNotificationBackend::animateChanged(const QVariant &v)
+{
+    _animate = v.toBool();
+}
+
+
+SettingsPage *SystrayAnimationNotificationBackend::createConfigWidget() const
+{
+    return nullptr;
+}

--- a/src/qtui/systrayanimationnotificationbackend.cpp
+++ b/src/qtui/systrayanimationnotificationbackend.cpp
@@ -65,5 +65,55 @@ void SystrayAnimationNotificationBackend::animateChanged(const QVariant &v)
 
 SettingsPage *SystrayAnimationNotificationBackend::createConfigWidget() const
 {
-    return nullptr;
+    return new ConfigWidget();
+}
+
+
+/***************************************************************************/
+
+SystrayAnimationNotificationBackend::ConfigWidget::ConfigWidget(QWidget *parent) : SettingsPage("Internal", "SystrayNotification", parent)
+{
+    _animateBox = new QCheckBox(tr("Animate system tray icon"));
+    _animateBox->setIcon(QIcon::fromTheme("dialog-information"));
+    connect(_animateBox, SIGNAL(toggled(bool)), this, SLOT(widgetChanged()));
+    QHBoxLayout *layout = new QHBoxLayout(this);
+    layout->addWidget(_animateBox);
+}
+
+
+void SystrayAnimationNotificationBackend::ConfigWidget::widgetChanged()
+{
+    bool changed = (_animate != _animateBox->isChecked());
+    if (changed != hasChanged())
+        setChangedState(changed);
+}
+
+
+bool SystrayAnimationNotificationBackend::ConfigWidget::hasDefaults() const
+{
+    return true;
+}
+
+
+void SystrayAnimationNotificationBackend::ConfigWidget::defaults()
+{
+    _animateBox->setChecked(false);
+    widgetChanged();
+}
+
+
+void SystrayAnimationNotificationBackend::ConfigWidget::load()
+{
+    NotificationSettings s;
+    _animate = s.value("Systray/Animate", true).toBool();
+    _animateBox->setChecked(_animate);
+    setChangedState(false);
+}
+
+
+void SystrayAnimationNotificationBackend::ConfigWidget::save()
+{
+    NotificationSettings s;
+    s.setValue("Systray/Animate", _animateBox->isChecked());
+    load();
 }

--- a/src/qtui/systrayanimationnotificationbackend.h
+++ b/src/qtui/systrayanimationnotificationbackend.h
@@ -41,5 +41,26 @@ private slots:
     void animateChanged(const QVariant &);
 
 private:
+    class ConfigWidget;
+    bool _animate;
+};
+
+
+class SystrayAnimationNotificationBackend::ConfigWidget : public SettingsPage
+{
+    Q_OBJECT
+
+public:
+    ConfigWidget(QWidget *parent = 0);
+    void save();
+    void load();
+    bool hasDefaults() const;
+    void defaults();
+
+private slots:
+    void widgetChanged();
+
+private:
+    QCheckBox *_animateBox;
     bool _animate;
 };

--- a/src/qtui/systrayanimationnotificationbackend.h
+++ b/src/qtui/systrayanimationnotificationbackend.h
@@ -26,51 +26,20 @@
 
 class QCheckBox;
 
-class SystrayNotificationBackend : public AbstractNotificationBackend
+class SystrayAnimationNotificationBackend : public AbstractNotificationBackend
 {
     Q_OBJECT
 
 public:
-    SystrayNotificationBackend(QObject *parent = 0);
+    SystrayAnimationNotificationBackend(QObject *parent = 0);
 
     void notify(const Notification &);
     void close(uint notificationId);
     virtual SettingsPage *createConfigWidget() const;
 
-protected:
-    virtual bool eventFilter(QObject *obj, QEvent *event);
-
 private slots:
-    void notificationActivated(uint notificationId);
-    void notificationActivated(SystemTray::ActivationReason);
-
-    void showBubbleChanged(const QVariant &);
-    void updateToolTip();
+    void animateChanged(const QVariant &);
 
 private:
-    class ConfigWidget;
-
-    bool _showBubble;
-    QList<Notification> _notifications;
-    bool _blockActivation;
-};
-
-
-class SystrayNotificationBackend::ConfigWidget : public SettingsPage
-{
-    Q_OBJECT
-
-public:
-    ConfigWidget(QWidget *parent = 0);
-    void save();
-    void load();
-    bool hasDefaults() const;
-    void defaults();
-
-private slots:
-    void widgetChanged();
-
-private:
-    QCheckBox *_showBubbleBox;
-    bool _showBubble;
+    bool _animate;
 };

--- a/src/qtui/systraynotificationbackend.cpp
+++ b/src/qtui/systraynotificationbackend.cpp
@@ -39,7 +39,6 @@ SystrayNotificationBackend::SystrayNotificationBackend(QObject *parent)
 {
     NotificationSettings notificationSettings;
     notificationSettings.initAndNotify("Systray/ShowBubble", this, SLOT(showBubbleChanged(QVariant)), true);
-    notificationSettings.initAndNotify("Systray/Animate", this, SLOT(animateChanged(QVariant)), true);
 
     connect(QtUi::mainWindow()->systemTray(), SIGNAL(messageClicked(uint)), SLOT(notificationActivated(uint)));
     connect(QtUi::mainWindow()->systemTray(), SIGNAL(activated(SystemTray::ActivationReason)),
@@ -63,9 +62,6 @@ void SystrayNotificationBackend::notify(const Notification &n)
         QtUi::mainWindow()->systemTray()->showMessage(title, message, SystemTray::Information, 10000, n.notificationId);
     }
 
-    if (_animate)
-        QtUi::mainWindow()->systemTray()->setAlert(true);
-
     updateToolTip();
 }
 
@@ -81,9 +77,6 @@ void SystrayNotificationBackend::close(uint notificationId)
     }
 
     QtUi::mainWindow()->systemTray()->closeMessage(notificationId);
-
-    //if(!_notifications.count()) //FIXME make configurable
-    QtUi::mainWindow()->systemTray()->setAlert(false);
 
     updateToolTip();
 }
@@ -130,12 +123,6 @@ bool SystrayNotificationBackend::eventFilter(QObject *obj, QEvent *event)
 void SystrayNotificationBackend::showBubbleChanged(const QVariant &v)
 {
     _showBubble = v.toBool();
-}
-
-
-void SystrayNotificationBackend::animateChanged(const QVariant &v)
-{
-    _animate = v.toBool();
 }
 
 


### PR DESCRIPTION
First attempt at fixing this: PR #328 

**Problem**
With the change from PR #139 the update to the new Snore Notification Backend modified the behaviour of loading the SystrayNotificationBackend if Snore is enabled.

See: https://github.com/quassel/quassel/commit/79ef34a9495187b296dd554cf57983019001c38b#diff-cfff7c7c664d451740ea7bda9372fc10L83

Although it makes sense to not show a message bubble if snore is enabled, the tray icon animation is handled by SystrayNotificationBackend too.

Additionally, (in my opinion) having KDE should not stop you from allowing the Tray icon to be animated …
~(This might be the issue of https://bugs.quassel-irc.org/issues/1383 but I'm not sure.)~

**Solution**
In order to fix this, the animation trigger from SystrayNotificationBackend now got split away into SystrayAnimationNotificationBackend which gets loaded as long as QT_NO_SYSTEMTRAYICON is not set.

**Additional Changes**
The second commit moves the "Animate system tray icon" settings from the "Interface-" (or appearance)-Settings-Page to the Notifications-Settings-Page …

I think this makes more sense, but I don't mind if the second commit doesn't get merged.

**Screenshot**

[![https://gyazo.com/d8107f589c38bf2865ca7b46dfd801e5](https://i.gyazo.com/d8107f589c38bf2865ca7b46dfd801e5.png)](https://gyazo.com/d8107f589c38bf2865ca7b46dfd801e5)
Above: old, Below: new

**Persistent Issue**
There's still something wrong with the tray icon with KDE. Even with the fixed icon loading in #327:  
It does change to the "message" icon on notification (but not blink) but it doesn't update on connect/disconnect!