### PR TITLE
Change HTTP links to HTTPS for quassel-irc.org and subdomains

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,10 +6,10 @@ contains end-user visible, mostly major new features. It does not contain (most)
 bugfixes, nor is it guaranteed to be complete or up-to-date at all. Also, it does
 start at 0.3.0 only, since this was the first version widely available.
 
-Please have a look at <http://bugs.quassel-irc.org/projects/quassel-irc/roadmap> for a
+Please have a look at <https://bugs.quassel-irc.org/projects/quassel-irc/roadmap> for a
 list of closed bug/feature reports (which still does not cover bugs we have
 fixed but which were never reported, of course), and for a full list of
-changes, the git history at <http://git.quassel-irc.org> is your friend.
+changes, the git history at <https://git.quassel-irc.org> is your friend.
 
 Without further ado, let's start:
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Thanks for reading,
 
 ~ *The Quassel IRC Team*
 
-[web-home]: http://quassel-irc.org
-[dev-bugs]: http://bugs.quassel-irc.org
+[web-home]: https://quassel-irc.org
+[dev-bugs]: https://bugs.quassel-irc.org
 [dev-email]: mailto:devel@quassel-irc.org
 [dev-pr-new]: https://github.com/quassel/quassel/pull/new/master
-[docs-wiki]: http://bugs.quassel-irc.org/projects/quassel-irc/wiki
+[docs-wiki]: https://bugs.quassel-irc.org/projects/quassel-irc/wiki
 [help-freenode]: https://webchat.freenode.net?channels=%23quassel
 [repo-changelog]: ChangeLog

--- a/data/quassel.appdata.xml
+++ b/data/quassel.appdata.xml
@@ -25,11 +25,11 @@ without setting up a core.
 	</description>
 	<screenshots>
 		<screenshot type="default">
-			<image>http://quassel-irc.org/files/images/20080914-011743-quasselkde4.preview.png</image>
+			<image>https://quassel-irc.org/files/images/20080914-011743-quasselkde4.preview.png</image>
 			<caption>Quassel, with a dark theme enabled</caption>
 		</screenshot>
 		<screenshot type="default">
-			<image>http://quassel-irc.org/files/images/quassel_win7.preview.png</image>
+			<image>https://quassel-irc.org/files/images/quassel_win7.preview.png</image>
 			<caption>
 The default quassel white theme. Quassel runs on all major desktop platforms,
 and many smartphones as well.

--- a/data/quasselclient.appdata.xml
+++ b/data/quasselclient.appdata.xml
@@ -25,11 +25,11 @@ This application is the client-only version of Quassel. You must first set up
 	</description>
 	<screenshots>
 		<screenshot type="default">
-			<image>http://quassel-irc.org/files/images/20080914-011743-quasselkde4.preview.png</image>
+			<image>https://quassel-irc.org/files/images/20080914-011743-quasselkde4.preview.png</image>
 			<caption>Quassel, with a dark theme enabled</caption>
 		</screenshot>
 		<screenshot type="default">
-			<image>http://quassel-irc.org/files/images/quassel_win7.preview.png</image>
+			<image>https://quassel-irc.org/files/images/quassel_win7.preview.png</image>
 			<caption>
 The default quassel white theme. Quassel runs on all major desktop platforms,
 and many smartphones as well.

--- a/scripts/build/NullsoftInstaller.nsi
+++ b/scripts/build/NullsoftInstaller.nsi
@@ -24,7 +24,7 @@ var nameOfToBeRunend
 
 Var StartMenuFolder
 
-!define PRODUCT_WEB_SITE http://quassel-irc.org/
+!define PRODUCT_WEB_SITE https://quassel-irc.org/
 !define MyApp_AppUserModelId  QuasselProject.QuasselIRC
 !define SnoreToastExe "$INSTDIR\SnoreToast.exe"
 

--- a/src/common/identity.cpp
+++ b/src/common/identity.cpp
@@ -191,8 +191,8 @@ void Identity::setToDefaults()
     setDetachAwayReasonEnabled(false);
     setIdent("quassel");
     setKickReason(tr("Kindergarten is elsewhere!"));
-    setPartReason(tr("http://quassel-irc.org - Chat comfortably. Anywhere."));
-    setQuitReason(tr("http://quassel-irc.org - Chat comfortably. Anywhere."));
+    setPartReason(tr("https://quassel-irc.org - Chat comfortably. Anywhere."));
+    setQuitReason(tr("https://quassel-irc.org - Chat comfortably. Anywhere."));
 }
 
 

--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
         ki18n("A modern, distributed IRC client"));
     aboutData.addLicense(KAboutData::License_GPL_V2);
     aboutData.addLicense(KAboutData::License_GPL_V3);
