### PR TITLE
Store highlight status per buffer coreside

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -394,6 +394,7 @@ void Client::setSyncedToCore()
     connect(bufferSyncer(), SIGNAL(buffersPermanentlyMerged(BufferId, BufferId)), _messageModel, SLOT(buffersPermanentlyMerged(BufferId, BufferId)));
     connect(bufferSyncer(), SIGNAL(bufferMarkedAsRead(BufferId)), SIGNAL(bufferMarkedAsRead(BufferId)));
     connect(bufferSyncer(), SIGNAL(bufferActivityChanged(BufferId, const Message::Types)), _networkModel, SLOT(bufferActivityChanged(BufferId, const Message::Types)));
+    connect(bufferSyncer(), SIGNAL(highlightCountChanged(BufferId, int)), _networkModel, SLOT(highlightCountChanged(BufferId, int)));
     connect(networkModel(), SIGNAL(requestSetLastSeenMsg(BufferId, MsgId)), bufferSyncer(), SLOT(requestSetLastSeenMsg(BufferId, const MsgId &)));
 
     SignalProxy *p = signalProxy();
@@ -460,8 +461,10 @@ void Client::finishConnectionInitialization()
     disconnect(bufferSyncer(), SIGNAL(initDone()), this, SLOT(finishConnectionInitialization()));
 
     requestInitialBacklog();
-    if (isCoreFeatureEnabled(Quassel::Feature::BufferActivitySync))
+    if (isCoreFeatureEnabled(Quassel::Feature::BufferActivitySync)) {
         bufferSyncer()->markActivitiesChanged();
+        bufferSyncer()->markHighlightCountsChanged();
+    }
 }
 
 

--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -147,8 +147,12 @@ BufferItem *NetworkItem::bufferItem(const BufferInfo &bufferInfo)
     }
 
     BufferSyncer *bufferSyncer = Client::bufferSyncer();
-    if (bufferSyncer)
-        bufferItem->addActivity(bufferSyncer->activity(bufferItem->bufferId()), false);
+    if (bufferSyncer) {
+        bufferItem->addActivity(
+                bufferSyncer->activity(bufferItem->bufferId()),
+                bufferSyncer->highlightCount(bufferItem->bufferId()) > 0
+        );
+    }
 
     return bufferItem;
 }

--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -1757,3 +1757,12 @@ void NetworkModel::bufferActivityChanged(BufferId bufferId, const Message::Types
     auto activityVisibleTypesIntersection = activity & visibleTypes;
     _bufferItem->setActivity(activityVisibleTypesIntersection, false);
 }
+
+void NetworkModel::highlightCountChanged(BufferId bufferId, int count) {
+    auto _bufferItem = findBufferItem(bufferId);
+    if (!_bufferItem) {
+        qDebug() << "NetworkModel::bufferActivityChanged(): buffer is unknown:" << bufferId;
+        return;
+    }
+    _bufferItem->addActivity(Message::Types{}, count > 0);
+}

--- a/src/client/networkmodel.h
+++ b/src/client/networkmodel.h
@@ -386,6 +386,7 @@ public slots:
     void updateBufferActivity(Message &msg);
     void networkRemoved(const NetworkId &networkId);
     void bufferActivityChanged(BufferId, Message::Types);
+    void highlightCountChanged(BufferId, int);
 
 signals:
     void requestSetLastSeenMsg(BufferId buffer, MsgId msg);

--- a/src/common/buffersyncer.cpp
+++ b/src/common/buffersyncer.cpp
@@ -168,6 +168,8 @@ void BufferSyncer::removeBuffer(BufferId buffer)
         _markerLines.remove(buffer);
     if (_bufferActivities.contains(buffer))
         _bufferActivities.remove(buffer);
+    if (_highlightCounts.contains(buffer))
+        _highlightCounts.remove(buffer);
     SYNC(ARG(buffer))
     emit bufferRemoved(buffer);
 }
