### PR TITLE
Persist Blowfish keys in the database

### DIFF
--- a/src/core/SQL/PostgreSQL/select_buffer_ciphers.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_ciphers.sql
@@ -1,0 +1,3 @@
+SELECT buffername, cipher
+FROM buffer
+WHERE userid = :userid AND networkid = :networkid AND buffertype IN (2, 4)

--- a/src/core/SQL/PostgreSQL/setup_050_buffer.sql
+++ b/src/core/SQL/PostgreSQL/setup_050_buffer.sql
@@ -12,6 +12,7 @@ create TABLE buffer (
 	bufferactivity integer NOT NULL DEFAULT 0,
 	key varchar(128),
 	joined boolean NOT NULL DEFAULT FALSE, -- BOOL
+	cipher TEXT,
 	UNIQUE(userid, networkid, buffercname),
 	CHECK (buffer.lastseenmsgid <= buffer.lastmsgid)
 )

--- a/src/core/SQL/PostgreSQL/update_buffer_cipher.sql
+++ b/src/core/SQL/PostgreSQL/update_buffer_cipher.sql
@@ -1,0 +1,3 @@
+UPDATE buffer
+SET cipher = :cipher
+WHERE userid = :userid AND networkid = :networkid AND buffercname = :buffercname

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_000_alter_buffer_add_cipher.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_000_alter_buffer_add_cipher.sql
@@ -1,0 +1,2 @@
+ALTER TABLE buffer
+ADD COLUMN cipher TEXT

--- a/src/core/SQL/SQLite/select_buffer_ciphers.sql
+++ b/src/core/SQL/SQLite/select_buffer_ciphers.sql
@@ -1,0 +1,3 @@
+SELECT buffername, cipher
+FROM buffer
+WHERE userid = :userid AND networkid = :networkid AND buffertype IN (2, 4)

--- a/src/core/SQL/SQLite/setup_030_buffer.sql
+++ b/src/core/SQL/SQLite/setup_030_buffer.sql
@@ -12,5 +12,6 @@ CREATE TABLE buffer (
 	bufferactivity INTEGER NOT NULL DEFAULT 0,
 	key TEXT,
 	joined INTEGER NOT NULL DEFAULT 0, -- BOOL
+	cipher TEXT,
 	CHECK (lastseenmsgid <= lastmsgid)
 )

--- a/src/core/SQL/SQLite/update_buffer_cipher.sql
+++ b/src/core/SQL/SQLite/update_buffer_cipher.sql
@@ -1,0 +1,3 @@
+UPDATE buffer
+SET cipher = :cipher
+WHERE userid = :userid AND networkid = :networkid AND buffercname = :buffercname

--- a/src/core/SQL/SQLite/version/27/upgrade_000_alter_buffer_add_cipher.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_000_alter_buffer_add_cipher.sql
@@ -1,0 +1,2 @@
+ALTER TABLE buffer
+ADD COLUMN cipher TEXT

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -236,6 +236,7 @@ public:
         int bufferactivity;
         QString key;
         bool joined;
+        QString cipher;
     };
 
     struct BacklogMO {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -273,6 +273,33 @@ public:
     }
 
 