-    aboutData.setBugAddress("http://bugs.quassel-irc.org/projects/quassel-irc/issues/new");
+    aboutData.setBugAddress("https://bugs.quassel-irc.org/projects/quassel-irc/issues/new");
     aboutData.setOrganizationDomain(Quassel::buildInfo().organizationDomain.toUtf8());
     KCmdLineArgs::init(argc, argv, &aboutData);
 

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -1550,6 +1550,6 @@ void CoreSessionEventProcessor::handleCtcpTime(CtcpEvent *e)
 
 void CoreSessionEventProcessor::handleCtcpVersion(CtcpEvent *e)
 {
-    e->setReply(QString("Quassel IRC %1 (built on %2) -- http://www.quassel-irc.org")
+    e->setReply(QString("Quassel IRC %1 (built on %2) -- https://www.quassel-irc.org")
         .arg(Quassel::buildInfo().plainVersionString).arg(Quassel::buildInfo().commitDate));
 }

--- a/src/core/sslserver.cpp
+++ b/src/core/sslserver.cpp
@@ -57,7 +57,7 @@ SslServer::SslServer(QObject *parent)
             quWarning()
             << "SslServer: Unable to set certificate file\n"
             << "          Quassel Core will still work, but cannot provide SSL for client connections.\n"
-            << "          Please see http://quassel-irc.org/faq/cert to learn how to enable SSL support.";
+            << "          Please see https://quassel-irc.org/faq/cert to learn how to enable SSL support.";
             sslWarningShown = true;
         }
     }
@@ -112,12 +112,12 @@ bool SslServer::reloadCerts()
             quWarning()
             << "SslServer: Unable to reload certificate file, reverting\n"
             << "          Quassel Core will use the previous key to provide SSL for client connections.\n"
-            << "          Please see http://quassel-irc.org/faq/cert to learn how to enable SSL support.";
+            << "          Please see https://quassel-irc.org/faq/cert to learn how to enable SSL support.";
         } else {
             quWarning()
             << "SslServer: Unable to reload certificate file\n"
             << "          Quassel Core will still work, but cannot provide SSL for client connections.\n"
-            << "          Please see http://quassel-irc.org/faq/cert to learn how to enable SSL support.";
+            << "          Please see https://quassel-irc.org/faq/cert to learn how to enable SSL support.";
         }
         return false;
     }

--- a/src/qtui/aboutdlg.cpp
+++ b/src/qtui/aboutdlg.cpp
@@ -52,15 +52,15 @@ QString AboutDlg::about() const
 {
     QString res {tr("<b>A modern, distributed IRC Client</b><br><br>"
              "&copy;%1 by the Quassel Project<br>"
-             "<a href=\"http://quassel-irc.org\">http://quassel-irc.org</a><br>"
-             "<a href=\"irc://irc.freenode.net/quassel\">#quassel</a> on <a href=\"http://www.freenode.net\">Freenode</a><br><br>"
-             "Quassel IRC is dual-licensed under <a href=\"http://www.gnu.org/licenses/gpl-2.0.txt\">GPLv2</a> and "
-                 "<a href=\"http://www.gnu.org/licenses/gpl-3.0.txt\">GPLv3</a>.<br>"
+             "<a href=\"https://quassel-irc.org\">https://quassel-irc.org</a><br>"
+             "<a href=\"irc://irc.freenode.net/quassel\">#quassel</a> on <a href=\"https://www.freenode.net\">Freenode</a><br><br>"
+             "Quassel IRC is dual-licensed under <a href=\"https://www.gnu.org/licenses/gpl-2.0.txt\">GPLv2</a> and "
+                 "<a href=\"https://www.gnu.org/licenses/gpl-3.0.txt\">GPLv3</a>.<br>"
              "<a href=\"https://api.kde.org/frameworks/breeze-icons/html\">Breeze icon theme</a> &copy; Uri Herrera and others, licensed under the "
                  "<a href=\"https://github.com/KDE/breeze-icons/blob/21ffd9b/COPYING-ICONS\">LGPLv3</a>.<br>"
              "<a href=\"https://api.kde.org/frameworks/oxygen-icons5/html\">Oxygen icon theme</a> &copy; Nuno Pinheiro and others, licensed under the "
                  "<a href=\"https://github.com/KDE/oxygen-icons/blob/master/COPYING\">LGPLv3</a>.<br><br>"
-             "Please use <a href=\"http://bugs.quassel-irc.org\">http://bugs.quassel-irc.org</a> to report bugs."
+             "Please use <a href=\"https://bugs.quassel-irc.org\">https://bugs.quassel-irc.org</a> to report bugs."
         ).arg("2005-2016")
     };
 

--- a/src/uisupport/aboutdata.cpp
+++ b/src/uisupport/aboutdata.cpp
@@ -140,7 +140,7 @@ KAboutData AboutData::kAboutData() const
     aboutData.addLicense(KAboutLicense::GPL_V3);
     aboutData.setShortDescription(tr("A modern, distributed IRC client"));
     aboutData.setProgramLogo(QVariant::fromValue(QImage(":/pics/quassel-logo.png")));
-    aboutData.setBugAddress("http://bugs.quassel-irc.org/projects/quassel-irc/issues/new");
+    aboutData.setBugAddress("https://bugs.quassel-irc.org/projects/quassel-irc/issues/new");
     aboutData.setOrganizationDomain(Quassel::buildInfo().organizationDomain.toUtf8());
 
     for (const auto &person : authors()) {


### PR DESCRIPTION
I've updated any links to quassel-irc.org and any subdomains I could find from HTTP to HTTPS.