### PR TITLE
common: Polish core-side highlights

### DIFF
--- a/src/client/clientignorelistmanager.cpp
+++ b/src/client/clientignorelistmanager.cpp
@@ -50,8 +50,8 @@ QMap<QString, bool> ClientIgnoreListManager::matchingRulesForHostmask(const QStr
     QMap<QString, bool> result;
     foreach(IgnoreListItem item, ignoreList()) {
         if (item.type == SenderIgnore && pureMatch(item, hostmask)
-            && ((network.isEmpty() && channel.isEmpty()) || item.scope == GlobalScope || (item.scope == NetworkScope && scopeMatch(item.scopeRule, network))
-                || (item.scope == ChannelScope && scopeMatch(item.scopeRule, channel)))) {
+            && ((network.isEmpty() && channel.isEmpty()) || item.scope == GlobalScope || (item.scope == NetworkScope && scopeMatch(network, item.scopeRule))
+                || (item.scope == ChannelScope && scopeMatch(channel, item.scopeRule)))) {
             result[item.ignoreRule] = item.isActive;
 //      qDebug() << "matchingRulesForHostmask found: " << item.ignoreRule << "is active: " << item.isActive;
         }

--- a/src/client/clientsettings.cpp
+++ b/src/client/clientsettings.cpp
@@ -320,7 +320,7 @@ void NotificationSettings::setHighlightNick(NotificationSettings::HighlightNickT
 
 NotificationSettings::HighlightNickType NotificationSettings::highlightNick()
 {
-    return (NotificationSettings::HighlightNickType)localValue("Highlights/HighlightNick", CurrentNick).toInt();
+    return (NotificationSettings::HighlightNickType)localValue("Highlights/HighlightNick", NoNick).toInt();
 }
 
 

--- a/src/common/highlightrulemanager.cpp
+++ b/src/common/highlightrulemanager.cpp
@@ -145,7 +145,8 @@ bool HighlightRuleManager::match(const QString &msgContents,
         if (!rule.isEnabled)
             continue;
 
-        if (!rule.chanName.isEmpty() && !scopeMatch(rule.chanName, bufferName)) {
+        if (!rule.chanName.isEmpty()
+                && !scopeMatch(bufferName, rule.chanName, rule.isRegEx, rule.isCaseSensitive)) {
             // A channel name rule is specified and does NOT match the current buffer name, skip
             // this rule
             continue;
@@ -163,12 +164,8 @@ bool HighlightRuleManager::match(const QString &msgContents,
         if (rule.sender.isEmpty()) {
             senderMatch = true;
         } else {
-            if (rule.isRegEx) {
-                rx = QRegExp(rule.sender, rule.isCaseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
-            } else {
-                rx = QRegExp(rule.sender, Qt::CaseInsensitive, QRegExp::Wildcard);
-            }
-            senderMatch = rx.exactMatch(msgSender);
+            // A sender name rule is specified, match according to scope rules.
+            senderMatch = scopeMatch(msgSender, rule.sender, rule.isRegEx, rule.isCaseSensitive);
         }
 
         if (nameMatch && senderMatch) {

--- a/src/common/highlightrulemanager.cpp
+++ b/src/common/highlightrulemanager.cpp
@@ -141,17 +141,10 @@ bool HighlightRuleManager::match(const QString &msgContents,
         if (!rule.isEnabled)
             continue;
 
-        if (rule.chanName.size() > 0 && rule.chanName.compare(".*") != 0) {
-            if (rule.chanName.startsWith("!")) {
-                QRegExp rx(rule.chanName.mid(1), Qt::CaseInsensitive);
-                if (rx.exactMatch(bufferName))
-                    continue;
-            }
-            else {
-                QRegExp rx(rule.chanName, Qt::CaseInsensitive);
-                if (!rx.exactMatch(bufferName))
-                    continue;
-            }
+        if (!rule.chanName.isEmpty() && !scopeMatch(rule.chanName, bufferName)) {
+            // A channel name rule is specified and does NOT match the current buffer name, skip
+            // this rule
+            continue;
         }
 
         QRegExp rx;

--- a/src/common/highlightrulemanager.cpp
+++ b/src/common/highlightrulemanager.cpp
@@ -104,7 +104,11 @@ void HighlightRuleManager::initSetHighlightRuleList(const QVariantMap &highlight
         _highlightRuleList << HighlightRule(name[i], isRegEx[i].toBool(), isCaseSensitive[i].toBool(),
                                             isActive[i].toBool(), isInverse[i].toBool(), sender[i], channel[i]);
     }
-    _highlightNick = HighlightNickType(highlightRuleList["highlightNick"].toInt());
+
+    // Make sure the default for _highlightNick is "CurrentNick" if not set
+    _highlightNick = HighlightNickType(
+                highlightRuleList.value("highlightNick", HighlightNickType::CurrentNick).toInt());
+
     _nicksCaseSensitive = highlightRuleList["nicksCaseSensitive"].toBool();
 }
 

--- a/src/common/ignorelistmanager.cpp
+++ b/src/common/ignorelistmanager.cpp
@@ -160,62 +160,6 @@ IgnoreListManager::StrictnessType IgnoreListManager::_match(const QString &msgCo
 }
 
 
-bool IgnoreListManager::scopeMatch(const QString &scopeRule, const QString &string) const
-{
-    // A match happens when the string does NOT match ANY inverted rules and matches AT LEAST one
-    // normal rule, unless no normal rules exist (implicit wildcard match).  This gives inverted
-    // rules higher priority regardless of ordering.
-    //
-    // TODO: After switching to Qt 5, use of this should be split into two parts, one part that
-    // would generate compiled QRegularExpressions for match/inverted match, regenerating it on any
-    // rule changes, and another part that would check each message against these compiled rules.
-
-    // Keep track if any matches are found
-    bool matches = false;
-    // Keep track if normal rules and inverted rules are found, allowing for implicit wildcard
-    bool normalRuleFound = false, invertedRuleFound = false;
-
-    // Split each scope rule by separator, ignoring empty parts
-    foreach(QString rule, scopeRule.split(";", QString::SkipEmptyParts)) {
-        // Trim whitespace from the start/end of the rule
-        rule = rule.trimmed();
-        // Ignore empty rules
-        if (rule.isEmpty())
-            continue;
-
-        // Check if this is an inverted rule (starts with '!')
-        if (rule.startsWith("!")) {
-            // Inverted rule found
-            invertedRuleFound = true;
-
-            // Take the reminder of the string
-            QRegExp ruleRx(rule.mid(1), Qt::CaseInsensitive);
-            ruleRx.setPatternSyntax(QRegExp::Wildcard);
-            if (ruleRx.exactMatch(string)) {
-                // Matches an inverted rule, full rule cannot match
-                return false;
-            }
-        } else {
-            // Normal rule found
-            normalRuleFound = true;
-
-            QRegExp ruleRx(rule, Qt::CaseInsensitive);
-            ruleRx.setPatternSyntax(QRegExp::Wildcard);
-            if (ruleRx.exactMatch(string)) {
-                // Matches a normal rule, full rule might match
-                matches = true;
-                // Continue checking in case other inverted rules negate this
-            }
-        }
-    }
-    // No inverted rules matched, okay to match normally
-    // Return true if...
-    // ...we found a normal match
-    // ...implicit wildcard: we had inverted rules (that didn't match) and no normal rules
-    return matches || (invertedRuleFound && !normalRuleFound);
-}
-
-
 void IgnoreListManager::removeIgnoreListItem(const QString &ignoreRule)
 {
     removeAt(indexOf(ignoreRule));

--- a/src/common/ignorelistmanager.cpp
+++ b/src/common/ignorelistmanager.cpp
@@ -162,15 +162,57 @@ IgnoreListManager::StrictnessType IgnoreListManager::_match(const QString &msgCo
 
 bool IgnoreListManager::scopeMatch(const QString &scopeRule, const QString &string) const
 {
-    foreach(QString rule, scopeRule.split(";")) {
-        QRegExp ruleRx = QRegExp(rule.trimmed());
-        ruleRx.setCaseSensitivity(Qt::CaseInsensitive);
-        ruleRx.setPatternSyntax(QRegExp::Wildcard);
-        if (ruleRx.exactMatch(string)) {
-            return true;
+    // A match happens when the string does NOT match ANY inverted rules and matches AT LEAST one
+    // normal rule, unless no normal rules exist (implicit wildcard match).  This gives inverted
+    // rules higher priority regardless of ordering.
+    //
+    // TODO: After switching to Qt 5, use of this should be split into two parts, one part that
+    // would generate compiled QRegularExpressions for match/inverted match, regenerating it on any
+    // rule changes, and another part that would check each message against these compiled rules.
+
+    // Keep track if any matches are found
+    bool matches = false;
+    // Keep track if normal rules and inverted rules are found, allowing for implicit wildcard
+    bool normalRuleFound = false, invertedRuleFound = false;
+
+    // Split each scope rule by separator, ignoring empty parts
+    foreach(QString rule, scopeRule.split(";", QString::SkipEmptyParts)) {
+        // Trim whitespace from the start/end of the rule
+        rule = rule.trimmed();
+        // Ignore empty rules
+        if (rule.isEmpty())
+            continue;
+
+        // Check if this is an inverted rule (starts with '!')
+        if (rule.startsWith("!")) {
+            // Inverted rule found
+            invertedRuleFound = true;
+
+            // Take the reminder of the string
+            QRegExp ruleRx(rule.mid(1), Qt::CaseInsensitive);
+            ruleRx.setPatternSyntax(QRegExp::Wildcard);
+            if (ruleRx.exactMatch(string)) {
+                // Matches an inverted rule, full rule cannot match
+                return false;
+            }
+        } else {
+            // Normal rule found
+            normalRuleFound = true;
+
+            QRegExp ruleRx(rule, Qt::CaseInsensitive);
+            ruleRx.setPatternSyntax(QRegExp::Wildcard);
+            if (ruleRx.exactMatch(string)) {
+                // Matches a normal rule, full rule might match
+                matches = true;
+                // Continue checking in case other inverted rules negate this
+            }
         }
     }
-    return false;
+    // No inverted rules matched, okay to match normally
+    // Return true if...
+    // ...we found a normal match
+    // ...implicit wildcard: we had inverted rules (that didn't match) and no normal rules
+    return matches || (invertedRuleFound && !normalRuleFound);
 }
 
 

--- a/src/common/ignorelistmanager.cpp
+++ b/src/common/ignorelistmanager.cpp
@@ -136,8 +136,8 @@ IgnoreListManager::StrictnessType IgnoreListManager::_match(const QString &msgCo
         if (!item.isActive || item.type == CtcpIgnore)
             continue;
         if (item.scope == GlobalScope
-            || (item.scope == NetworkScope && scopeMatch(item.scopeRule, network))
-            || (item.scope == ChannelScope && scopeMatch(item.scopeRule, bufferName))) {
+            || (item.scope == NetworkScope && scopeMatch(network, item.scopeRule))
+            || (item.scope == ChannelScope && scopeMatch(bufferName, item.scopeRule))) {
             QString str;
             if (item.type == MessageIgnore)
                 str = msgContents;
@@ -182,7 +182,7 @@ bool IgnoreListManager::ctcpMatch(const QString sender, const QString &network, 
     foreach(IgnoreListItem item, _ignoreList) {
         if (!item.isActive)
             continue;
-        if (item.scope == GlobalScope || (item.scope == NetworkScope && scopeMatch(item.scopeRule, network))) {
+        if (item.scope == GlobalScope || (item.scope == NetworkScope && scopeMatch(network, item.scopeRule))) {
             QString sender_;
             QStringList types = item.ignoreRule.split(QRegExp("\\s+"), QString::SkipEmptyParts);
 

--- a/src/common/ignorelistmanager.h
+++ b/src/common/ignorelistmanager.h
@@ -26,6 +26,8 @@
 
 #include "message.h"
 #include "syncableobject.h"
+// Scope matching
+#include "util.h"
 
 class IgnoreListManager : public SyncableObject
 {
@@ -147,19 +149,6 @@ public slots:
 
 protected:
     void setIgnoreList(const QList<IgnoreListItem> &ignoreList) { _ignoreList = ignoreList; }
-
-    //! Check if a scope rule matches a string
-    /** Checks that the string does NOT match ANY inverted rules (prefixed by '!'), then checks that
-     * it matches AT LEAST one normal (non-inverted) rule.
-     *
-     * If only inverted rules are specified, it'll match so long as the string does not match any
-     * inverted rules (implicit wildcard).
-     *
-     * \param scopeRule  A ';'-separated list of wildcard expressions, prefix of '!' inverts subrule
-     * \param string     String to test, e.g. network/channel name
-     * \return True if matches, otherwise false
-     */
-    bool scopeMatch(const QString &scopeRule, const QString &string) const;
 
     StrictnessType _match(const QString &msgContents, const QString &msgSender, Message::Type msgType, const QString &network, const QString &bufferName);
 

--- a/src/common/ignorelistmanager.h
+++ b/src/common/ignorelistmanager.h
@@ -147,7 +147,19 @@ public slots:
 
 protected:
     void setIgnoreList(const QList<IgnoreListItem> &ignoreList) { _ignoreList = ignoreList; }
-    bool scopeMatch(const QString &scopeRule, const QString &string) const; // scopeRule is a ';'-separated list, string is a network/channel-name
+
+    //! Check if a scope rule matches a string
+    /** Checks that the string does NOT match ANY inverted rules (prefixed by '!'), then checks that
+     * it matches AT LEAST one normal (non-inverted) rule.
+     *
+     * If only inverted rules are specified, it'll match so long as the string does not match any
+     * inverted rules (implicit wildcard).
+     *
+     * \param scopeRule  A ';'-separated list of wildcard expressions, prefix of '!' inverts subrule
+     * \param string     String to test, e.g. network/channel name
+     * \return True if matches, otherwise false
+     */
+    bool scopeMatch(const QString &scopeRule, const QString &string) const;
 
     StrictnessType _match(const QString &msgContents, const QString &msgSender, Message::Type msgType, const QString &network, const QString &bufferName);
 

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -280,3 +280,59 @@ QString formatCurrentDateTimeInString(const QString &formatStr)
 
     return formattedStr;
 }
+
+
+bool scopeMatch(const QString &scopeRule, const QString &string)
+{
+    // A match happens when the string does NOT match ANY inverted rules and matches AT LEAST one
+    // normal rule, unless no normal rules exist (implicit wildcard match).  This gives inverted
+    // rules higher priority regardless of ordering.
+    //
+    // TODO: After switching to Qt 5, use of this should be split into two parts, one part that
+    // would generate compiled QRegularExpressions for match/inverted match, regenerating it on any
+    // rule changes, and another part that would check each message against these compiled rules.
+
+    // Keep track if any matches are found
+    bool matches = false;
+    // Keep track if normal rules and inverted rules are found, allowing for implicit wildcard
+    bool normalRuleFound = false, invertedRuleFound = false;
+
+    // Split each scope rule by separator, ignoring empty parts
+    foreach(QString rule, scopeRule.split(";", QString::SkipEmptyParts)) {
+        // Trim whitespace from the start/end of the rule
+        rule = rule.trimmed();
+        // Ignore empty rules
+        if (rule.isEmpty())
+            continue;
+
+        // Check if this is an inverted rule (starts with '!')
+        if (rule.startsWith("!")) {
+            // Inverted rule found
+            invertedRuleFound = true;
+
+            // Take the reminder of the string
+            QRegExp ruleRx(rule.mid(1), Qt::CaseInsensitive);
+            ruleRx.setPatternSyntax(QRegExp::Wildcard);
+            if (ruleRx.exactMatch(string)) {
+                // Matches an inverted rule, full rule cannot match
+                return false;
+            }
+        } else {
+            // Normal rule found
+            normalRuleFound = true;
+
+            QRegExp ruleRx(rule, Qt::CaseInsensitive);
+            ruleRx.setPatternSyntax(QRegExp::Wildcard);
+            if (ruleRx.exactMatch(string)) {
+                // Matches a normal rule, full rule might match
+                matches = true;
+                // Continue checking in case other inverted rules negate this
+            }
+        }
+    }
+    // No inverted rules matched, okay to match normally
+    // Return true if...
+    // ...we found a normal match
+    // ...implicit wildcard: we had inverted rules (that didn't match) and no normal rules
+    return matches || (invertedRuleFound && !normalRuleFound);
+}

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -82,14 +82,22 @@ QString formatCurrentDateTimeInString(const QString &formatStr);
 
 /** Check if a scope rule matches a string
  *
+ * When isRegEx is false:
  * Checks that the string does NOT match ANY inverted rules (prefixed by '!'), then checks that
  * it matches AT LEAST one normal (non-inverted) rule.
  *
  * If only inverted rules are specified, it'll match so long as the string does not match any
  * inverted rules (implicit wildcard).
  *
- * @param scopeRule  A ';'-separated list of wildcard expressions, prefix of '!' inverts subrule
- * @param string     String to test, e.g. network/channel name
+ * When isRegEx is true:
+ * Checks that the string matches the entire scopeRule as a regular expression.  If scopeRule starts
+ * with a '!', check that the string does NOT match the regular expression.
+ *
+ * @param string           String to test, e.g. network/channel name
+ * @param scopeRule        ';'-separated list of wildcard expressions, prefix of '!' inverts subrule
+ * @param isRegEx          If true, treat entire scope rule as regular expression, not wildcards
+ * @param isCaseSensitive  If true, treat as case-sensitive, else case-insensitive
  * @return True if matches, otherwise false
  */
-bool scopeMatch(const QString &scopeRule, const QString &string);
+bool scopeMatch(const QString &string, const QString &scopeRule,
+                const bool &isRegEx = false, const bool &isCaseSensitive = false);

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -79,3 +79,17 @@ QByteArray prettyDigest(const QByteArray &digest);
  * @return String with current date/time substituted in via formatting codes
  */
 QString formatCurrentDateTimeInString(const QString &formatStr);
+
+/** Check if a scope rule matches a string
+ *
+ * Checks that the string does NOT match ANY inverted rules (prefixed by '!'), then checks that
+ * it matches AT LEAST one normal (non-inverted) rule.
+ *
+ * If only inverted rules are specified, it'll match so long as the string does not match any
+ * inverted rules (implicit wildcard).
+ *
+ * @param scopeRule  A ';'-separated list of wildcard expressions, prefix of '!' inverts subrule
+ * @param string     String to test, e.g. network/channel name
+ * @return True if matches, otherwise false
+ */
+bool scopeMatch(const QString &scopeRule, const QString &string);

--- a/src/qtui/qtuimessageprocessor.cpp
+++ b/src/qtui/qtuimessageprocessor.cpp
@@ -141,17 +141,11 @@ void QtUiMessageProcessor::checkForHighlight(Message &msg)
             if (!rule.isEnabled)
                 continue;
 
-            if (rule.chanName.size() > 0 && rule.chanName.compare(".*") != 0) {
-                if (rule.chanName.startsWith("!")) {
-                    QRegExp rx(rule.chanName.mid(1), Qt::CaseInsensitive);
-                    if (rx.exactMatch(msg.bufferInfo().bufferName()))
-                        continue;
-                }
-                else {
-                    QRegExp rx(rule.chanName, Qt::CaseInsensitive);
-                    if (!rx.exactMatch(msg.bufferInfo().bufferName()))
-                        continue;
-                }
+            if (!rule.chanName.isEmpty()
+                    && !scopeMatch(rule.chanName, msg.bufferInfo().bufferName())) {
+                // A channel name rule is specified and does NOT match the current buffer name, skip
+                // this rule
+                continue;
             }
 
             QRegExp rx;

--- a/src/qtui/qtuimessageprocessor.cpp
+++ b/src/qtui/qtuimessageprocessor.cpp
@@ -142,7 +142,8 @@ void QtUiMessageProcessor::checkForHighlight(Message &msg)
                 continue;
 
             if (!rule.chanName.isEmpty()
-                    && !scopeMatch(rule.chanName, msg.bufferInfo().bufferName())) {
+                    && !scopeMatch(msg.bufferInfo().bufferName(), rule.chanName,
+                                   rule.isRegExp, rule.caseSensitive)) {
                 // A channel name rule is specified and does NOT match the current buffer name, skip
                 // this rule
                 continue;

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -101,19 +101,31 @@ void CoreHighlightSettingsPage::setupRuleTable(QTableWidget *table) const
     table->setShowGrid(false);
 
     table->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->setToolTip(
-        tr("<b>RegEx</b>: This option determines if the highlight rule should be interpreted as a <b>regular expression</b> or just as a keyword."));
+                tr("<b>RegEx</b>: This option determines if the highlight rule should be "
+                   "interpreted as a <b>regular expression</b> or just as a keyword."));
     table->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->setWhatsThis(
-        tr("<b>RegEx</b>: This option determines if the highlight rule should be interpreted as a <b>regular expression</b> or just as a keyword."));
+                table->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->toolTip());
 
     table->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->setToolTip(
-        tr("<b>CS</b>: This option determines if the highlight rule should be interpreted <b>case sensitive</b>."));
+                tr("<b>CS</b>: This option determines if the highlight rule should be interpreted "
+                   "<b>case sensitive</b>."));
     table->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->setWhatsThis(
-        tr("<b>CS</b>: This option determines if the highlight rule should be interpreted <b>case sensitive</b>."));
+                table->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->toolTip());
 
     table->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->setToolTip(
-        tr("<b>Channel</b>: This regular expression determines for which <b>channels</b> the highlight rule works. Leave blank to match any channel. Put <b>!</b> in the beginning to negate. Case insensitive."));
+                tr("<p><b>Channel</b>: Semicolon separated list of channel names.</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
+                   "would match on #foobar and on any channel starting with <i>#quassel</i> except "
+                   "for <i>#quasseldroid</i><br />"
+                   "<p>If only inverted names are specified, it will match anything except for "
+                   "what's specified (implicit wildcard).</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>!#quassel*; !#foobar</i><br />"
+                   "would match anything except for #foobar or any channel starting with "
+                   "<i>#quassel</i></p>"));
     table->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->setWhatsThis(
-        tr("<b>Channel</b>: This regular expression determines for which <b>channels</b> the highlight rule works. Leave blank to match any channel. Put <b>!</b> in the beginning to negate. Case insensitive."));
+                table->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->toolTip());
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     table->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::EnableColumn, QHeaderView::ResizeToContents);
@@ -193,6 +205,30 @@ void CoreHighlightSettingsPage::addNewHighlightRow(bool enable, const QString &n
 
     auto *senderItem = new QTableWidgetItem(sender);
 
+    enableItem->setToolTip(tr("Enable/disable this rule"));
+    nameItem->setToolTip(tr("Phrase to match"));
+    regexItem->setToolTip(
+                tr("<b>RegEx</b>: This option determines if the highlight rule should be "
+                   "interpreted as a <b>regular expression</b> or just as a keyword."));
+    csItem->setToolTip(
+                tr("<b>CS</b>: This option determines if the highlight rule should be interpreted "
+                   "<b>case sensitive</b>."));
+    senderItem->setToolTip(
+                tr("<b>Sender</b>: This option specifies which sender to match.  Leave blank to "
+                   "match any nickname."));
+    chanNameItem->setToolTip(
+                tr("<p><b>Channel</b>: Semicolon separated list of channel names.</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
+                   "would match on #foobar and on any channel starting with <i>#quassel</i> except "
+                   "for <i>#quasseldroid</i><br />"
+                   "<p>If only inverted names are specified, it will match anything except for "
+                   "what's specified (implicit wildcard).</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>!#quassel*; !#foobar</i><br />"
+                   "would match anything except for #foobar or any channel starting with "
+                   "<i>#quassel</i></p>"));
+
     int lastRow = ui.highlightTable->rowCount() - 1;
     ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::NameColumn, nameItem);
     ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::RegExColumn, regexItem);
@@ -238,6 +274,30 @@ void CoreHighlightSettingsPage::addNewIgnoredRow(bool enable, const QString &nam
     auto *chanNameItem = new QTableWidgetItem(chanName);
 
     auto *senderItem = new QTableWidgetItem(sender);
+
+    enableItem->setToolTip(tr("Enable/disable this rule"));
+    nameItem->setToolTip(tr("Phrase to match"));
+    regexItem->setToolTip(
+                tr("<b>RegEx</b>: This option determines if the highlight rule should be "
+                   "interpreted as a <b>regular expression</b> or just as a keyword."));
+    csItem->setToolTip(
+                tr("<b>CS</b>: This option determines if the highlight rule should be interpreted "
+                   "<b>case sensitive</b>."));
+    senderItem->setToolTip(
+                tr("<b>Sender</b>: This option specifies which sender nicknames match.  Leave "
+                   "blank to match any nickname."));
+    chanNameItem->setToolTip(
+                tr("<p><b>Channel</b>: Semicolon separated list of channel names.</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
+                   "would match on #foobar and on any channel starting with <i>#quassel</i> except "
+                   "for <i>#quasseldroid</i><br />"
+                   "<p>If only inverted names are specified, it will match anything except for "
+                   "what's specified (implicit wildcard).</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>!#quassel*; !#foobar</i><br />"
+                   "would match anything except for #foobar or any channel starting with "
+                   "<i>#quassel</i></p>"));
 
     int lastRow = ui.ignoredTable->rowCount() - 1;
     ui.ignoredTable->setItem(lastRow, CoreHighlightSettingsPage::NameColumn, nameItem);

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -57,6 +57,11 @@ CoreHighlightSettingsPage::CoreHighlightSettingsPage(QWidget *parent)
             this,
             SLOT(selectIgnoredRow(QTableWidgetItem * )));
 
+    // Update the "Case sensitive" checkbox
+    connect(ui.highlightNicksComboBox,
+            SIGNAL(currentIndexChanged(int)),
+            this,
+            SLOT(highlightNicksChanged(int)));
 
     connect(ui.highlightNicksComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(widgetHasChanged()));
     connect(ui.nicksCaseSensitive, SIGNAL(clicked(bool)), this, SLOT(widgetHasChanged()));
@@ -284,6 +289,12 @@ void CoreHighlightSettingsPage::removeSelectedIgnoredRows()
     }
 }
 
+void CoreHighlightSettingsPage::highlightNicksChanged(const int index) {
+    // Only allow toggling "Case sensitive" when a nickname will be highlighted
+    auto highlightNickType = ui.highlightNicksComboBox->itemData(index).value<int>();
+    ui.nicksCaseSensitive->setEnabled(highlightNickType != HighlightRuleManager::NoNick);
+}
+
 void CoreHighlightSettingsPage::selectHighlightRow(QTableWidgetItem *item)
 {
     int row = item->row();
@@ -426,6 +437,8 @@ void CoreHighlightSettingsPage::load()
 
         int highlightNickType = ruleManager->highlightNick();
         ui.highlightNicksComboBox->setCurrentIndex(ui.highlightNicksComboBox->findData(QVariant(highlightNickType)));
+        // Trigger the initial update of nicksCaseSensitive being enabled or not
+        highlightNicksChanged(ui.highlightNicksComboBox->currentIndex());
         ui.nicksCaseSensitive->setChecked(ruleManager->nicksCaseSensitive());
 
         setChangedState(false);

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -591,6 +591,33 @@ void CoreHighlightSettingsPage::on_coreUnsupportedDetails_clicked()
 void CoreHighlightSettingsPage::importRules() {
     NotificationSettings notificationSettings;
 
+    const auto localHighlightList = notificationSettings.highlightList();
+
+    // Re-use translations of "Local Highlights" as this is a word-for-word reference, forcing all
+    // spaces to non-breaking
+    const QString localHighlightsName = tr("Local Highlights").replace(" ", "&nbsp;");
+
+    if (localHighlightList.count() == 0) {
+        // No highlight rules exist to import, do nothing
+        QMessageBox::information(this,
+                                 tr("No local highlights"),
+                                 tr("No highlight rules in <i>%1</i>."
+                                    ).arg(localHighlightsName));
+        return;
+    }
+
+    int ret = QMessageBox::question(this,
+                                    tr("Import local highlights?"),
+                                    tr("Import all highlight rules from <i>%1</i>?"
+                                       ).arg(localHighlightsName),
+                                    QMessageBox::Yes|QMessageBox::No,
+                                    QMessageBox::No);
+
+    if (ret == QMessageBox::No) {
+        // Only two options, Yes or No, just return if No
+        return;
+    }
+
     auto clonedManager = HighlightRuleManager();
     clonedManager.fromVariantMap(Client::highlightRuleManager()->toVariantMap());
 
@@ -611,6 +638,12 @@ void CoreHighlightSettingsPage::importRules() {
     Client::highlightRuleManager()->requestUpdate(clonedManager.toVariantMap());
     setChangedState(false);
     load();
+
+    // Give a heads-up that all succeeded
+    QMessageBox::information(this,
+                             tr("Imported local highlights"),
+                             tr("%1 highlight rules successfully imported."
+                                ).arg(QString::number(localHighlightList.count())));
 }
 
 bool CoreHighlightSettingsPage::isSelectable() const {

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -105,29 +105,57 @@ void CoreHighlightSettingsPage::setupRuleTable(QTableWidget *table) const
     table->verticalHeader()->hide();
     table->setShowGrid(false);
 
+    table->horizontalHeaderItem(CoreHighlightSettingsPage::EnableColumn)->setToolTip(
+                tr("Enable/disable this rule"));
+    table->horizontalHeaderItem(CoreHighlightSettingsPage::EnableColumn)->setWhatsThis(
+                table->horizontalHeaderItem(CoreHighlightSettingsPage::EnableColumn)->toolTip());
+
+    table->horizontalHeaderItem(CoreHighlightSettingsPage::NameColumn)->setToolTip(
+                tr("Phrase to match"));
+    table->horizontalHeaderItem(CoreHighlightSettingsPage::NameColumn)->setWhatsThis(
+                table->horizontalHeaderItem(CoreHighlightSettingsPage::NameColumn)->toolTip());
+
     table->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->setToolTip(
-                tr("<b>RegEx</b>: This option determines if the highlight rule should be "
-                   "interpreted as a <b>regular expression</b> or just as a keyword."));
+                tr("<b>RegEx</b>: This option determines if the highlight rule, <i>Sender</i>, and "
+                   "<i>Channel</i> should be interpreted as <b>regular expressions</b> or just as "
+                   "keywords."));
     table->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->setWhatsThis(
                 table->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->toolTip());
 
     table->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->setToolTip(
-                tr("<b>CS</b>: This option determines if the highlight rule should be interpreted "
-                   "<b>case sensitive</b>."));
+                tr("<b>CS</b>: This option determines if the highlight rule, <i>Sender</i>, and "
+                   "<i>Channel</i> should be interpreted <b>case sensitive</b>."));
     table->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->setWhatsThis(
                 table->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->toolTip());
 
+    table->horizontalHeaderItem(CoreHighlightSettingsPage::SenderColumn)->setToolTip(
+                tr("<p><b>Sender</b>: Semicolon separated list of <i>nick!ident@host</i> names, "
+                   "leave blank to match any nickname.</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>Alice!*; Bob!*@example.com; Carol*!*; !Caroline!*</i><br />"
+                   "would match on <i>Alice</i>, <i>Bob</i> with hostmask <i>example.com</i>, and "
+                   "any nickname starting with <i>Carol</i> except for <i>Caroline</i><br />"
+                   "<p>If only inverted names are specified, it will match anything except for "
+                   "what's specified (implicit wildcard).</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>!Announce*!*; !Wheatley!aperture@*</i><br />"
+                   "would match anything except for <i>Wheatley</i> with ident <i>aperture</i> or "
+                   "any nickname starting with <i>Announce</i></p>"));
+    table->horizontalHeaderItem(CoreHighlightSettingsPage::SenderColumn)->setWhatsThis(
+                table->horizontalHeaderItem(CoreHighlightSettingsPage::SenderColumn)->toolTip());
+
     table->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->setToolTip(
-                tr("<p><b>Channel</b>: Semicolon separated list of channel names.</p>"
+                tr("<p><b>Channel</b>: Semicolon separated list of channel names, leave blank to "
+                   "match any name.</p>"
                    "<p><i>Example:</i><br />"
                    "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
-                   "would match on #foobar and on any channel starting with <i>#quassel</i> except "
-                   "for <i>#quasseldroid</i><br />"
+                   "would match on <i>#foobar</i> and any channel starting with <i>#quassel</i> "
+                   "except for <i>#quasseldroid</i><br />"
                    "<p>If only inverted names are specified, it will match anything except for "
                    "what's specified (implicit wildcard).</p>"
                    "<p><i>Example:</i><br />"
                    "<i>!#quassel*; !#foobar</i><br />"
-                   "would match anything except for #foobar or any channel starting with "
+                   "would match anything except for <i>#foobar</i> or any channel starting with "
                    "<i>#quassel</i></p>"));
     table->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->setWhatsThis(
                 table->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->toolTip());
@@ -221,32 +249,44 @@ void CoreHighlightSettingsPage::addNewHighlightRow(bool enable, const QString &n
         enableItem->setCheckState(Qt::Unchecked);
     enableItem->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
 
-    auto *chanNameItem = new QTableWidgetItem(chanName);
-
     auto *senderItem = new QTableWidgetItem(sender);
+
+    auto *chanNameItem = new QTableWidgetItem(chanName);
 
     enableItem->setToolTip(tr("Enable/disable this rule"));
     nameItem->setToolTip(tr("Phrase to match"));
     regexItem->setToolTip(
-                tr("<b>RegEx</b>: This option determines if the highlight rule should be "
-                   "interpreted as a <b>regular expression</b> or just as a keyword."));
+                tr("<b>RegEx</b>: This option determines if the highlight rule, <i>Sender</i>, and "
+                   "<i>Channel</i> should be interpreted as <b>regular expressions</b> or just as "
+                   "keywords."));
     csItem->setToolTip(
-                tr("<b>CS</b>: This option determines if the highlight rule should be interpreted "
-                   "<b>case sensitive</b>."));
+                tr("<b>CS</b>: This option determines if the highlight rule, <i>Sender</i>, and "
+                   "<i>Channel</i> should be interpreted <b>case sensitive</b>."));
     senderItem->setToolTip(
-                tr("<b>Sender</b>: This option specifies which sender to match.  Leave blank to "
-                   "match any nickname."));
+                tr("<p><b>Sender</b>: Semicolon separated list of <i>nick!ident@host</i> names, "
+                   "leave blank to match any nickname.</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>Alice!*; Bob!*@example.com; Carol*!*; !Caroline!*</i><br />"
+                   "would match on <i>Alice</i>, <i>Bob</i> with hostmask <i>example.com</i>, and "
+                   "any nickname starting with <i>Carol</i> except for <i>Caroline</i><br />"
+                   "<p>If only inverted names are specified, it will match anything except for "
+                   "what's specified (implicit wildcard).</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>!Announce*!*; !Wheatley!aperture@*</i><br />"
+                   "would match anything except for <i>Wheatley</i> with ident <i>aperture</i> or "
+                   "any nickname starting with <i>Announce</i></p>"));
     chanNameItem->setToolTip(
-                tr("<p><b>Channel</b>: Semicolon separated list of channel names.</p>"
+                tr("<p><b>Channel</b>: Semicolon separated list of channel names, leave blank to "
+                   "match any name.</p>"
                    "<p><i>Example:</i><br />"
                    "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
-                   "would match on #foobar and on any channel starting with <i>#quassel</i> except "
-                   "for <i>#quasseldroid</i><br />"
+                   "would match on <i>#foobar</i> and any channel starting with <i>#quassel</i> "
+                   "except for <i>#quasseldroid</i><br />"
                    "<p>If only inverted names are specified, it will match anything except for "
                    "what's specified (implicit wildcard).</p>"
                    "<p><i>Example:</i><br />"
                    "<i>!#quassel*; !#foobar</i><br />"
-                   "would match anything except for #foobar or any channel starting with "
+                   "would match anything except for <i>#foobar</i> or any channel starting with "
                    "<i>#quassel</i></p>"));
 
     int lastRow = ui.highlightTable->rowCount() - 1;
@@ -310,7 +350,7 @@ void CoreHighlightSettingsPage::addNewIgnoredRow(bool enable, const QString &nam
                 tr("<p><b>Channel</b>: Semicolon separated list of channel names.</p>"
                    "<p><i>Example:</i><br />"
                    "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
-                   "would match on #foobar and on any channel starting with <i>#quassel</i> except "
+                   "would match on #foobar and any channel starting with <i>#quassel</i> except "
                    "for <i>#quasseldroid</i><br />"
                    "<p>If only inverted names are specified, it will match anything except for "
                    "what's specified (implicit wildcard).</p>"

--- a/src/qtui/settingspages/corehighlightsettingspage.h
+++ b/src/qtui/settingspages/corehighlightsettingspage.h
@@ -62,6 +62,12 @@ private slots:
     void highlightTableChanged(QTableWidgetItem *item);
     void ignoredTableChanged(QTableWidgetItem *item);
 
+    /** Import local Highlight rules into the Core Highlight rules
+     *
+     * Iterates through all local highlight rules, converting each into core-side highlight rules.
+     */
+    void importRules();
+
 private:
     Ui::CoreHighlightSettingsPage ui;
 
@@ -82,8 +88,6 @@ private:
     void emptyIgnoredTable();
 
     void setupRuleTable(QTableWidget *highlightTable) const;
-
-    void importRules();
 
     bool _initialized;
 };

--- a/src/qtui/settingspages/corehighlightsettingspage.h
+++ b/src/qtui/settingspages/corehighlightsettingspage.h
@@ -56,6 +56,7 @@ private slots:
                           bool cs = false, const QString &sender = "", const QString &chanName = "", bool self = false);
     void removeSelectedHighlightRows();
     void removeSelectedIgnoredRows();
+    void highlightNicksChanged(const int index);
     void selectHighlightRow(QTableWidgetItem *item);
     void selectIgnoredRow(QTableWidgetItem *item);
     void highlightTableChanged(QTableWidgetItem *item);

--- a/src/qtui/settingspages/corehighlightsettingspage.h
+++ b/src/qtui/settingspages/corehighlightsettingspage.h
@@ -68,6 +68,11 @@ private slots:
      */
     void importRules();
 
+    /**
+     * Event handler for core unspported Details button
+     */
+    void on_coreUnsupportedDetails_clicked();
+
 private:
     Ui::CoreHighlightSettingsPage ui;
 
@@ -88,6 +93,15 @@ private:
     void emptyIgnoredTable();
 
     void setupRuleTable(QTableWidget *highlightTable) const;
+
+    /** Update the UI to show core support for highlights
+     *
+     * Shows or hides the UI warnings around core-side highlights according to core connection and
+     * core feature support.
+     *
+     * @param state  True if connected to core, otherwise false
+     */
+    void updateCoreSupportStatus(bool state);
 
     bool _initialized;
 };

--- a/src/qtui/settingspages/corehighlightsettingspage.ui
+++ b/src/qtui/settingspages/corehighlightsettingspage.ui
@@ -161,8 +161,11 @@
             </item>
             <item>
              <widget class="QPushButton" name="highlightImport">
+              <property name="toolTip">
+               <string>Import highlight rules configured in &lt;i&gt;Local Highlights&lt;/i&gt;</string>
+              </property>
               <property name="text">
-               <string>Import</string>
+               <string>Import Local</string>
               </property>
              </widget>
             </item>
@@ -177,83 +180,92 @@
       <attribute name="title">
        <string>Highlight Ignore Rules</string>
       </attribute>
-      <layout class="QVBoxLayout" name="ignoredLayout">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
-        <widget class="QTableWidget" name="ignoredTable">
-         <property name="toolTip">
-          <string/>
+        <widget class="QGroupBox" name="ignoresBox">
+         <property name="title">
+          <string>Never Highlight For</string>
          </property>
-         <property name="styleSheet">
-          <string notr="true"/>
-         </property>
-         <column>
-          <property name="text">
-           <string>Enabled</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Rule</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>RegEx</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>CS</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Sender</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Channel</string>
-          </property>
-         </column>
+         <layout class="QVBoxLayout" name="ignoredLayout">
+          <item>
+           <widget class="QTableWidget" name="ignoredTable">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="styleSheet">
+             <string notr="true"/>
+            </property>
+            <column>
+             <property name="text">
+              <string>Enabled</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Rule</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>RegEx</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>CS</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Sender</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Channel</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="ignoredButtonBarLayout">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QPushButton" name="ignoredAdd">
+              <property name="text">
+               <string>Add</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="ignoredRemove">
+              <property name="text">
+               <string>Remove</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="ignoredButtonBarSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="ignoredButtonBarLayout">
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QPushButton" name="ignoredAdd">
-           <property name="text">
-            <string>Add</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="ignoredRemove">
-           <property name="text">
-            <string>Remove</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="ignoredButtonBarSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
        </item>
       </layout>
      </widget>

--- a/src/qtui/settingspages/corehighlightsettingspage.ui
+++ b/src/qtui/settingspages/corehighlightsettingspage.ui
@@ -15,260 +15,332 @@
   </property>
   <layout class="QVBoxLayout">
    <item>
-    <widget class="QTabWidget" name="tabWidget">
-     <property name="currentIndex">
+    <widget class="QFrame" name="coreUnsupportedWidget">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="highlightTab">
-      <attribute name="title">
-       <string>Highlight Rules</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <widget class="QGroupBox" name="nickBox">
-         <property name="title">
-          <string>Highlight Nicks</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QHBoxLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="coreUnsupportedIcon">
+        <property name="text">
+         <string notr="true">[icon]</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="coreUnsupportedLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Your Quassel core is too old to support remote highlights</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="coreUnsupportedDetails">
+        <property name="text">
+         <string>Details...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="highlightsConfigWidget" native="true">
+     <layout class="QVBoxLayout" name="highlightConfigLayout">
+     <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QTabWidget" name="tabWidget">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <widget class="QWidget" name="highlightTab">
+         <attribute name="title">
+          <string>Highlight Rules</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
-           <widget class="QComboBox" name="highlightNicksComboBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+           <widget class="QGroupBox" name="nickBox">
+            <property name="title">
+             <string>Highlight Nicks</string>
             </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="currentIndex">
-             <number>-1</number>
-            </property>
-            <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToContents</enum>
-            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QComboBox" name="highlightNicksComboBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="currentIndex">
+                <number>-1</number>
+               </property>
+               <property name="sizeAdjustPolicy">
+                <enum>QComboBox::AdjustToContents</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="nicksCaseSensitive">
+               <property name="text">
+                <string>Case sensitive</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="nicksCaseSensitive">
-            <property name="text">
-             <string>Case sensitive</string>
+           <widget class="QGroupBox" name="rulesBox">
+            <property name="title">
+             <string>Custom Highlights</string>
             </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
+            <layout class="QVBoxLayout" name="highlightLayout">
+             <item>
+              <widget class="QTableWidget" name="highlightTable">
+               <property name="toolTip">
+                <string/>
+               </property>
+               <property name="styleSheet">
+                <string notr="true"/>
+               </property>
+               <column>
+                <property name="text">
+                 <string>Enabled</string>
+                </property>
+               </column>
+               <column>
+                <property name="text">
+                 <string>Rule</string>
+                </property>
+               </column>
+               <column>
+                <property name="text">
+                 <string>RegEx</string>
+                </property>
+               </column>
+               <column>
+                <property name="text">
+                 <string>CS</string>
+                </property>
+               </column>
+               <column>
+                <property name="text">
+                 <string>Sender</string>
+                </property>
+               </column>
+               <column>
+                <property name="text">
+                 <string>Channel</string>
+                </property>
+               </column>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="highlightButtonBarLayout">
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QPushButton" name="highlightAdd">
+                 <property name="text">
+                  <string>Add</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="highlightRemove">
+                 <property name="text">
+                  <string>Remove</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="highlightButtonBarSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QPushButton" name="highlightImport">
+                 <property name="toolTip">
+                  <string>Import highlight rules configured in &lt;i&gt;Local Highlights&lt;/i&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Import Local</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
            </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="rulesBox">
-         <property name="title">
-          <string>Custom Highlights</string>
-         </property>
-         <layout class="QVBoxLayout" name="highlightLayout">
+        <widget class="QWidget" name="ignoredTab">
+         <attribute name="title">
+          <string>Highlight Ignore Rules</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
-           <widget class="QTableWidget" name="highlightTable">
-            <property name="toolTip">
-             <string/>
+           <widget class="QGroupBox" name="ignoresBox">
+            <property name="title">
+             <string>Never Highlight For</string>
             </property>
-            <property name="styleSheet">
-             <string notr="true"/>
-            </property>
-            <column>
-             <property name="text">
-              <string>Enabled</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Rule</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>RegEx</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>CS</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Sender</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Channel</string>
-             </property>
-            </column>
+            <layout class="QVBoxLayout" name="ignoredLayout">
+             <item>
+              <widget class="QTableWidget" name="ignoredTable">
+               <property name="toolTip">
+                <string/>
+               </property>
+               <property name="styleSheet">
+                <string notr="true"/>
+               </property>
+               <column>
+                <property name="text">
+                 <string>Enabled</string>
+                </property>
+               </column>
+               <column>
+                <property name="text">
+                 <string>Rule</string>
+                </property>
+               </column>
+               <column>
+                <property name="text">
+                 <string>RegEx</string>
+                </property>
+               </column>
+               <column>
+                <property name="text">
+                 <string>CS</string>
+                </property>
+               </column>
+               <column>
+                <property name="text">
+                 <string>Sender</string>
+                </property>
+               </column>
+               <column>
+                <property name="text">
+                 <string>Channel</string>
+                </property>
+               </column>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="ignoredButtonBarLayout">
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QPushButton" name="ignoredAdd">
+                 <property name="text">
+                  <string>Add</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="ignoredRemove">
+                 <property name="text">
+                  <string>Remove</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="ignoredButtonBarSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+            </layout>
            </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="highlightButtonBarLayout">
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QPushButton" name="highlightAdd">
-              <property name="text">
-               <string>Add</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="highlightRemove">
-              <property name="text">
-               <string>Remove</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="highlightButtonBarSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="highlightImport">
-              <property name="toolTip">
-               <string>Import highlight rules configured in &lt;i&gt;Local Highlights&lt;/i&gt;</string>
-              </property>
-              <property name="text">
-               <string>Import Local</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
           </item>
          </layout>
         </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="ignoredTab">
-      <attribute name="title">
-       <string>Highlight Ignore Rules</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <widget class="QGroupBox" name="ignoresBox">
-         <property name="title">
-          <string>Never Highlight For</string>
-         </property>
-         <layout class="QVBoxLayout" name="ignoredLayout">
-          <item>
-           <widget class="QTableWidget" name="ignoredTable">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="styleSheet">
-             <string notr="true"/>
-            </property>
-            <column>
-             <property name="text">
-              <string>Enabled</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Rule</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>RegEx</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>CS</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Sender</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Channel</string>
-             </property>
-            </column>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="ignoredButtonBarLayout">
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QPushButton" name="ignoredAdd">
-              <property name="text">
-               <string>Add</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="ignoredRemove">
-              <property name="text">
-               <string>Remove</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="ignoredButtonBarSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/src/qtui/settingspages/highlightsettingspage.cpp
+++ b/src/qtui/settingspages/highlightsettingspage.cpp
@@ -91,6 +91,13 @@ void HighlightSettingsPage::addNewRow(QString name, bool regex, bool cs, bool en
 {
     ui.highlightTable->setRowCount(ui.highlightTable->rowCount()+1);
 
+    QTableWidgetItem *enableItem = new QTableWidgetItem("");
+    if (enable)
+        enableItem->setCheckState(Qt::Checked);
+    else
+        enableItem->setCheckState(Qt::Unchecked);
+    enableItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
+
     QTableWidgetItem *nameItem = new QTableWidgetItem(name);
 
     QTableWidgetItem *regexItem = new QTableWidgetItem("");
@@ -107,20 +114,13 @@ void HighlightSettingsPage::addNewRow(QString name, bool regex, bool cs, bool en
         csItem->setCheckState(Qt::Unchecked);
     csItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
 
-    QTableWidgetItem *enableItem = new QTableWidgetItem("");
-    if (enable)
-        enableItem->setCheckState(Qt::Checked);
-    else
-        enableItem->setCheckState(Qt::Unchecked);
-    enableItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
-
     QTableWidgetItem *chanNameItem = new QTableWidgetItem(chanName);
 
     int lastRow = ui.highlightTable->rowCount()-1;
+    ui.highlightTable->setItem(lastRow, HighlightSettingsPage::EnableColumn, enableItem);
     ui.highlightTable->setItem(lastRow, HighlightSettingsPage::NameColumn, nameItem);
     ui.highlightTable->setItem(lastRow, HighlightSettingsPage::RegExColumn, regexItem);
     ui.highlightTable->setItem(lastRow, HighlightSettingsPage::CsColumn, csItem);
-    ui.highlightTable->setItem(lastRow, HighlightSettingsPage::EnableColumn, enableItem);
     ui.highlightTable->setItem(lastRow, HighlightSettingsPage::ChanColumn, chanNameItem);
 
     if (!self)
@@ -188,6 +188,9 @@ void HighlightSettingsPage::tableChanged(QTableWidgetItem *item)
 
     switch (item->column())
     {
+    case HighlightSettingsPage::EnableColumn:
+        highlightRule["Enable"] = (item->checkState() == Qt::Checked);
+        break;
     case HighlightSettingsPage::NameColumn:
         if (item->text() == "")
             item->setText(tr("this shouldn't be empty"));
@@ -198,9 +201,6 @@ void HighlightSettingsPage::tableChanged(QTableWidgetItem *item)
         break;
     case HighlightSettingsPage::CsColumn:
         highlightRule["CS"] = (item->checkState() == Qt::Checked);
-        break;
-    case HighlightSettingsPage::EnableColumn:
-        highlightRule["Enable"] = (item->checkState() == Qt::Checked);
         break;
     case HighlightSettingsPage::ChanColumn:
         if (!item->text().isEmpty() && item->text().trimmed().isEmpty())

--- a/src/qtui/settingspages/highlightsettingspage.cpp
+++ b/src/qtui/settingspages/highlightsettingspage.cpp
@@ -33,14 +33,32 @@ HighlightSettingsPage::HighlightSettingsPage(QWidget *parent)
     ui.highlightTable->verticalHeader()->hide();
     ui.highlightTable->setShowGrid(false);
 
-    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::RegExColumn)->setToolTip("<b>RegEx</b>: This option determines if the highlight rule should be interpreted as a <b>regular expression</b> or just as a keyword.");
-    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::RegExColumn)->setWhatsThis("<b>RegEx</b>: This option determines if the highlight rule should be interpreted as a <b>regular expression</b> or just as a keyword.");
+    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::RegExColumn)->setToolTip(
+                tr("<b>RegEx</b>: This option determines if the highlight rule should be "
+                   "interpreted as a <b>regular expression</b> or just as a keyword."));
+    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::RegExColumn)->setWhatsThis(
+                ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::RegExColumn)->toolTip());
 
-    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::CsColumn)->setToolTip("<b>CS</b>: This option determines if the highlight rule should be interpreted <b>case sensitive</b>.");
-    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::CsColumn)->setWhatsThis("<b>CS</b>: This option determines if the highlight rule should be interpreted <b>case sensitive</b>.");
+    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::CsColumn)->setToolTip(
+                tr("<b>CS</b>: This option determines if the highlight rule should be interpreted "
+                   "<b>case sensitive</b>."));
+    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::CsColumn)->setWhatsThis(
+                ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::CsColumn)->toolTip());
 
-    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::ChanColumn)->setToolTip("<b>Channel</b>: This regular expression determines for which <b>channels</b> the highlight rule works. Leave blank to match any channel. Put <b>!</b> in the beginning to negate. Case insensitive.");
-    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::ChanColumn)->setWhatsThis("<b>Channel</b>: This regular expression determines for which <b>channels</b> the highlight rule works. Leave blank to match any channel. Put <b>!</b> in the beginning to negate. Case insensitive.");
+    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::ChanColumn)->setToolTip(
+                tr("<p><b>Channel</b>: Semicolon separated list of channel names.</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
+                   "would match on #foobar and on any channel starting with <i>#quassel</i> except "
+                   "for <i>#quasseldroid</i><br />"
+                   "<p>If only inverted names are specified, it will match anything except for "
+                   "what's specified (implicit wildcard).</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>!#quassel*; !#foobar</i><br />"
+                   "would match anything except for #foobar or any channel starting with "
+                   "<i>#quassel</i></p>"));
+    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::ChanColumn)->setWhatsThis(
+                ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::ChanColumn)->toolTip());
 
 #if QT_VERSION < 0x050000
     ui.highlightTable->horizontalHeader()->setResizeMode(HighlightSettingsPage::NameColumn, QHeaderView::Stretch);
@@ -115,6 +133,27 @@ void HighlightSettingsPage::addNewRow(QString name, bool regex, bool cs, bool en
     csItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
 
     QTableWidgetItem *chanNameItem = new QTableWidgetItem(chanName);
+
+    enableItem->setToolTip(tr("Enable/disable this rule"));
+    nameItem->setToolTip(tr("Phrase to match"));
+    regexItem->setToolTip(
+                tr("<b>RegEx</b>: This option determines if the highlight rule should be "
+                   "interpreted as a <b>regular expression</b> or just as a keyword."));
+    csItem->setToolTip(
+                tr("<b>CS</b>: This option determines if the highlight rule should be interpreted "
+                   "<b>case sensitive</b>."));
+    chanNameItem->setToolTip(
+                tr("<p><b>Channel</b>: Semicolon separated list of channel names.</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
+                   "would match on #foobar and on any channel starting with <i>#quassel</i> except "
+                   "for <i>#quasseldroid</i><br />"
+                   "<p>If only inverted names are specified, it will match anything except for "
+                   "what's specified (implicit wildcard).</p>"
+                   "<p><i>Example:</i><br />"
+                   "<i>!#quassel*; !#foobar</i><br />"
+                   "would match anything except for #foobar or any channel starting with "
+                   "<i>#quassel</i></p>"));
 
     int lastRow = ui.highlightTable->rowCount()-1;
     ui.highlightTable->setItem(lastRow, HighlightSettingsPage::EnableColumn, enableItem);

--- a/src/qtui/settingspages/highlightsettingspage.cpp
+++ b/src/qtui/settingspages/highlightsettingspage.cpp
@@ -34,29 +34,41 @@ HighlightSettingsPage::HighlightSettingsPage(QWidget *parent)
     ui.highlightTable->verticalHeader()->hide();
     ui.highlightTable->setShowGrid(false);
 
+
+    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::EnableColumn)->setToolTip(
+                tr("Enable/disable this rule"));
+    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::EnableColumn)->setWhatsThis(
+                ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::EnableColumn)->toolTip());
+
+    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::NameColumn)->setToolTip(
+                tr("Phrase to match"));
+    ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::NameColumn)->setWhatsThis(
+                ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::NameColumn)->toolTip());
+
     ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::RegExColumn)->setToolTip(
-                tr("<b>RegEx</b>: This option determines if the highlight rule should be "
-                   "interpreted as a <b>regular expression</b> or just as a keyword."));
+                tr("<b>RegEx</b>: This option determines if the highlight rule and <i>Channel</i> "
+                   "should be interpreted as <b>regular expressions</b> or just as keywords."));
     ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::RegExColumn)->setWhatsThis(
                 ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::RegExColumn)->toolTip());
 
     ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::CsColumn)->setToolTip(
-                tr("<b>CS</b>: This option determines if the highlight rule should be interpreted "
-                   "<b>case sensitive</b>."));
+                tr("<b>CS</b>: This option determines if the highlight rule and <i>Channel</i> "
+                   "should be interpreted <b>case sensitive</b>."));
     ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::CsColumn)->setWhatsThis(
                 ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::CsColumn)->toolTip());
 
     ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::ChanColumn)->setToolTip(
-                tr("<p><b>Channel</b>: Semicolon separated list of channel names.</p>"
+                tr("<p><b>Channel</b>: Semicolon separated list of channel names, leave blank to "
+                   "match any name.</p>"
                    "<p><i>Example:</i><br />"
                    "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
-                   "would match on #foobar and on any channel starting with <i>#quassel</i> except "
-                   "for <i>#quasseldroid</i><br />"
+                   "would match on <i>#foobar</i> and any channel starting with <i>#quassel</i> "
+                   "except for <i>#quasseldroid</i><br />"
                    "<p>If only inverted names are specified, it will match anything except for "
                    "what's specified (implicit wildcard).</p>"
                    "<p><i>Example:</i><br />"
                    "<i>!#quassel*; !#foobar</i><br />"
-                   "would match anything except for #foobar or any channel starting with "
+                   "would match anything except for <i>#foobar</i> or any channel starting with "
                    "<i>#quassel</i></p>"));
     ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::ChanColumn)->setWhatsThis(
                 ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::ChanColumn)->toolTip());