+    //! Get a hash of buffers with their ciphers for a given network
+    /** The keys are channel names and values are ciphers (possibly empty)
+     *  \note This method is threadsafe
+     *
+     *  \param user       The id of the networks owner
+     *  \param networkId  The Id of the network
+     */
+    static inline QHash<QString, QByteArray> bufferCiphers(UserId user, const NetworkId &networkId)
+    {
+        return instance()->_storage->bufferCiphers(user, networkId);
+    }
+
+
+    //! Update the cipher of a buffer
+    /** \note This method is threadsafe
+     *
+     *  \param user        The Id of the networks owner
+     *  \param networkId   The Id of the network
+     *  \param bufferName The Cname of the buffer
+     *  \param cipher      The cipher for the buffer
+     */
+    static inline void setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher)
+    {
+        return instance()->_storage->setBufferCipher(user, networkId, bufferName, cipher);
+    }
+
+
     //! Update the key of a channel
     /** \note This method is threadsafe
      *

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -63,6 +63,11 @@ CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
         _channelKeys[chan.toLower()] = channels[chan];
     }
 
+    QHash<QString, QByteArray> bufferCiphers = coreSession()->bufferCiphers(networkId());
+    foreach(QString buffer, bufferCiphers.keys()) {
+        storeChannelCipherKey(buffer.toLower(), bufferCiphers[buffer]);
+    }
+
     connect(networkConfig(), SIGNAL(pingTimeoutEnabledSet(bool)), SLOT(enablePingTimeout(bool)));
     connect(networkConfig(), SIGNAL(pingIntervalSet(int)), SLOT(setPingInterval(int)));
     connect(networkConfig(), SIGNAL(autoWhoEnabledSet(bool)), SLOT(setAutoWhoEnabled(bool)));
@@ -442,6 +447,7 @@ void CoreNetwork::setCipherKey(const QString &target, const QByteArray &key)
     CoreIrcChannel *c = qobject_cast<CoreIrcChannel*>(ircChannel(target));
     if (c) {
         c->setEncrypted(c->cipher()->setKey(key));
+        coreSession()->setBufferCipher(networkId(), target, key);
         return;
     }
 
@@ -451,6 +457,7 @@ void CoreNetwork::setCipherKey(const QString &target, const QByteArray &key)
 
     if (u) {
         u->setEncrypted(u->cipher()->setKey(key));
+        coreSession()->setBufferCipher(networkId(), target, key);
         return;
     }
 }

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -288,6 +288,17 @@ QHash<QString, QString> CoreSession::persistentChannels(NetworkId id) const
 }
 
 
+QHash<QString, QByteArray> CoreSession::bufferCiphers(NetworkId id) const
+{
+    return Core::bufferCiphers(user(), id);
+}
+
+void CoreSession::setBufferCipher(NetworkId id, const QString &bufferName, const QByteArray &cipher) const
+{
+    Core::setBufferCipher(user(), id, bufferName, cipher);
+}
+
+
 // FIXME switch to BufferId
 void CoreSession::msgFromClient(BufferInfo bufinfo, QString msg)
 {

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -137,6 +137,9 @@ public slots:
 
     QHash<QString, QString> persistentChannels(NetworkId) const;
 
+    QHash<QString, QByteArray> bufferCiphers(NetworkId id) const;
+    void setBufferCipher(NetworkId id, const QString &bufferName, const QByteArray &cipher) const;
+
     /**
      * Marks us away (or unaway) on all networks
      *

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1440,6 +1440,44 @@ Message::Types PostgreSqlStorage::bufferActivity(BufferId bufferId, MsgId lastSe
     return result;
 }
 
+QHash<QString, QByteArray> PostgreSqlStorage::bufferCiphers(UserId user, const NetworkId &networkId)
+{
+    QHash<QString, QByteArray> bufferCiphers;
+
+    QSqlDatabase db = logDb();
+    if (!beginReadOnlyTransaction(db)) {
+        qWarning() << "PostgreSqlStorage::persistentChannels(): cannot start read only transaction!";
+        qWarning() << " -" << qPrintable(db.lastError().text());
+        return bufferCiphers;
+    }
+
+    QSqlQuery query(db);
+    query.prepare(queryString("select_buffer_ciphers"));
+    query.bindValue(":userid", user.toInt());
+    query.bindValue(":networkid", networkId.toInt());
+    safeExec(query);
+    watchQuery(query);
+
+    while (query.next()) {
+        bufferCiphers[query.value(0).toString()] = QByteArray::fromHex(query.value(1).toString().toUtf8());
+    }
+
+    db.commit();
+    return bufferCiphers;
+}
+
+void PostgreSqlStorage::setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher)
+{
+    QSqlQuery query(logDb());
+    query.prepare(queryString("update_buffer_cipher"));
+    query.bindValue(":userid", user.toInt());
+    query.bindValue(":networkid", networkId.toInt());
+    query.bindValue(":buffercname", bufferName.toLower());
+    query.bindValue(":cipher", QString(cipher.toHex()));
+    safeExec(query);
+    watchQuery(query);
+}
+
 bool PostgreSqlStorage::logMessage(Message &msg)
 {
     QSqlDatabase db = logDb();
@@ -2036,6 +2074,7 @@ bool PostgreSqlMigrationWriter::writeMo(const BufferMO &buffer)
     bindValue(10, buffer.bufferactivity);
     bindValue(11, buffer.key);
     bindValue(12, buffer.joined);
+    bindValue(13, buffer.cipher);
     return exec();
 }
 

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -98,6 +98,8 @@ public slots:
     void setBufferActivity(UserId id, BufferId bufferId, Message::Types type) override;
     QHash<BufferId, Message::Types> bufferActivities(UserId id) override;
     Message::Types bufferActivity(BufferId bufferId, MsgId lastSeenMsgId) override;
+    QHash<QString, QByteArray> bufferCiphers(UserId user, const NetworkId &networkId) override;
+    void setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher) override;
 
     /* Message handling */
     bool logMessage(Message &msg) override;

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -37,6 +37,7 @@
     <file>./SQL/PostgreSQL/select_buffer_bufferactivities.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_bufferactivity.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_by_id.sql</file>