@@ -181,6 +183,8 @@ void BufferSyncer::mergeBuffersPermanently(BufferId buffer1, BufferId buffer2)
         _markerLines.remove(buffer2);
     if (_bufferActivities.contains(buffer2))
         _bufferActivities.remove(buffer2);
+    if (_highlightCounts.contains(buffer2))
+        _highlightCounts.remove(buffer2);
     SYNC(ARG(buffer1), ARG(buffer2))
     emit buffersPermanentlyMerged(buffer1, buffer2);
 }

--- a/src/common/buffersyncer.cpp
+++ b/src/common/buffersyncer.cpp
@@ -27,11 +27,17 @@ BufferSyncer::BufferSyncer(QObject *parent)
 }
 
 
-BufferSyncer::BufferSyncer(const QHash<BufferId, MsgId> &lastSeenMsg, const QHash<BufferId, MsgId> &markerLines, const QHash<BufferId, Message::Types> &activities, QObject *parent)
-    : SyncableObject(parent),
+BufferSyncer::BufferSyncer(
+        const QHash<BufferId, MsgId> &lastSeenMsg,
+        const QHash<BufferId, MsgId> &markerLines,
+        const QHash<BufferId, Message::Types> &activities,
+        const QHash<BufferId, int> &highlightCounts,
+        QObject *parent
+) : SyncableObject(parent),
     _lastSeenMsg(lastSeenMsg),
     _markerLines(markerLines),
-    _bufferActivities(activities)
+    _bufferActivities(activities),
+    _highlightCounts(highlightCounts)
 {
 }
 
@@ -177,4 +183,27 @@ void BufferSyncer::mergeBuffersPermanently(BufferId buffer1, BufferId buffer2)
         _bufferActivities.remove(buffer2);
     SYNC(ARG(buffer1), ARG(buffer2))
     emit buffersPermanentlyMerged(buffer1, buffer2);
+}
+
+int BufferSyncer::highlightCount(BufferId buffer) const {
+    return _highlightCounts.value(buffer, 0);
+}
+
+QVariantList BufferSyncer::initHighlightCounts() const {
+    QVariantList list;
+    auto iter = _highlightCounts.constBegin();
+    while (iter != _highlightCounts.constEnd()) {
+        list << QVariant::fromValue<BufferId>(iter.key())
+             << QVariant::fromValue<int>((int) iter.value());
+        ++iter;
+    }
+    return list;
+}
+
+void BufferSyncer::initSetHighlightCounts(const QVariantList &list) {
+    _highlightCounts.clear();
+    Q_ASSERT(list.count() % 2 == 0);
+    for (int i = 0; i < list.count(); i += 2) {
+        setHighlightCount(list.at(i).value<BufferId>(), list.at(i+1).value<int>());
+    }
 }

