### PR TITLE
Correct issue where messages were over-trimmed

### DIFF
--- a/src/core/coreuserinputhandler.cpp
+++ b/src/core/coreuserinputhandler.cpp
@@ -460,8 +460,7 @@ void CoreUserInputHandler::handleMe(const BufferInfo &bufferInfo, const QString 
     QStringList messages = msg.split(QCharLF);
 
     foreach (auto message, messages) {
-        // Handle each separated message independently, ignoring any carriage returns
-        message = message.trimmed();
+        // Handle each separated message independently
         coreNetwork()->coreSession()->ctcpParser()->query(coreNetwork(), bufferInfo.bufferName(),
                                                           "ACTION", message);
         emit displayMsg(Message::Action, bufferInfo.type(), bufferInfo.bufferName(), message,
@@ -532,8 +531,7 @@ void CoreUserInputHandler::handleNotice(const BufferInfo &bufferInfo, const QStr
     QStringList messages = msg.section(' ', 1).split(QCharLF);
 
     foreach (auto message, messages) {
-        // Handle each separated message independently, ignoring any carriage returns
-        message = message.trimmed();
+        // Handle each separated message independently
         params.clear();
         params << serverEncode(bufferName) << channelEncode(bufferInfo.bufferName(), message);
         emit putCmd("NOTICE", params);
@@ -607,8 +605,7 @@ void CoreUserInputHandler::handleQuery(const BufferInfo &bufferInfo, const QStri
     QStringList messages = msg.section(' ', 1).split(QCharLF);
 
     foreach (auto message, messages) {
-        // Handle each separated message independently, ignoring any carriage returns
-        message = message.trimmed();
+        // Handle each separated message independently
         if (message.isEmpty()) {
             emit displayMsg(Message::Server, BufferInfo::QueryBuffer, target,
                             tr("Starting query with %1").arg(target), network()->myNick(),
@@ -656,11 +653,10 @@ void CoreUserInputHandler::handleSay(const BufferInfo &bufferInfo, const QString
 
     // Split apart messages at line feeds.  The IRC protocol uses those to separate commands, so
     // they need to be split into multiple messages.
-    QStringList messages = msg.split(QCharLF);
+    QStringList messages = msg.split(QCharLF, QString::SkipEmptyParts);
 
     foreach (auto message, messages) {
-        // Handle each separated message independently, ignoring any carriage returns
-        message = message.trimmed();
+        // Handle each separated message independently
 #ifdef HAVE_QCA2
         putPrivmsg(bufferInfo.bufferName(), message, encodeFunc,
                    network()->cipher(bufferInfo.bufferName()));


### PR DESCRIPTION
In an attempt to correct a problem with quasseldroid multiline
messages (97a9b1646bb0d6362cef14bac3a577481cc01e49) the core started
trimming leading whitespace from lines.  This broke pasting of things
like formatted code.

This commit causes messages to only have CRs trimmed, as the comment
originally provided suggests it ought to.