+    <file>./SQL/PostgreSQL/select_buffer_ciphers.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_lastseen_messages.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_markerlinemsgids.sql</file>
     <file>./SQL/PostgreSQL/select_buffers.sql</file>
@@ -78,6 +79,7 @@
     <file>./SQL/PostgreSQL/setup_130_function_lastmsgid.sql</file>
     <file>./SQL/PostgreSQL/update_backlog_bufferid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_bufferactivity.sql</file>
+    <file>./SQL/PostgreSQL/update_buffer_cipher.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_lastseen.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_markerlinemsgid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_name.sql</file>
@@ -109,6 +111,7 @@
     <file>./SQL/PostgreSQL/version/22/upgrade_000_alter_quasseluser_add_authenticator.sql</file>
     <file>./SQL/PostgreSQL/version/23/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/PostgreSQL/version/24/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_000_alter_buffer_add_cipher.sql</file>
     <file>./SQL/SQLite/delete_backlog_by_uid.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_buffer.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_network.sql</file>
@@ -146,6 +149,7 @@
     <file>./SQL/SQLite/select_buffer_bufferactivities.sql</file>
     <file>./SQL/SQLite/select_buffer_bufferactivity.sql</file>
     <file>./SQL/SQLite/select_buffer_by_id.sql</file>
+    <file>./SQL/SQLite/select_buffer_ciphers.sql</file>
     <file>./SQL/SQLite/select_buffer_lastseen_messages.sql</file>
     <file>./SQL/SQLite/select_buffer_markerlinemsgids.sql</file>
     <file>./SQL/SQLite/select_buffers.sql</file>
@@ -189,6 +193,7 @@
     <file>./SQL/SQLite/setup_140_identity_nick.sql</file>
     <file>./SQL/SQLite/update_backlog_bufferid.sql</file>
     <file>./SQL/SQLite/update_buffer_bufferactivity.sql</file>
+    <file>./SQL/SQLite/update_buffer_cipher.sql</file>
     <file>./SQL/SQLite/update_buffer_lastseen.sql</file>
     <file>./SQL/SQLite/update_buffer_markerlinemsgid.sql</file>
     <file>./SQL/SQLite/update_buffer_name.sql</file>
@@ -293,5 +298,6 @@
     <file>./SQL/SQLite/version/24/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/SQLite/version/25/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
     <file>./SQL/SQLite/version/26/upgrade_000_create_buffer_idx.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_000_alter_buffer_add_cipher.sql</file>
 </qresource>
 </RCC>

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1576,6 +1576,50 @@ Message::Types SqliteStorage::bufferActivity(BufferId bufferId, MsgId lastSeenMs
     return result;
 }
 
