### PR TITLE
core: Fix CAP REQ display for SASL only supported

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -1210,9 +1210,10 @@ void CoreNetwork::beginCapNegotiation()
                tr("Ready to negotiate (found: %1)").arg(caps().join(", ")));
 
     // Build a list of queued capabilities, starting with individual, then bundled, only adding the
-    // comma separator between the two if needed.
+    // comma separator between the two if needed (both individual and bundled caps exist).
     QString queuedCapsDisplay =
-            (!_capsQueuedIndividual.empty() ? _capsQueuedIndividual.join(", ") + ", " : "")
+            _capsQueuedIndividual.join(", ")
+            + ((!_capsQueuedIndividual.empty() && !_capsQueuedBundled.empty()) ? ", " : "")
             + _capsQueuedBundled.join(", ");
     displayMsg(Message::Server, BufferInfo::StatusBuffer, "",
                tr("Negotiating capabilities (requesting: %1)...").arg(queuedCapsDisplay));


### PR DESCRIPTION
## In short
* When negotiating capabilities, stop adding a `, ` when unneccessary
  * E.g. when connecting to a server that only supports `sasl`
  * Only add `, ` between `_capsQueuedIndividual` and `_capsQueuedBundled` when both have items
  * [`QStringList.join()`](https://doc.qt.io/qt-5/qstringlist.html#join ) will only add the separator when more than one item's in the list

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | User-facing corner case for capability negotiation
Risk | ★☆☆ *1/3* | Might add or miss commas when displaying negotiation messages
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other PRs

## Examples
### Before
*Notice the `Negotiating capabilities` message*
```
* Ready to negotiate (found: extended-join, userhost-in-names, multi-prefix, away-notify, sasl)
* Negotiating capabilities (requesting: sasl, )...
[localhost] BitlBee-IRCd initialized, please go on
* Capability negotiation finished (enabled: sasl)
```

### After
```
* Ready to negotiate (found: userhost-in-names, multi-prefix, sasl, away-notify, extended-join)
* Negotiating capabilities (requesting: sasl)...
[localhost] BitlBee-IRCd initialized, please go on
* Capability negotiation finished (enabled: sasl)
```