@@ -152,22 +164,23 @@ void HighlightSettingsPage::addNewRow(QString name, bool regex, bool cs, bool en
     enableItem->setToolTip(tr("Enable/disable this rule"));
     nameItem->setToolTip(tr("Phrase to match"));
     regexItem->setToolTip(
-                tr("<b>RegEx</b>: This option determines if the highlight rule should be "
-                   "interpreted as a <b>regular expression</b> or just as a keyword."));
+                tr("<b>RegEx</b>: This option determines if the highlight rule and <i>Channel</i> "
+                   "should be interpreted as <b>regular expressions</b> or just as keywords."));
     csItem->setToolTip(
-                tr("<b>CS</b>: This option determines if the highlight rule should be interpreted "
-                   "<b>case sensitive</b>."));
+                tr("<b>CS</b>: This option determines if the highlight rule and <i>Channel</i> "
+                   "should be interpreted <b>case sensitive</b>."));
     chanNameItem->setToolTip(
-                tr("<p><b>Channel</b>: Semicolon separated list of channel names.</p>"
+                tr("<p><b>Channel</b>: Semicolon separated list of channel names, leave blank to "
+                   "match any name.</p>"
                    "<p><i>Example:</i><br />"
                    "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
-                   "would match on #foobar and on any channel starting with <i>#quassel</i> except "
-                   "for <i>#quasseldroid</i><br />"
+                   "would match on <i>#foobar</i> and any channel starting with <i>#quassel</i> "
+                   "except for <i>#quasseldroid</i><br />"
                    "<p>If only inverted names are specified, it will match anything except for "
                    "what's specified (implicit wildcard).</p>"
                    "<p><i>Example:</i><br />"
                    "<i>!#quassel*; !#foobar</i><br />"
-                   "would match anything except for #foobar or any channel starting with "
+                   "would match anything except for <i>#foobar</i> or any channel starting with "
                    "<i>#quassel</i></p>"));
 
     int lastRow = ui.highlightTable->rowCount()-1;

--- a/src/qtui/settingspages/highlightsettingspage.h
+++ b/src/qtui/settingspages/highlightsettingspage.h
@@ -56,10 +56,10 @@ private:
     //    name:   QString
     //    enable: bool
     enum column {
-        NameColumn = 0,
-        RegExColumn = 1,
-        CsColumn = 2,
-        EnableColumn = 3,
+        EnableColumn = 0,
+        NameColumn = 1,
+        RegExColumn = 2,
+        CsColumn = 3,
         ChanColumn = 4,
         ColumnCount = 5
     };

--- a/src/qtui/settingspages/highlightsettingspage.h
+++ b/src/qtui/settingspages/highlightsettingspage.h
@@ -48,6 +48,11 @@ private slots:
     void selectRow(QTableWidgetItem *item);
     void tableChanged(QTableWidgetItem *item);
 
+    /**
+     * Event handler for Local Highlights Details button
+     */
+    void on_localHighlightsDetails_clicked();
+
 private:
     Ui::HighlightSettingsPage ui;
     QVariantList highlightList;

--- a/src/qtui/settingspages/highlightsettingspage.ui
+++ b/src/qtui/settingspages/highlightsettingspage.ui
@@ -30,6 +30,11 @@
         </property>
         <column>
          <property name="text">
+          <string>Enabled</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
           <string>Highlight</string>
          </property>
         </column>
@@ -41,11 +46,6 @@
         <column>
          <property name="text">
           <string>CS</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Enable</string>
          </property>
         </column>
         <column>

--- a/src/qtui/settingspages/highlightsettingspage.ui
+++ b/src/qtui/settingspages/highlightsettingspage.ui
@@ -138,6 +138,37 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <layout class="QHBoxLayout">
+     <item>
+      <widget class="QLabel" name="localHighlightsIcon">
+       <property name="text">
+        <string notr="true">[icon]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="localHighlightsLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Local Highlights apply to this device only</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="localHighlightsDetails">
+       <property name="text">
+        <string>Details...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/qtui/settingspages/ignorelisteditdlg.ui
+++ b/src/qtui/settingspages/ignorelisteditdlg.ui
@@ -184,9 +184,16 @@ Whenever you disable/delete the ignore rule, the messages are shown again.&lt;/p
 &lt;p&gt;A scope rule is a semicolon separated list of either &lt;i&gt;network&lt;/i&gt; or &lt;i&gt;channel&lt;/i&gt; names.&lt;/p&gt;
 &lt;p&gt;&lt;i&gt;Example:&lt;/i&gt;
 &lt;br /&gt;
-&lt;i&gt;#quassel*; #foobar&lt;/i&gt;
+&lt;i&gt;#quassel*; #foobar; !#quasseldroid&lt;/i&gt;
 &lt;br /&gt;
-would match on #foobar and on any channel starting with &lt;i&gt;#quassel&lt;/i&gt;&lt;/p&gt;</string>
+would match on #foobar and on any channel starting with &lt;i&gt;#quassel&lt;/i&gt; except for &lt;i&gt;#quasseldroid&lt;/i&gt;
+&lt;br /&gt;
+&lt;p&gt;If only inverted names are specified, it will match anything except for what's specified (implicit wildcard).&lt;/p&gt;
+&lt;p&gt;&lt;i&gt;Example:&lt;/i&gt;
+&lt;br /&gt;
+&lt;i&gt;!#quassel*; !#foobar&lt;/i&gt;
+&lt;br /&gt;
+would match anything except for #foobar or any channel starting with &lt;i&gt;#quassel&lt;/i&gt;&lt;/p&gt;</string>
         </property>
        </widget>
       </item>

--- a/src/qtui/settingspages/ignorelisteditdlg.ui
+++ b/src/qtui/settingspages/ignorelisteditdlg.ui
@@ -186,14 +186,14 @@ Whenever you disable/delete the ignore rule, the messages are shown again.&lt;/p
 &lt;br /&gt;
 &lt;i&gt;#quassel*; #foobar; !#quasseldroid&lt;/i&gt;
 &lt;br /&gt;
-would match on #foobar and on any channel starting with &lt;i&gt;#quassel&lt;/i&gt; except for &lt;i&gt;#quasseldroid&lt;/i&gt;
+would match on &lt;i&gt;#foobar&lt;/i&gt; and any channel starting with &lt;i&gt;#quassel&lt;/i&gt; except for &lt;i&gt;#quasseldroid&lt;/i&gt;
 &lt;br /&gt;
 &lt;p&gt;If only inverted names are specified, it will match anything except for what's specified (implicit wildcard).&lt;/p&gt;
 &lt;p&gt;&lt;i&gt;Example:&lt;/i&gt;
 &lt;br /&gt;
 &lt;i&gt;!#quassel*; !#foobar&lt;/i&gt;
 &lt;br /&gt;
-would match anything except for #foobar or any channel starting with &lt;i&gt;#quassel&lt;/i&gt;&lt;/p&gt;</string>
+would match anything except for &lt;i&gt;#foobar&lt;/i&gt; or any channel starting with &lt;i&gt;#quassel&lt;/i&gt;&lt;/p&gt;</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
## In short

* Unify highlight and ignore channel matching
  * Add `!` syntax to ignore list scope matching
  * Switch highlight rule scope matching to same as ignore list
  * Make `RegEx`, `CS` also apply to `Sender` and `Channel`
  * Breaks existing advanced highlight rules, but local rules are **migrated on upgrade**
  * Almost no functionality lost, see examples
* Highlight current nick by default on upgrade/new configuration
  * For remote highlights, specify `CurrentNick` as default
  * For local highlights, specify `NoNick` as default
* Fix up importing local highlights
  * Prompt before importing, show success afterwards
  * Fix import button not working
* Explain highlights and Local vs. Remote highlights
  * Add tool-tips to the highlight/ignore list box and other elements
  * Indicate 'local' is for this device only, encourage monolithic to use remote
  * Warn when remote highlights aren't supported
* Align list boxes when switching between `Highlight Rules` and `Highlight Ignore Rules`
  * Add a `QGroupBox` to `Highlight Ignore Rules`, labeled `Never Highlight For`
* Disable `Case sensitive` checkbox when highlight nicks is `None`
  * Reduces confusion as the checkbox does nothing if nicks aren't highlighted

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | User-facing polish, consistency, fixes bugs
Risk | ★★★ *3/3* | Changes highlight rule matching behavior, possible confusion
Intrusiveness | ★★☆ *2/3* | UI, string, core changes, may interfere with other PRs

*Depends on [pull request #317](https://github.com/quassel/quassel/pull/317 ) being merged.*

# Rationale
Quassel provides two different locations to reference channel names (technically buffer names), `Ignore List` and `Highlights` (both remote and local).  Before now, Quassel treated channel names differently according to where you configured them.

Instead, Quassel should unify the handling of channel names to reduce confusion.  In order to still provide regular expression functionality, the `RegEx` option should also apply to the channel column.  This will break any existing advanced highlight rules, but it simplifies the easier cases and no functionality is lost.

## Breaking changes
* `Channel` and `Sender` no longer use regular expressions by default
  * Change `Channel` and `Sender` to the simpler wildcard format
  * Check the `RegEx` box, modify `Rule` to also be a regular expression
  * **Existing rules automatically converted to `RegEx` format** if `Channel` is specified
* Case sensitivity now applies to `Channel` and `Sender`, not just `Rule`
  * Un/check the `CS` box to get all case-sensitive or all case-insensitive
  * **No longer possible to have a case-sensitive rule and case-insensitive `Channel` or `Sender`**

# Examples
## Scope Matching
### Unified Model (this pull request)
* Advantages
  * Makes common cases easy, already learned behavior
  * Shared logic between ignore list and highlight rules
* Disadvantages
  * No way to escape `;` or `!` in non-`RegEx` rules
  * Use of regular expressions tied to `RegEx`, requiring `Rule` to also be regex or not
  * Breaks existing highlight rule channel names, but they are automatically migrated
```
#quassel*; #ircv3; !#quasseldroid
al!*; Sput!*@quassel/developer/sput; Carol*!*; !Caroline!*
```
***Channel:*** *matches `#quassel...`, `#ircv3`, but not `#quasseldroid`*
***Sender:*** *matches `al`, `Sput` with hostmask `quassel/developer/sput`, and `Carol...` but not `Caroline`*
```
!#quassel*; !#ircv3
!Announce*!*; !Wheatley!aperture@*
```
***Channel:*** *matches anything except for `#quassel...` or `#ircv3` (implicit wildcard)*
***Sender:*** *matches anything except for `Announce...` or `Wheatley` with ident `aperture` (implicit wildcard)*

### Ignore List (before)
* Advantages
  * Simpler to manage common cases
  * Already learned behavior
* Disadvantages
  * No invert-match `!`
  * No advanced regular expressions
  * No way to escape `;` in rules
```
#quassel*; #ircv3
```

### Highlight Rules (before)
*Includes highlight ignore rules and local highlights*
```
(#quassel.*|#ircv3)
!#quasseldroid
```

## Local and Remote Highlights guidance
### Local Highlights
*In Settings → Interface → Local Highlights, information bar at bottom and "Details…" dialog*
![Settings - Local Highlights - Details dialog, showing Local Highlight vs. Remote Highlights](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-core-highlight-polish/Settings%20-%20Local%20Highlights%20-%20explanation%20v2.png#v1 )
> *:information_source: Local Highlights apply to this device only*
> 
> Dialog:
> **Local highlights apply to this device only**
> Highlights configured on this page only apply to your current device.
> Configure highlights for all of your devices in *Remote Highlights*.

### Local Highlights (Monolithic)
**For the monolithic build only**
*In Settings → Interface → Local Highlights, information bar at bottom and "Details…" dialog*
![Settings - Local Highlights - Details dialog, showing Local Highlight vs. Remote Highlights](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-core-highlight-polish/Settings%20-%20Local%20Highlights%20-%20explanation%20v2%20monolithic.png#v1 )
> *:information_source: Local Highlights are replaced by Remote Highlights*
> 
> Dialog:
> **Local Highlights are replaced by Remote Highlights**
> These highlights will keep working for now, but you should move to the improved highlight rules when you can.
> Configure the new style of highlights in *Remote Highlights*.

### Remote Highlights unsupported
*In Settings → Interface → Remote Highlights, warning bar at top and "Details…" dialog*
![Settings - Remote Highlights - Details dialog, showing when Remote Highlights aren't supported](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-core-highlight-polish/Settings%20-%20Remote%20Highlights%20-%20explanation%20v2.png#v3 )
> *:warning: Your Quassel core is too old to support remote highlights*
> 
> Dialog:
> **Your Quassel core is too old to support remote highlights**
> You need a Quassel core v0.13.0 or newer to configure remote highlights.
> You can still configure highlights for this device only in *Local Highlights*.

### Remote Highlights importing Local
*In Settings → Interface → Remote Highlights, clicking the Import Local button*
![Settings - Remote Highlights - Import Local dialogs, showing the stages of an import](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-core-highlight-polish/Settings%20-%20Local%20Highlights%20-%20import%20dialogs.png#v1 )

*Asking to import*
> Import all highlight rules from *Local Highlights*?
> No | Yes

*Import done*
> `number` highlight rules successfully imported.

*Nothing to import*
> No highlight rules in *Local Highlights*.

### Highlight Rules tooltips
![Settings - Remote Highlights - showing different tooltips](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-core-highlight-polish/Settings%20-%20Highlight%20Tooltips%20v2%20-%20part%20A.png#v3 )

> * Enabled
>   * Enable/disable this rule
> * Rule
>   * Phrase to match
> * RegEx
>   * **RegEx**: This option determines if the highlight rule, *Sender*, and *Channel* should be interpreted as a **regular expressions** or just as keywords.
> * CS
>   * **CS**: This option determines if the highlight rule, *Sender*, and *Channel* should be interpreted as **case sensitive**.
> * Import Local (button at bottom)
>   * Import highlight rules configured in *Local Highlights*

![Settings - Remote Highlights - showing sender tooltip](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-core-highlight-polish/Settings%20-%20Highlight%20Tooltips%20v2%20-%20part%20B%20-%20sender.png#v1 )
*This one is long and shares most of the content from the channel tooltip below*

> **Sender**: Semicolon separated list of *nick!ident@host* names, leave blank to match any nickname.
> 
> *Example:*
> *Alice!\*; Bob!\*@example.com; Carol\*!\*; !Caroline!\**
> would match on *Alice*, *Bob* with hostmask *example.com*, and any nickname starting with *Carol* except for *Caroline*
> 
> If only inverted names are specified, it will match anything except for what's specified (implicit wildcard).
> 
> *Example:*
> *!Announce\*!\*; !Wheatley!aperture@\**
> would match anything except for *Wheatley* with ident *aperture* or any nickname starting with *Announce*

![Settings - Remote Highlights - showing channel tooltip](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-core-highlight-polish/Settings%20-%20Highlight%20Tooltips%20v2%20-%20part%20C%20-%20channel.png#v1 )
*This one is long and shares most of the content from the updated tooltip in the Ignore List window*

> **Channel**: Semicolon separated list of channel names, leave blank to match any name.
> 
> *Example:*
> *#quassel\*; #foobar; !#quasseldroid*
> would match on #foobar and any channel starting with *#quassel* except for *#quasseldroid*
> 
> If only inverted names are specified, it will match anything except for what's specified (implicit wildcard).
> 
> *Example:*
> *!#quassel\*; !#foobar*
> would match anything except for #foobar or any channel starting with *#quassel*

---

**To be done in a later pull request/future time:**
* Switch to a view model for highlight rules
  * Requires a `highlightrulemodel.cpp`, mimicking [`aliasesmodel.cpp`](https://github.com/quassel/quassel/blob/934fa4151f48fd12549fe0772cfbc995c6e63034/src/qtui/settingspages/aliasesmodel.cpp#L54-L74 ) and [`ignorelistmodel.cpp`](https://github.com/quassel/quassel/blob/934fa4151f48fd12549fe0772cfbc995c6e63034/src/qtui/settingspages/ignorelistmodel.cpp#L55-L86 )
* Hide `Local Highlights` page behind a `Manage local rules` button
  * Make `Local Highlights` into a dialog-able window, mimicking ignores
  * Move `Import` button into dialog behind `Manage local rules` button
  * Avoids confusing new users
  * Allows power-users to access old functionality
  * *Better naming?*