+QHash<QString, QByteArray> SqliteStorage::bufferCiphers(UserId user, const NetworkId &networkId)
+{
+    QHash<QString, QByteArray> bufferCiphers;
+
+    QSqlDatabase db = logDb();
+    db.transaction();
+    {
+        QSqlQuery query(db);
+        query.prepare(queryString("select_buffer_ciphers"));
+        query.bindValue(":userid", user.toInt());
+        query.bindValue(":networkid", networkId.toInt());
+
+        lockForRead();
+        safeExec(query);
+        watchQuery(query);
+        while (query.next()) {
+            bufferCiphers[query.value(0).toString()] = QByteArray::fromHex(query.value(1).toString().toUtf8());
+        }
+    }
+    unlock();
+    return bufferCiphers;
+}
+
+void SqliteStorage::setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher)
+{
+    QSqlDatabase db = logDb();
+    db.transaction();
+
+    {
+        QSqlQuery query(db);
+        query.prepare(queryString("update_buffer_cipher"));
+        query.bindValue(":userid", user.toInt());
+        query.bindValue(":networkid", networkId.toInt());
+        query.bindValue(":buffercname", bufferName.toLower());
+        query.bindValue(":cipher", QString(cipher.toHex()));
+
+        lockForWrite();
+        safeExec(query);
+        watchQuery(query);
+        db.commit();
+    }
+    unlock();
+}
+
 bool SqliteStorage::logMessage(Message &msg)
 {
     QSqlDatabase db = logDb();
@@ -2032,6 +2076,7 @@ bool SqliteMigrationReader::readMo(BufferMO &buffer)
     buffer.bufferactivity = value(10).toInt();
     buffer.key = value(11).toString();
     buffer.joined = value(12).toInt() == 1 ? true : false;
+    buffer.cipher = value(13).toString();
     return true;
 }
 

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -99,6 +99,8 @@ public slots:
     void setBufferActivity(UserId id, BufferId bufferId, Message::Types type) override;
     QHash<BufferId, Message::Types> bufferActivities(UserId id) override;
     Message::Types bufferActivity(BufferId bufferId, MsgId lastSeenMsgId) override;
+    QHash<QString, QByteArray> bufferCiphers(UserId user, const NetworkId &networkId) override;
+    void setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher) override;
 
     /* Message handling */
     bool logMessage(Message &msg) override;

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -411,6 +411,25 @@ public slots:
      */
     virtual Message::Types bufferActivity(BufferId bufferId, MsgId lastSeenMsgId) = 0;
 
+    //! Get a hash of buffers with their ciphers for a given network
+    /** The keys are channel names and values are ciphers (possibly empty)
+     *  \note This method is threadsafe
+     *
+     *  \param user       The id of the networks owner
+     *  \param networkId  The Id of the network
+     */
+    virtual QHash<QString, QByteArray> bufferCiphers(UserId user, const NetworkId &networkId) = 0;
+
+    //! Update the cipher of a buffer
+    /** \note This method is threadsafe
+     *
+     *  \param user        The Id of the networks owner
+     *  \param networkId   The Id of the network
+     *  \param bufferName The Cname of the buffer
+     *  \param cipher      The cipher for the buffer
+     */
+    virtual void setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher) = 0;
+
     /* Message handling */
 
     //! Store a Message in the storage backend and set its unique Id.


### PR DESCRIPTION
Add a new text field called "cipher" and store the hex-encoded
cipher key there whenever a new key is set or exchanged.  Also,
when each network is initialized, load the ciphers out of the
database and initialize the in-memory hashmap.  Then, the existing
behavior of each CoreIrcNetwork automatically using these keys
upon construction occurs.

Additionally, this makes PM buffer ciphers persistent both across
destruction/construction and across core restarts.

Note that the existing "key" field in the database is confusingly
named.  It does not contain any sort of cryptographic key but
instead holds channel passwords.

Closes #1473