--- a/src/core/SQL/PostgreSQL/migrate_write_buffer.sql
+++ b/src/core/SQL/PostgreSQL/migrate_write_buffer.sql
@@ -1,2 +1,2 @@
-INSERT INTO buffer (bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, key, joined)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO buffer (bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, highlightcount, key, joined)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
@@ -1,0 +1,6 @@
+SELECT COALESCE(t.sum,0)
+FROM
+  (SELECT SUM(1) AS sum FROM backlog
+   WHERE bufferid = :bufferid
+     AND flags & 2 != 0
+     AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
@@ -3,5 +3,5 @@ FROM
   (SELECT SUM(1) AS sum FROM backlog
    WHERE bufferid = :bufferid
      AND flags & 2 != 0
-     AND flags & 1 == 0
+     AND flags & 1 = 0
      AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
@@ -3,4 +3,5 @@ FROM
   (SELECT SUM(1) AS sum FROM backlog
    WHERE bufferid = :bufferid
      AND flags & 2 != 0
+     AND flags & 1 == 0
      AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
@@ -1,6 +1,6 @@
 SELECT COALESCE(t.sum,0)
 FROM
-  (SELECT SUM(1) AS sum FROM backlog
+  (SELECT COUNT(*) AS sum FROM backlog
    WHERE bufferid = :bufferid
      AND flags & 2 != 0
      AND flags & 1 = 0

--- a/src/core/SQL/PostgreSQL/select_buffer_highlightcounts.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_highlightcounts.sql
@@ -1,0 +1,3 @@
+SELECT bufferid, highlightcount
+FROM buffer
+WHERE userid = :userid

--- a/src/core/SQL/PostgreSQL/setup_050_buffer.sql
+++ b/src/core/SQL/PostgreSQL/setup_050_buffer.sql
@@ -10,6 +10,7 @@ create TABLE buffer (
 	lastseenmsgid integer NOT NULL DEFAULT 0,
 	markerlinemsgid integer NOT NULL DEFAULT 0,
 	bufferactivity integer NOT NULL DEFAULT 0,
+	highlightcount integer NOT NULL DEFAULT 0,
 	key varchar(128),
 	joined boolean NOT NULL DEFAULT FALSE, -- BOOL
 	UNIQUE(userid, networkid, buffercname),

--- a/src/core/SQL/PostgreSQL/update_buffer_highlightcount.sql
+++ b/src/core/SQL/PostgreSQL/update_buffer_highlightcount.sql
@@ -1,0 +1,3 @@
+UPDATE buffer
+SET highlightcount = :highlightcount
+WHERE userid = :userid AND bufferid = :bufferid

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_000_alter_buffer_add_highlightcount.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_000_alter_buffer_add_highlightcount.sql
@@ -1,0 +1,2 @@
+ALTER TABLE buffer
+ADD COLUMN highlightcount integer NOT NULL DEFAULT 0

--- a/src/core/SQL/SQLite/migrate_read_buffer.sql
+++ b/src/core/SQL/SQLite/migrate_read_buffer.sql
@@ -1,2 +1,2 @@
-SELECT bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, key, joined
+SELECT bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, highlightcount, key, joined
 FROM buffer

--- a/src/core/SQL/SQLite/select_buffer_highlightcount.sql
+++ b/src/core/SQL/SQLite/select_buffer_highlightcount.sql
@@ -1,0 +1,6 @@
+SELECT COALESCE(t.sum,0)
+FROM
+  (SELECT SUM(1) AS sum FROM backlog
+   WHERE bufferid = :bufferid
+     AND flags & 2 != 0
+     AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/SQLite/select_buffer_highlightcount.sql
+++ b/src/core/SQL/SQLite/select_buffer_highlightcount.sql
@@ -3,4 +3,5 @@ FROM
   (SELECT SUM(1) AS sum FROM backlog
    WHERE bufferid = :bufferid
      AND flags & 2 != 0
+     AND flags & 1 = 0
      AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/SQLite/select_buffer_highlightcount.sql
+++ b/src/core/SQL/SQLite/select_buffer_highlightcount.sql
@@ -1,6 +1,6 @@
 SELECT COALESCE(t.sum,0)
 FROM
-  (SELECT SUM(1) AS sum FROM backlog
+  (SELECT COUNT(*) AS sum FROM backlog
    WHERE bufferid = :bufferid
      AND flags & 2 != 0
      AND flags & 1 = 0

--- a/src/core/SQL/SQLite/select_buffer_highlightcounts.sql
+++ b/src/core/SQL/SQLite/select_buffer_highlightcounts.sql
@@ -1,0 +1,3 @@
+SELECT bufferid, highlightcount
+FROM buffer
+WHERE userid = :userid

--- a/src/core/SQL/SQLite/setup_030_buffer.sql
+++ b/src/core/SQL/SQLite/setup_030_buffer.sql
@@ -10,6 +10,7 @@ CREATE TABLE buffer (
 	lastseenmsgid INTEGER NOT NULL DEFAULT 0,
 	markerlinemsgid INTEGER NOT NULL DEFAULT 0,
 	bufferactivity INTEGER NOT NULL DEFAULT 0,
+	highlightcount INTEGER NOT NULL DEFAULT 0,
 	key TEXT,
 	joined INTEGER NOT NULL DEFAULT 0, -- BOOL
 	CHECK (lastseenmsgid <= lastmsgid)

--- a/src/core/SQL/SQLite/update_buffer_highlightcount.sql
+++ b/src/core/SQL/SQLite/update_buffer_highlightcount.sql
@@ -1,0 +1,3 @@
+UPDATE buffer
+SET highlightcount = :highlightcount
+WHERE userid = :userid AND bufferid = :bufferid

--- a/src/core/SQL/SQLite/version/27/upgrade_000_alter_buffer_add_highlightcount.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_000_alter_buffer_add_highlightcount.sql
@@ -1,0 +1,2 @@
+ALTER TABLE buffer
+ADD COLUMN highlightcount integer NOT NULL DEFAULT 0

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -234,6 +234,7 @@ public:
         int lastseenmsgid;
         int markerlinemsgid;
         int bufferactivity;
+        int highlightcount;
         QString key;
         bool joined;
     };

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -565,6 +565,39 @@ public:
         return instance()->_storage->bufferActivity(bufferId, lastSeenMsgId);
     }
 
+    //! Update the highlight count for a Buffer
+    /** This Method is used to make the highlight count state of a Buffer persistent
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of that Buffer
+     * \param bufferId  The buffer id
+     * \param MsgId     The Message id where the marker line should be placed
+     */
+    static inline void setHighlightCount(UserId user, BufferId bufferId, int highlightCount) {
+        return instance()->_storage->setHighlightCount(user, bufferId, highlightCount);
+    }
+
+
+    //! Get a Hash of all highlight count states
+    /** This Method is called when the Quassel Core is started to restore the highlight count
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of the buffers
+     */
+    static inline QHash<BufferId, int> highlightCounts(UserId user) {
+        return instance()->_storage->highlightCounts(user);
+    }
+    //! Get the highlight count states for a buffer
+    /** This method is used to load the highlight count of a buffer when its last seen message changes.
+     *  \note This method is threadsafe.
+     *
+     * \param bufferId The buffer
+     * \param lastSeenMsgId     The last seen message
+     */
+    static inline int highlightCount(BufferId bufferId, MsgId lastSeenMsgId) {
+        return instance()->_storage->highlightCount(bufferId, lastSeenMsgId);
+    }
+
     static inline QDateTime startTime() { return instance()->_startTime; }
     static inline bool isConfigured() { return instance()->_configured; }
     static bool sslSupported();

--- a/src/core/corebuffersyncer.h
+++ b/src/core/corebuffersyncer.h
@@ -49,7 +49,7 @@ public slots:
 
     void addCoreHighlight(const Message &message) {
         auto oldHighlightCount = highlightCount(message.bufferId());
-        if (message.flags().testFlag(Message::Flag::Highlight)) {
+        if (message.flags().testFlag(Message::Flag::Highlight) && !message.flags().testFlag(Message::Flag::Self)) {
             setHighlightCount(message.bufferId(), oldHighlightCount + 1);
         }
     }

--- a/src/core/corebuffersyncer.h
+++ b/src/core/corebuffersyncer.h
@@ -47,7 +47,16 @@ public slots:
         }
     }
 
+    void addCoreHighlight(const Message &message) {
+        auto oldHighlightCount = highlightCount(message.bufferId());
+        if (message.flags().testFlag(Message::Flag::Highlight)) {
+            setHighlightCount(message.bufferId(), oldHighlightCount + 1);
+        }
+    }
+
     void setBufferActivity(BufferId buffer, int activity) override;
+
+    void setHighlightCount(BufferId buffer, int highlightCount) override;
 
     inline void requestRenameBuffer(BufferId buffer, QString newName) override { renameBuffer(buffer, newName); }
     void renameBuffer(BufferId buffer, QString newName) override;
@@ -60,6 +69,7 @@ public slots:
     inline void requestMarkBufferAsRead(BufferId buffer) override {
         int activity = Message::Types();
         setBufferActivity(buffer, activity);
+        setHighlightCount(buffer, 0);
         markBufferAsRead(buffer);
     }
 
@@ -75,6 +85,7 @@ private:
     QSet<BufferId> dirtyLastSeenBuffers;
     QSet<BufferId> dirtyMarkerLineBuffers;
     QSet<BufferId> dirtyActivities;
+    QSet<BufferId> dirtyHighlights;
 
     void purgeBufferIds();
 };

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1440,6 +1440,61 @@ Message::Types PostgreSqlStorage::bufferActivity(BufferId bufferId, MsgId lastSe
     return result;
 }
 
+
+void PostgreSqlStorage::setHighlightCount(UserId user, BufferId bufferId, int highlightcount)
+{
+    QSqlQuery query(logDb());
+    query.prepare(queryString("update_buffer_highlightcount"));
+
+    query.bindValue(":userid", user.toInt());
+    query.bindValue(":bufferid", bufferId.toInt());
+    query.bindValue(":highlightcount", highlightcount);
+    safeExec(query);
+    watchQuery(query);
+}
+
+QHash<BufferId, int> PostgreSqlStorage::highlightCounts(UserId user)
+{
+    QHash<BufferId, int> highlightCountHash;
+
+    QSqlDatabase db = logDb();
+    if (!beginReadOnlyTransaction(db)) {
+        qWarning() << "PostgreSqlStorage::highlightCounts(): cannot start read only transaction!";
+        qWarning() << " -" << qPrintable(db.lastError().text());
+        return highlightCountHash;
+    }
+
+    QSqlQuery query(db);
+    query.prepare(queryString("select_buffer_highlightcounts"));
+    query.bindValue(":userid", user.toInt());
+    safeExec(query);
+    if (!watchQuery(query)) {
+        db.rollback();
+        return highlightCountHash;
+    }
+
+    while (query.next()) {
+        highlightCountHash[query.value(0).toInt()] = query.value(1).toInt();
+    }
+
+    db.commit();
+    return highlightCountHash;
+}
+
+int PostgreSqlStorage::highlightCount(BufferId bufferId, MsgId lastSeenMsgId)
+{
+    QSqlQuery query(logDb());
+    query.prepare(queryString("select_buffer_highlightcount"));
+    query.bindValue(":bufferid", bufferId.toInt());
+    query.bindValue(":lastseenmsgid", lastSeenMsgId.toInt());
+    safeExec(query);
+    watchQuery(query);
+    int result = int(0);
+    if (query.first())
+        result = query.value(0).toInt();
+    return result;
+}
+
 bool PostgreSqlStorage::logMessage(Message &msg)
 {
     QSqlDatabase db = logDb();

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -2089,8 +2089,9 @@ bool PostgreSqlMigrationWriter::writeMo(const BufferMO &buffer)
     bindValue(8, buffer.lastseenmsgid);
     bindValue(9, buffer.markerlinemsgid);
     bindValue(10, buffer.bufferactivity);
-    bindValue(11, buffer.key);
-    bindValue(12, buffer.joined);
+    bindValue(11, buffer.highlightcount);
+    bindValue(12, buffer.key);
+    bindValue(13, buffer.joined);
     return exec();
 }
 

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -98,6 +98,9 @@ public slots:
     void setBufferActivity(UserId id, BufferId bufferId, Message::Types type) override;
     QHash<BufferId, Message::Types> bufferActivities(UserId id) override;
     Message::Types bufferActivity(BufferId bufferId, MsgId lastSeenMsgId) override;
+    void setHighlightCount(UserId id, BufferId bufferId, int count) override;
+    QHash<BufferId, int> highlightCounts(UserId id) override;
+    int highlightCount(BufferId bufferId, MsgId lastSeenMsgId) override;
 
     /* Message handling */
     bool logMessage(Message &msg) override;

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -37,6 +37,8 @@
     <file>./SQL/PostgreSQL/select_buffer_bufferactivities.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_bufferactivity.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_by_id.sql</file>
+    <file>./SQL/PostgreSQL/select_buffer_highlightcount.sql</file>
+    <file>./SQL/PostgreSQL/select_buffer_highlightcounts.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_lastseen_messages.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_markerlinemsgids.sql</file>
     <file>./SQL/PostgreSQL/select_buffers.sql</file>
@@ -78,6 +80,7 @@
     <file>./SQL/PostgreSQL/setup_130_function_lastmsgid.sql</file>
     <file>./SQL/PostgreSQL/update_backlog_bufferid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_bufferactivity.sql</file>
+    <file>./SQL/PostgreSQL/update_buffer_highlightcount.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_lastseen.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_markerlinemsgid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_name.sql</file>
@@ -109,6 +112,7 @@
     <file>./SQL/PostgreSQL/version/22/upgrade_000_alter_quasseluser_add_authenticator.sql</file>
     <file>./SQL/PostgreSQL/version/23/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/PostgreSQL/version/24/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_000_alter_buffer_add_highlightcount.sql</file>
     <file>./SQL/SQLite/delete_backlog_by_uid.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_buffer.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_network.sql</file>
@@ -146,6 +150,8 @@
     <file>./SQL/SQLite/select_buffer_bufferactivities.sql</file>
     <file>./SQL/SQLite/select_buffer_bufferactivity.sql</file>
     <file>./SQL/SQLite/select_buffer_by_id.sql</file>
+    <file>./SQL/SQLite/select_buffer_highlightcount.sql</file>
+    <file>./SQL/SQLite/select_buffer_highlightcounts.sql</file>
     <file>./SQL/SQLite/select_buffer_lastseen_messages.sql</file>
     <file>./SQL/SQLite/select_buffer_markerlinemsgids.sql</file>
     <file>./SQL/SQLite/select_buffers.sql</file>
@@ -189,6 +195,7 @@
     <file>./SQL/SQLite/setup_140_identity_nick.sql</file>
     <file>./SQL/SQLite/update_backlog_bufferid.sql</file>
     <file>./SQL/SQLite/update_buffer_bufferactivity.sql</file>
+    <file>./SQL/SQLite/update_buffer_highlightcount.sql</file>
     <file>./SQL/SQLite/update_buffer_lastseen.sql</file>
     <file>./SQL/SQLite/update_buffer_markerlinemsgid.sql</file>
     <file>./SQL/SQLite/update_buffer_name.sql</file>
@@ -293,5 +300,6 @@
     <file>./SQL/SQLite/version/24/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/SQLite/version/25/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
     <file>./SQL/SQLite/version/26/upgrade_000_create_buffer_idx.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_000_alter_buffer_add_highlightcount.sql</file>
 </qresource>
 </RCC>

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1576,6 +1576,79 @@ Message::Types SqliteStorage::bufferActivity(BufferId bufferId, MsgId lastSeenMs
     return result;
 }
 
+void SqliteStorage::setHighlightCount(UserId user, BufferId bufferId, int count)
+{
+    QSqlDatabase db = logDb();
+    db.transaction();
+
+    {
+        QSqlQuery query(db);
+        query.prepare(queryString("update_buffer_highlightcount"));
+        query.bindValue(":userid", user.toInt());
+        query.bindValue(":bufferid", bufferId.toInt());
+        query.bindValue(":highlightcount", count);
+
+        lockForWrite();
+        safeExec(query);
+        watchQuery(query);
+    }
+    db.commit();
+    unlock();
+}
+
+
+QHash<BufferId, int> SqliteStorage::highlightCounts(UserId user)
+{
+    QHash<BufferId, int> highlightCountHash;
+
+    QSqlDatabase db = logDb();
+    db.transaction();
+
+    bool error = false;
+    {
+        QSqlQuery query(db);
+        query.prepare(queryString("select_buffer_highlightcounts"));
+        query.bindValue(":userid", user.toInt());
+
+        lockForRead();
+        safeExec(query);
+        error = !watchQuery(query);
+        if (!error) {
+            while (query.next()) {
+                highlightCountHash[query.value(0).toInt()] = query.value(1).toInt();
+            }
+        }
+    }
+
+    db.commit();
+    unlock();
+    return highlightCountHash;
+}
+
+
+int SqliteStorage::highlightCount(BufferId bufferId, MsgId lastSeenMsgId)
+{
+    QSqlDatabase db = logDb();
+    db.transaction();
+
+    int result = 0;
+    {
+        QSqlQuery query(db);
+        query.prepare(queryString("select_buffer_highlightcount"));
+        query.bindValue(":bufferid", bufferId.toInt());
+        query.bindValue(":lastseenmsgid", lastSeenMsgId.toInt());
+
+        lockForRead();
+        safeExec(query);
+        if (query.first())
+            result = query.value(0).toInt();
+    }
+
+    db.commit();
+    unlock();
+    return result;
+}
+
 bool SqliteStorage::logMessage(Message &msg)
 {
     QSqlDatabase db = logDb();

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -2103,8 +2103,9 @@ bool SqliteMigrationReader::readMo(BufferMO &buffer)
     buffer.lastseenmsgid = value(8).toInt();
     buffer.markerlinemsgid = value(9).toInt();
     buffer.bufferactivity = value(10).toInt();
-    buffer.key = value(11).toString();
-    buffer.joined = value(12).toInt() == 1 ? true : false;
+    buffer.highlightcount = value(11).toInt();
+    buffer.key = value(12).toString();
+    buffer.joined = value(13).toInt() == 1 ? true : false;
     return true;
 }
 

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -99,6 +99,9 @@ public slots:
     void setBufferActivity(UserId id, BufferId bufferId, Message::Types type) override;
     QHash<BufferId, Message::Types> bufferActivities(UserId id) override;
     Message::Types bufferActivity(BufferId bufferId, MsgId lastSeenMsgId) override;
+    void setHighlightCount(UserId id, BufferId bufferId, int count) override;
+    QHash<BufferId, int> highlightCounts(UserId id) override;
+    int highlightCount(BufferId bufferId, MsgId lastSeenMsgId) override;
 
     /* Message handling */
     bool logMessage(Message &msg) override;

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -411,6 +411,33 @@ public slots:
      */
     virtual Message::Types bufferActivity(BufferId bufferId, MsgId lastSeenMsgId) = 0;
 
+    //! Update the highlight count for a Buffer
+    /** This Method is used to make the activity state of a Buffer persistent
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of that Buffer
+     * \param bufferId  The buffer id
+     * \param MsgId     The Message id where the marker line should be placed
+     */
+    virtual void setHighlightCount(UserId id, BufferId bufferId, int count) = 0;
+
+    //! Get a Hash of all highlight count states
+    /** This Method is called when the Quassel Core is started to restore the HighlightCounts
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of the buffers
+     */
+    virtual QHash<BufferId, int> highlightCounts(UserId id) = 0;
+
+    //! Get the highlight count states for a buffer
+    /** This method is used to load the activity state of a buffer when its last seen message changes.
+     *  \note This method is threadsafe.
+     *
+     * \param bufferId The buffer
+     * \param lastSeenMsgId     The last seen message
+     */
+    virtual int highlightCount(BufferId bufferId, MsgId lastSeenMsgId) = 0;
+
     /* Message handling */
 
     //! Store a Message in the storage backend and set its unique Id.


### PR DESCRIPTION
## In Short
* Add highlightCount to buffersyncer, same as with buffer activities
* Sync this with clients

## Status
- [x] Implement database backend
- [x] Integrate the highlight count tracking into the buffersyncer
- [x] Implement the actual sync of the activity between core and client
- [x] Have the client make use of this feature

## Rationale
Currently a client needs to request backlog for all channels, to know if events have occured on that channel (and potentially unhide it, show it differently in the UI, etc). This patch aims at removing that requirement by allowing the client to know the number of unseen highlights that have occured in a channel.

## Disadvantages
The core can not take ignore list items into account, so under some circumstances a channel might be marked as having new highlights, but the client might not show them once the channel is activated. Additionally, this can not process local highlights.