### PR TITLE
[Requires #340, #351] Support core-side filtering of backlog by type

### DIFF
--- a/src/common/backlogmanager.cpp
+++ b/src/common/backlogmanager.cpp
@@ -27,9 +27,20 @@ QVariantList BacklogManager::requestBacklog(BufferId bufferId, MsgId first, MsgI
     return QVariantList();
 }
 
+QVariantList BacklogManager::requestBacklogFiltered(BufferId bufferId, MsgId first, MsgId last, int limit, int additional, int type, int flags)
+{
+    REQUEST(ARG(bufferId), ARG(first), ARG(last), ARG(limit), ARG(additional), ARG(type), ARG(flags))
+    return QVariantList();
+}
 
 QVariantList BacklogManager::requestBacklogAll(MsgId first, MsgId last, int limit, int additional)
 {
     REQUEST(ARG(first), ARG(last), ARG(limit), ARG(additional))
+    return QVariantList();
+}
+
+QVariantList BacklogManager::requestBacklogAllFiltered(MsgId first, MsgId last, int limit, int additional, int type, int flags)
+{
+    REQUEST(ARG(first), ARG(last), ARG(limit), ARG(additional), ARG(type), ARG(flags))
     return QVariantList();
 }

--- a/src/common/backlogmanager.h
+++ b/src/common/backlogmanager.h
@@ -35,10 +35,14 @@ public:
 
 public slots:
     virtual QVariantList requestBacklog(BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0);
+    virtual QVariantList requestBacklogFiltered(BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0, int type = -1, int flags = -1);
     inline virtual void receiveBacklog(BufferId, MsgId, MsgId, int, int, QVariantList) {};
+    inline virtual void receiveBacklogFiltered(BufferId, MsgId, MsgId, int, int, int, int, QVariantList) {};
 
     virtual QVariantList requestBacklogAll(MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0);
+    virtual QVariantList requestBacklogAllFiltered(MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0, int type = -1, int flags = -1);
     inline virtual void receiveBacklogAll(MsgId, MsgId, int, int, QVariantList) {};
+    inline virtual void receiveBacklogAllFiltered(MsgId, MsgId, int, int, int, int, QVariantList) {};
 
 signals:
     void backlogRequested(BufferId, MsgId, MsgId, int, int);

--- a/src/common/message.cpp
+++ b/src/common/message.cpp
@@ -26,24 +26,31 @@
 
 #include <QDataStream>
 
-Message::Message(const BufferInfo &bufferInfo, Type type, const QString &contents, const QString &sender, const QString &senderPrefixes, Flags flags)
+Message::Message(const BufferInfo &bufferInfo, Type type, const QString &contents, const QString &sender,
+                 const QString &senderPrefixes, const QString &realName, const QString &avatarUrl, Flags flags)
     : _timestamp(QDateTime::currentDateTime().toUTC()),
     _bufferInfo(bufferInfo),
     _contents(contents),
     _sender(sender),
     _senderPrefixes(senderPrefixes),
+    _realName(realName),
+    _avatarUrl(avatarUrl),
     _type(type),
     _flags(flags)
 {
 }
 
 
-Message::Message(const QDateTime &ts, const BufferInfo &bufferInfo, Type type, const QString &contents, const QString &sender, const QString &senderPrefixes, Flags flags)
+Message::Message(const QDateTime &ts, const BufferInfo &bufferInfo, Type type, const QString &contents,
+                 const QString &sender, const QString &senderPrefixes, const QString &realName,
+                 const QString &avatarUrl, Flags flags)
     : _timestamp(ts),
     _bufferInfo(bufferInfo),
     _contents(contents),
     _sender(sender),
     _senderPrefixes(senderPrefixes),
+    _realName(realName),
+    _avatarUrl(avatarUrl),
     _type(type),
     _flags(flags)
 {
@@ -68,6 +75,12 @@ QDataStream &operator<<(QDataStream &out, const Message &msg)
 
     if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::SenderPrefixes))
         out << msg.senderPrefixes().toUtf8();
+
+    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::RichMessages))
+        out << msg.realName().toUtf8();
+
+    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::RichMessages))
+        out << msg.avatarUrl().toUtf8();
 
     out << msg.contents().toUtf8();
     return out;
@@ -107,6 +120,16 @@ QDataStream &operator>>(QDataStream &in, Message &msg)
         in >> senderPrefixes;
     msg._senderPrefixes = QString::fromUtf8(senderPrefixes);
 
+    QByteArray realName;
+    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::RichMessages))
+        in >> realName;
+    msg._realName = QString::fromUtf8(realName);
+
+    QByteArray avatarUrl;
+    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::RichMessages))
+        in >> avatarUrl;
+    msg._avatarUrl = QString::fromUtf8(avatarUrl);
+
     QByteArray contents;
     in >> contents;
     msg._contents = QString::fromUtf8(contents);
@@ -120,7 +143,9 @@ QDebug operator<<(QDebug dbg, const Message &msg)
     dbg.nospace() << qPrintable(QString("Message(MsgId:")) << msg.msgId()
     << qPrintable(QString(",")) << msg.timestamp()
     << qPrintable(QString(", Type:")) << msg.type()
+    << qPrintable(QString(", RealName:")) << msg.realName()
+    << qPrintable(QString(", AvatarURL:")) << msg.avatarUrl()
     << qPrintable(QString(", Flags:")) << msg.flags() << qPrintable(QString(")"))
-    << msg.sender() << ":" << msg.contents();
+    << msg.senderPrefixes() << msg.sender() << ":" << msg.contents();
     return dbg;
 }

--- a/src/common/message.cpp
+++ b/src/common/message.cpp
@@ -76,11 +76,10 @@ QDataStream &operator<<(QDataStream &out, const Message &msg)
     if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::SenderPrefixes))
         out << msg.senderPrefixes().toUtf8();
 
-    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::RichMessages))
+    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::RichMessages)) {
         out << msg.realName().toUtf8();
-
-    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::RichMessages))
         out << msg.avatarUrl().toUtf8();
+    }
 
     out << msg.contents().toUtf8();
     return out;
@@ -121,13 +120,12 @@ QDataStream &operator>>(QDataStream &in, Message &msg)
     msg._senderPrefixes = QString::fromUtf8(senderPrefixes);
 
     QByteArray realName;
-    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::RichMessages))
-        in >> realName;
-    msg._realName = QString::fromUtf8(realName);
-
     QByteArray avatarUrl;
-    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::RichMessages))
+    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::RichMessages)) {
+        in >> realName;
         in >> avatarUrl;
+    }
+    msg._realName = QString::fromUtf8(realName);
     msg._avatarUrl = QString::fromUtf8(avatarUrl);
 
     QByteArray contents;

--- a/src/common/message.h
+++ b/src/common/message.h
@@ -68,10 +68,11 @@ public:
     Q_DECLARE_FLAGS(Flags, Flag)
 
     Message(const BufferInfo &bufferInfo = BufferInfo(), Type type = Plain, const QString &contents = {},
-            const QString &sender = {}, const QString &senderPrefixes = {}, Flags flags = None);
+            const QString &sender = {}, const QString &senderPrefixes = {}, const QString &realName = {},
+            const QString &avatarUrl = {}, Flags flags = None);
     Message(const QDateTime &ts, const BufferInfo &buffer = BufferInfo(), Type type = Plain,
             const QString &contents = {}, const QString &sender = {}, const QString &senderPrefixes = {},
-            Flags flags = None);
+            const QString &realName = {}, const QString &avatarUrl = {}, Flags flags = None);
 
     inline static Message ChangeOfDay(const QDateTime &day) { return Message(day, BufferInfo(), DayChange); }
     inline const MsgId &msgId() const { return _msgId; }
@@ -83,6 +84,8 @@ public:
     inline const QString &contents() const { return _contents; }
     inline const QString &sender() const { return _sender; }
     inline const QString &senderPrefixes() const { return _senderPrefixes; }
+    inline const QString &realName() const { return _realName; }
+    inline const QString &avatarUrl() const { return _avatarUrl; }
     inline Type type() const { return _type; }
     inline Flags flags() const { return _flags; }
     inline void setFlags(Flags flags) { _flags = flags; }
@@ -99,6 +102,8 @@ private:
     QString _contents;
     QString _sender;
     QString _senderPrefixes;
+    QString _realName;
+    QString _avatarUrl;
     Type _type;
     Flags _flags;
 

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -131,6 +131,7 @@ public:
         SenderPrefixes,           ///< Show prefixes for senders in backlog
         RemoteDisconnect,         ///< Allow this peer to be remotely disconnected
         ExtendedFeatures,         ///< Extended features
+        LongMessageTime,          ///< Serialize message time as 64-bit
 #if QT_VERSION >= 0x050500
         EcdsaCertfpKeys,          ///< ECDSA keys for CertFP in identities
 #endif

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -132,6 +132,7 @@ public:
         RemoteDisconnect,         ///< Allow this peer to be remotely disconnected
         ExtendedFeatures,         ///< Extended features
         LongMessageTime,          ///< Serialize message time as 64-bit
+        RichMessages,             ///< Real Name and Avatar URL in backlog
 #if QT_VERSION >= 0x050500
         EcdsaCertfpKeys,          ///< ECDSA keys for CertFP in identities
 #endif

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -133,6 +133,7 @@ public:
         ExtendedFeatures,         ///< Extended features
         LongMessageTime,          ///< Serialize message time as 64-bit
         RichMessages,             ///< Real Name and Avatar URL in backlog
+        BacklogFilterType,        ///< Backlogmanager supports filtering backlog by messagetype
 #if QT_VERSION >= 0x050500
         EcdsaCertfpKeys,          ///< ECDSA keys for CertFP in identities
 #endif

--- a/src/core/SQL/PostgreSQL/insert_sender.sql
+++ b/src/core/SQL/PostgreSQL/insert_sender.sql
@@ -1,3 +1,3 @@
-INSERT INTO sender (sender)
-VALUES ($1)
+INSERT INTO sender (sender, realname, avatarurl)
+VALUES ($1, $2, $3)
 RETURNING senderid

--- a/src/core/SQL/PostgreSQL/migrate_write_sender.sql
+++ b/src/core/SQL/PostgreSQL/migrate_write_sender.sql
@@ -1,2 +1,2 @@
-INSERT INTO sender (senderid, sender)
-VALUES (?, ?)
+INSERT INTO sender (senderid, sender, realname, avatarurl)
+VALUES (?, ?, ?, ?)

--- a/src/core/SQL/PostgreSQL/select_messagesAll.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesAll.sql
@@ -1,4 +1,4 @@
-SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)

--- a/src/core/SQL/PostgreSQL/select_messagesAllNew.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesAllNew.sql
@@ -1,4 +1,4 @@
-SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)

--- a/src/core/SQL/PostgreSQL/select_messagesAllNew_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesAllNew_filtered.sql
@@ -1,0 +1,8 @@
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
+    AND backlog.messageid >= :firstmsg
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC

--- a/src/core/SQL/PostgreSQL/select_messagesAll_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesAll_filtered.sql
@@ -1,0 +1,9 @@
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
+    AND backlog.messageid >= :firstmsg
+    AND backlog.messageid < :lastmsg
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC

--- a/src/core/SQL/PostgreSQL/select_messagesNewerThan.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesNewerThan.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= $1

--- a/src/core/SQL/PostgreSQL/select_messagesNewerThan_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesNewerThan_filtered.sql
@@ -1,0 +1,10 @@
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.messageid >= :first
+AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :buffer)
+AND bufferid = :buffer
+AND backlog.type & :type != 0
+AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/PostgreSQL/select_messagesNewestK.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesNewestK.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE bufferid = $1

--- a/src/core/SQL/PostgreSQL/select_messagesNewestK_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesNewestK_filtered.sql
@@ -1,0 +1,9 @@
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE bufferid = :buffer
+AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :buffer)
+AND backlog.type & :type != 0
+AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/PostgreSQL/select_messagesRange.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesRange.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= $1

--- a/src/core/SQL/PostgreSQL/select_messagesRange_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesRange_filtered.sql
@@ -1,0 +1,10 @@
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.messageid >= :first
+    AND backlog.messageid < :last
+    AND bufferid = :buffer
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/PostgreSQL/select_senderid.sql
+++ b/src/core/SQL/PostgreSQL/select_senderid.sql
@@ -1,3 +1,3 @@
 SELECT senderid
 FROM sender
-WHERE sender = $1
+WHERE sender = $1 AND realname = $2 AND avatarurl = $3

--- a/src/core/SQL/PostgreSQL/setup_010_sender.sql
+++ b/src/core/SQL/PostgreSQL/setup_010_sender.sql
@@ -1,4 +1,6 @@
 CREATE TABLE sender ( -- THE SENDER OF IRC MESSAGES
        senderid serial NOT NULL PRIMARY KEY,
-       sender varchar(128) UNIQUE NOT NULL
-)
+       sender varchar(128) NOT NULL
+	   realname TEXT,
+	   avatarurl TEXT
+);

--- a/src/core/SQL/PostgreSQL/setup_010_sender.sql
+++ b/src/core/SQL/PostgreSQL/setup_010_sender.sql
@@ -1,6 +1,6 @@
 CREATE TABLE sender ( -- THE SENDER OF IRC MESSAGES
        senderid serial NOT NULL PRIMARY KEY,
-       sender varchar(128) NOT NULL
+       sender varchar(128) NOT NULL,
 	   realname TEXT,
 	   avatarurl TEXT
 );

--- a/src/core/SQL/PostgreSQL/setup_140_sender_idx.sql
+++ b/src/core/SQL/PostgreSQL/setup_140_sender_idx.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX sender_sender_realname_avatarurl_uindex ON sender(sender, realname, avatarurl);

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_000_update_sender_add_realname.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_000_update_sender_add_realname.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sender ADD realname TEXT NULL;

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_010_update_sender_add_avatarurl.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_010_update_sender_add_avatarurl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sender ADD avatarurl TEXT NULL;

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_020_update_sender_add_new_constraint.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_020_update_sender_add_new_constraint.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX sender_sender_realname_avatarurl_uindex ON sender(sender, realname, avatarurl);

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_030_upgrade_sender_drop_old_constraint.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_030_upgrade_sender_drop_old_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sender DROP CONSTRAINT sender_sender_key;

--- a/src/core/SQL/SQLite/insert_sender.sql
+++ b/src/core/SQL/SQLite/insert_sender.sql
@@ -1,2 +1,2 @@
-INSERT INTO sender (sender)
-VALUES (:sender)
+INSERT INTO sender (sender, realname, avatarurl)
+VALUES (:sender, :realname, :avatarurl)

--- a/src/core/SQL/SQLite/migrate_read_sender.sql
+++ b/src/core/SQL/SQLite/migrate_read_sender.sql
@@ -1,5 +1,4 @@
-SELECT senderid, sender
+SELECT senderid, sender, realname, avatarurl
 FROM sender
 WHERE senderid > ? AND senderid <= ?
 ORDER BY senderid ASC
-

--- a/src/core/SQL/SQLite/select_messagesAll.sql
+++ b/src/core/SQL/SQLite/select_messagesAll.sql
@@ -1,4 +1,4 @@
-SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)

--- a/src/core/SQL/SQLite/select_messagesAllNew.sql
+++ b/src/core/SQL/SQLite/select_messagesAllNew.sql
@@ -1,4 +1,4 @@
-SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)

--- a/src/core/SQL/SQLite/select_messagesAllNew_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesAllNew_filtered.sql
@@ -1,0 +1,9 @@
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
+    AND backlog.messageid >= :firstmsg
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesAll_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesAll_filtered.sql
@@ -1,0 +1,10 @@
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
+    AND backlog.messageid >= :firstmsg
+    AND backlog.messageid < :lastmsg
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesNewerThan.sql
+++ b/src/core/SQL/SQLite/select_messagesNewerThan.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= :firstmsg

--- a/src/core/SQL/SQLite/select_messagesNewerThan_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesNewerThan_filtered.sql
@@ -1,0 +1,10 @@
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.messageid >= :firstmsg
+    AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferid)
+    AND bufferid = :bufferid
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesNewestK.sql
+++ b/src/core/SQL/SQLite/select_messagesNewestK.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE bufferid = :bufferid

--- a/src/core/SQL/SQLite/select_messagesNewestK_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesNewestK_filtered.sql
@@ -1,0 +1,9 @@
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE bufferid = :bufferid
+AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferid)
+AND backlog.type & :type != 0
+AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesRange.sql
+++ b/src/core/SQL/SQLite/select_messagesRange.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE bufferid = :bufferid

--- a/src/core/SQL/SQLite/select_messagesRange_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesRange_filtered.sql
@@ -1,0 +1,10 @@
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE bufferid = :bufferid
+    AND backlog.messageid >= :firstmsg
+    AND backlog.messageid < :lastmsg
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/SQLite/setup_010_sender.sql
+++ b/src/core/SQL/SQLite/setup_010_sender.sql
@@ -1,6 +1,6 @@
 CREATE TABLE sender ( -- THE SENDER OF IRC MESSAGES
        senderid INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-       sender TEXT UNIQUE NOT NULL
-)
-
-	  
+       sender TEXT NOT NULL,
+       realname TEXT,
+       avatarurl TEXT
+);

--- a/src/core/SQL/SQLite/setup_150_sender_idx.sql
+++ b/src/core/SQL/SQLite/setup_150_sender_idx.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX sender_index ON sender(sender, realname, avatarurl);

--- a/src/core/SQL/SQLite/version/27/upgrade_000_create_sender_tmp.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_000_create_sender_tmp.sql
@@ -1,0 +1,1 @@
+CREATE TABLE sender_tmp (senderid INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, sender TEXT NOT NULL, realname TEXT, avatarurl TEXT);

--- a/src/core/SQL/SQLite/version/27/upgrade_010_copy_sender_sender_tmp.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_010_copy_sender_sender_tmp.sql
@@ -1,0 +1,1 @@
+INSERT INTO sender_tmp SELECT senderid, sender, NULL as realname, NULL as avatarurl FROM sender;

--- a/src/core/SQL/SQLite/version/27/upgrade_020_drop_sender.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_020_drop_sender.sql
@@ -1,0 +1,1 @@
+DROP TABLE sender;

--- a/src/core/SQL/SQLite/version/27/upgrade_030_rename_sender_tmp_sender.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_030_rename_sender_tmp_sender.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sender_tmp RENAME TO sender;

--- a/src/core/SQL/SQLite/version/27/upgrade_040_update_sender_add_realname_avatarurl.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_040_update_sender_add_realname_avatarurl.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX sender_index ON sender(sender, realname, avatarurl);

--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -584,3 +584,13 @@ bool AbstractSqlMigrationReader::transferMo(MigrationObject moType, T &mo)
     qDebug() << "Done.";
     return true;
 }
+
+uint qHash(const SenderData &key) {
+    return qHash(QString(key.sender + "\n" + key.realname + "\n" + key.avatarurl));
+}
+
+bool operator==(const SenderData &a, const SenderData &b) {
+    return a.sender == b.sender &&
+        a.realname == b.realname &&
+        a.avatarurl == b.avatarurl;
+}

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -118,6 +118,14 @@ private:
     QHash<QThread *, Connection *> _connectionPool;
 };
 
+struct SenderData {
+    QString sender;
+    QString realname;
+    QString avatarurl;
+
+    friend uint qHash(const SenderData &key);
+    friend bool operator==(const SenderData &a, const SenderData &b);
+};
 
 // ========================================
 //  AbstractSqlStorage::Connection
@@ -155,6 +163,8 @@ public:
     struct SenderMO {
         int senderId;
         QString sender;
+        QString realname;
+        QString avatarurl;
         SenderMO() : senderId(0) {}
     };
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -402,6 +402,22 @@ public:
     }
 
 
+    //! Request a certain number messages stored in a given buffer, matching certain filters
+    /** \param buffer   The buffer we request messages from
+     *  \param first    if != -1 return only messages with a MsgId >= first
+     *  \param last     if != -1 return only messages with a MsgId < last
+     *  \param limit    if != -1 limit the returned list to a max of \limit entries
+     *  \param type     The Message::Types that should be returned
+     *  \return The requested list of messages
+     */
+    static inline QList<Message> requestMsgsFiltered(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1,
+                                                     int limit = -1, Message::Types type = Message::Types{-1},
+                                                     Message::Flags flags = Message::Flags{-1})
+    {
+        return instance()->_storage->requestMsgsFiltered(user, bufferId, first, last, limit, type, flags);
+    }
+
+
     //! Request a certain number of messages across all buffers
     /** \param first    if != -1 return only messages with a MsgId >= first
      *  \param last     if != -1 return only messages with a MsgId < last
@@ -411,6 +427,21 @@ public:
     static inline QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1)
     {
         return instance()->_storage->requestAllMsgs(user, first, last, limit);
+    }
+
+
+    //! Request a certain number of messages across all buffers, matching certain filters
+    /** \param first    if != -1 return only messages with a MsgId >= first
+     *  \param last     if != -1 return only messages with a MsgId < last
+     *  \param limit    Max amount of messages
+     *  \param type     The Message::Types that should be returned
+     *  \return The requested list of messages
+     */
+    static inline QList<Message> requestAllMsgsFiltered(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1,
+                                                        Message::Types type = Message::Types{-1},
+                                                        Message::Flags flags = Message::Flags{-1})
+    {
+        return instance()->_storage->requestAllMsgsFiltered(user, first, last, limit, type, flags);
     }
 
 

--- a/src/core/corebacklogmanager.h
+++ b/src/core/corebacklogmanager.h
@@ -37,7 +37,11 @@ public:
 
 public slots:
     virtual QVariantList requestBacklog(BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0);
+    QVariantList requestBacklogFiltered(BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1,
+                                        int additional = 0, int type = -1, int flags = -1) override;
     virtual QVariantList requestBacklogAll(MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0);
+    QVariantList requestBacklogAllFiltered(MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0,
+                                           int type = -1, int flags = -1) override;
 
 private:
     CoreSession *_coreSession;

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -374,8 +374,9 @@ void CoreSession::processMessages()
             Q_ASSERT(!createBuffer);
             bufferInfo = Core::bufferInfo(user(), rawMsg.networkId, BufferInfo::StatusBuffer, "");
         }
-        Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender,
-                    senderPrefixes(rawMsg.sender, bufferInfo), rawMsg.flags);
+        Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender, senderPrefixes(rawMsg.sender, bufferInfo),
+                    realName(rawMsg.sender, rawMsg.networkId),  avatarUrl(rawMsg.sender, rawMsg.networkId),
+                    rawMsg.flags);
         if(Core::storeMessage(msg))
             emit displayMsg(msg);
     }
@@ -399,8 +400,9 @@ void CoreSession::processMessages()
                 }
                 bufferInfoCache[rawMsg.networkId][rawMsg.target] = bufferInfo;
             }
-            Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender,
-                        senderPrefixes(rawMsg.sender, bufferInfo), rawMsg.flags);
+            Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender, senderPrefixes(rawMsg.sender, bufferInfo),
+                        realName(rawMsg.sender, rawMsg.networkId),  avatarUrl(rawMsg.sender, rawMsg.networkId),
+                        rawMsg.flags);
             messages << msg;
         }
 
@@ -416,8 +418,9 @@ void CoreSession::processMessages()
                 // add the StatusBuffer to the Cache in case there are more Messages for the original target
                 bufferInfoCache[rawMsg.networkId][rawMsg.target] = bufferInfo;
             }
-            Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender,
-                        senderPrefixes(rawMsg.sender, bufferInfo), rawMsg.flags);
+            Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender, senderPrefixes(rawMsg.sender, bufferInfo),
+                        realName(rawMsg.sender, rawMsg.networkId),  avatarUrl(rawMsg.sender, rawMsg.networkId),
+                        rawMsg.flags);
             messages << msg;
         }
 
@@ -450,6 +453,27 @@ QString CoreSession::senderPrefixes(const QString &sender, const BufferInfo &buf
 
     const QString modes = currentChannel->userModes(nickFromMask(sender).toLower());
     return currentNetwork->modesToPrefixes(modes);
+}
+
+QString CoreSession::realName(const QString &sender, NetworkId networkId) const
+{
+    CoreNetwork *currentNetwork = network(networkId);
+    if (!currentNetwork) {
+        return {};
+    }
+
+    IrcUser *currentUser = currentNetwork->ircUser(nickFromMask(sender));
+    if (!currentUser) {
+        return {};
+    }
+
+    return currentUser->realName();
+}
+
+QString CoreSession::avatarUrl(const QString &sender, NetworkId networkId) const
+{
+    // Currently we do not have a way to retrieve this value yet.
+    return "";
 }
 
 Protocol::SessionState CoreSession::sessionState() const

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -238,6 +238,20 @@ private:
      * @param bufferInfo The BufferInfo object of the buffer
      */
     QString senderPrefixes(const QString &sender, const BufferInfo &bufferInfo) const;
+
+    /**
+     * This method obtains the realname of the message's sender.
+     * @param sender The hostmask of the sender
+     * @param networkId The network the user is on
+     */
+    QString realName(const QString &sender, NetworkId networkId) const;
+
+    /**
+     * This method obtains the avatar of the message's sender.
+     * @param sender The hostmask of the sender
+     * @param networkId The network the user is on
+     */
+    QString avatarUrl(const QString &sender, NetworkId networkId) const;
     QList<RawMessage> _messageQueue;
     bool _processMessages;
     CoreIgnoreListManager _ignoreListManager;

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1449,7 +1449,11 @@ bool PostgreSqlStorage::logMessage(Message &msg)
         return false;
     }
 
-    QSqlQuery getSenderIdQuery = executePreparedQuery("select_senderid", msg.sender(), db);
+    QVariantList senderParams;
+    senderParams << msg.sender()
+                 << msg.realName()
+                 << msg.avatarUrl();
+    QSqlQuery getSenderIdQuery = executePreparedQuery("select_senderid", senderParams, db);
     int senderId;
     if (getSenderIdQuery.first()) {
         senderId = getSenderIdQuery.value(0).toInt();
@@ -1458,11 +1462,11 @@ bool PostgreSqlStorage::logMessage(Message &msg)
         // it's possible that the sender was already added by another thread
         // since the insert might fail we're setting a savepoint
         savePoint("sender_sp1", db);
-        QSqlQuery addSenderQuery = executePreparedQuery("insert_sender", msg.sender(), db);
+        QSqlQuery addSenderQuery = executePreparedQuery("insert_sender", senderParams, db);
 
         if (addSenderQuery.lastError().isValid()) {
             rollbackSavePoint("sender_sp1", db);
-            getSenderIdQuery = executePreparedQuery("select_senderid", msg.sender(), db);
+            getSenderIdQuery = executePreparedQuery("select_senderid", senderParams, db);
             watchQuery(getSenderIdQuery);
             getSenderIdQuery.first();
             senderId = getSenderIdQuery.value(0).toInt();
@@ -1512,28 +1516,34 @@ bool PostgreSqlStorage::logMessages(MessageList &msgs)
     }
 
     QList<int> senderIdList;
-    QHash<QString, int> senderIds;
+    QHash<SenderData, int> senderIds;
     QSqlQuery addSenderQuery;
     QSqlQuery selectSenderQuery;;
     for (int i = 0; i < msgs.count(); i++) {
-        const QString &sender = msgs.at(i).sender();
+        auto &msg = msgs.at(i);
+        SenderData sender = { msg.sender(), msg.realName(), msg.avatarUrl() };
         if (senderIds.contains(sender)) {
             senderIdList << senderIds[sender];
             continue;
         }
 
-        selectSenderQuery = executePreparedQuery("select_senderid", sender, db);
+        QVariantList senderParams;
+        senderParams << sender.sender
+                     << sender.realname
+                     << sender.avatarurl;
+
+        selectSenderQuery = executePreparedQuery("select_senderid", senderParams, db);
         if (selectSenderQuery.first()) {
             senderIdList << selectSenderQuery.value(0).toInt();
             senderIds[sender] = selectSenderQuery.value(0).toInt();
         }
         else {
             savePoint("sender_sp", db);
-            addSenderQuery = executePreparedQuery("insert_sender", sender, db);
+            addSenderQuery = executePreparedQuery("insert_sender", senderParams, db);
             if (addSenderQuery.lastError().isValid()) {
                 // seems it was inserted meanwhile... by a different thread
                 rollbackSavePoint("sender_sp", db);
-                selectSenderQuery = executePreparedQuery("select_senderid", sender, db);
+                selectSenderQuery = executePreparedQuery("select_senderid", senderParams, db);
                 watchQuery(selectSenderQuery);
                 selectSenderQuery.first();
                 senderIdList << selectSenderQuery.value(0).toInt();
@@ -1637,9 +1647,11 @@ QList<Message> PostgreSqlStorage::requestMsgs(UserId user, BufferId bufferId, Ms
         Message msg(timestamp,
             bufferInfo,
             (Message::Type)query.value(2).toUInt(),
-            query.value(6).toString(),
+            query.value(8).toString(),
             query.value(4).toString(),
             query.value(5).toString(),
+            query.value(6).toString(),
+            query.value(7).toString(),
             (Message::Flags)query.value(3).toUInt());
         msg.setMsgId(query.value(0).toInt());
         messagelist << msg;
@@ -1690,9 +1702,11 @@ QList<Message> PostgreSqlStorage::requestAllMsgs(UserId user, MsgId first, MsgId
         Message msg(timestamp,
             bufferInfoHash[query.value(1).toInt()],
             (Message::Type)query.value(3).toUInt(),
-            query.value(7).toString(),
+            query.value(9).toString(),
             query.value(5).toString(),
             query.value(6).toString(),
+            query.value(7).toString(),
+            query.value(8).toString(),
             (Message::Flags)query.value(4).toUInt());
         msg.setMsgId(query.value(0).toInt());
         messagelist << msg;
@@ -1967,6 +1981,8 @@ bool PostgreSqlMigrationWriter::writeMo(const SenderMO &sender)
 {
     bindValue(0, sender.senderId);
     bindValue(1, sender.sender);
+    bindValue(2, sender.realname);
+    bindValue(3, sender.avatarurl);
     return exec();
 }
 

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1662,6 +1662,70 @@ QList<Message> PostgreSqlStorage::requestMsgs(UserId user, BufferId bufferId, Ms
 }
 
 
+QList<Message> PostgreSqlStorage::requestMsgsFiltered(UserId user, BufferId bufferId, MsgId first, MsgId last, int limit, Message::Types type, Message::Flags flags)
+{
+    QList<Message> messagelist;
+
+    QSqlDatabase db = logDb();
+    if (!beginReadOnlyTransaction(db)) {
+        qWarning() << "PostgreSqlStorage::requestMsgs(): cannot start read only transaction!";
+        qWarning() << " -" << qPrintable(db.lastError().text());
+        return messagelist;
+    }
+
+    BufferInfo bufferInfo = getBufferInfo(user, bufferId);
+    if (!bufferInfo.isValid()) {
+        db.rollback();
+        return messagelist;
+    }
+
+    QSqlQuery query(db);
+    if (last == -1 && first == -1) {
+        query.prepare(queryString("select_messagesNewestK_filtered"));
+    } else if (last == -1) {
+        query.prepare(queryString("select_messagesNewerThan_filtered"));
+        query.bindValue(":first", first.toInt());
+    } else {
+        query.prepare(queryString("select_messagesRange_filtered"));
+        query.bindValue(":last", last.toInt());
+        query.bindValue(":first", first.toInt());
+    }
+    query.bindValue(":buffer", bufferId.toInt());
+    query.bindValue(":limit", limit);
+    int typeRaw = type;
+    query.bindValue(":type", typeRaw);
+    int flagsRaw = flags;
+    query.bindValue(":flags", flagsRaw);
+
+    safeExec(query);
+    if (!watchQuery(query)) {
+        qDebug() << "select_messages failed";
+        db.rollback();
+        return messagelist;
+    }
+
+    QDateTime timestamp;
+    while (query.next()) {
+        timestamp = query.value(1).toDateTime();
+        timestamp.setTimeSpec(Qt::UTC);
+        Message msg(timestamp,
+                    bufferInfo,
+                    (Message::Type)query.value(2).toUInt(),
+                    query.value(8).toString(),
+                    query.value(4).toString(),
+                    query.value(5).toString(),
+                    query.value(6).toString(),
+                    query.value(7).toString(),
+                    Message::Flags{query.value(3).toInt()});
+        msg.setMsgId(query.value(0).toInt());
+        messagelist << msg;
+    }
+
+    db.commit();
+    return messagelist;
+}
+
+
 QList<Message> PostgreSqlStorage::requestAllMsgs(UserId user, MsgId first, MsgId last, int limit)
 {
     QList<Message> messagelist;
@@ -1716,6 +1780,67 @@ QList<Message> PostgreSqlStorage::requestAllMsgs(UserId user, MsgId first, MsgId
     return messagelist;
 }
 
+
+QList<Message> PostgreSqlStorage::requestAllMsgsFiltered(UserId user, MsgId first, MsgId last, int limit, Message::Types type, Message::Flags flags)
+{
+    QList<Message> messagelist;
+
+    // requestBuffers uses it's own transaction.
+    QHash<BufferId, BufferInfo> bufferInfoHash;
+            foreach(BufferInfo bufferInfo, requestBuffers(user)) {
+            bufferInfoHash[bufferInfo.bufferId()] = bufferInfo;
+        }
+
+    QSqlDatabase db = logDb();
+    if (!beginReadOnlyTransaction(db)) {
+        qWarning() << "PostgreSqlStorage::requestAllMsgs(): cannot start read only transaction!";
+        qWarning() << " -" << qPrintable(db.lastError().text());
+        return messagelist;
+    }
+
+    QSqlQuery query(db);
+    if (last == -1) {
+        query.prepare(queryString("select_messagesAllNew_filtered"));
+    }
+    else {
+        query.prepare(queryString("select_messagesAll_filtered"));
+        query.bindValue(":lastmsg", last.toInt());
+    }
+    query.bindValue(":userid", user.toInt());
+    query.bindValue(":firstmsg", first.toInt());
+
+    int typeRaw = type;
+    query.bindValue(":type", typeRaw);
+
+    int flagsRaw = flags;
+    query.bindValue(":flags", flagsRaw);
+
+    safeExec(query);
+    if (!watchQuery(query)) {
+        db.rollback();
+        return messagelist;
+    }
+
+    QDateTime timestamp;
+    for (int i = 0; i < limit && query.next(); i++) {
+        timestamp = query.value(2).toDateTime();
+        timestamp.setTimeSpec(Qt::UTC);
+        Message msg(timestamp,
+                    bufferInfoHash[query.value(1).toInt()],
+                    (Message::Type)query.value(3).toUInt(),
+                    query.value(9).toString(),
+                    query.value(5).toString(),
+                    query.value(6).toString(),
+                    query.value(7).toString(),
+                    query.value(8).toString(),
+                    Message::Flags{query.value(4).toInt()});
+        msg.setMsgId(query.value(0).toInt());
+        messagelist << msg;
+    }
+
+    db.commit();
+    return messagelist;
+}
 
 QMap<UserId, QString> PostgreSqlStorage::getAllAuthUserNames()
 {

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -103,7 +103,13 @@ public slots:
     bool logMessage(Message &msg) override;
     bool logMessages(MessageList &msgs) override;
     QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) override;
+    QList<Message> requestMsgsFiltered(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1,
+                                       int limit = -1, Message::Types type = Message::Types{-1},
+                                       Message::Flags flags = Message::Flags{-1}) override;
     QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
+    QList<Message> requestAllMsgsFiltered(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1,
+                                          Message::Types type = Message::Types{-1},
+                                          Message::Flags flags = Message::Flags{-1}) override;
 
     /* Sysident handling */
     QMap<UserId, QString> getAllAuthUserNames() override;

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -78,6 +78,7 @@
     <file>./SQL/PostgreSQL/setup_110_alter_sender_seq.sql</file>
     <file>./SQL/PostgreSQL/setup_120_alter_messageid_seq.sql</file>
     <file>./SQL/PostgreSQL/setup_130_function_lastmsgid.sql</file>
+    <file>./SQL/PostgreSQL/setup_140_sender_idx.sql</file>
     <file>./SQL/PostgreSQL/update_backlog_bufferid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_bufferactivity.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_lastseen.sql</file>
@@ -111,6 +112,10 @@
     <file>./SQL/PostgreSQL/version/22/upgrade_000_alter_quasseluser_add_authenticator.sql</file>
     <file>./SQL/PostgreSQL/version/23/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/PostgreSQL/version/24/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_000_update_sender_add_realname.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_010_update_sender_add_avatarurl.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_020_update_sender_add_new_constraint.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_030_upgrade_sender_drop_old_constraint.sql</file>
     <file>./SQL/SQLite/delete_backlog_by_uid.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_buffer.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_network.sql</file>
@@ -191,6 +196,7 @@
     <file>./SQL/SQLite/setup_120_user_setting.sql</file>
     <file>./SQL/SQLite/setup_130_identity.sql</file>
     <file>./SQL/SQLite/setup_140_identity_nick.sql</file>
+    <file>./SQL/SQLite/setup_150_sender_idx.sql</file>
     <file>./SQL/SQLite/update_backlog_bufferid.sql</file>
     <file>./SQL/SQLite/update_buffer_bufferactivity.sql</file>
     <file>./SQL/SQLite/update_buffer_lastseen.sql</file>
@@ -297,5 +303,10 @@
     <file>./SQL/SQLite/version/24/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/SQLite/version/25/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
     <file>./SQL/SQLite/version/26/upgrade_000_create_buffer_idx.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_000_create_sender_tmp.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_010_copy_sender_sender_tmp.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_020_drop_sender.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_030_rename_sender_tmp_sender.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_040_update_sender_add_realname_avatarurl.sql</file>
 </qresource>
 </RCC>

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -49,9 +49,14 @@
     <file>./SQL/PostgreSQL/select_internaluser.sql</file>
     <file>./SQL/PostgreSQL/select_messagesAll.sql</file>
     <file>./SQL/PostgreSQL/select_messagesAllNew.sql</file>
+    <file>./SQL/PostgreSQL/select_messagesAllNew_filtered.sql</file>
+    <file>./SQL/PostgreSQL/select_messagesAll_filtered.sql</file>
     <file>./SQL/PostgreSQL/select_messagesNewerThan.sql</file>
+    <file>./SQL/PostgreSQL/select_messagesNewerThan_filtered.sql</file>
     <file>./SQL/PostgreSQL/select_messagesNewestK.sql</file>
+    <file>./SQL/PostgreSQL/select_messagesNewestK_filtered.sql</file>
     <file>./SQL/PostgreSQL/select_messagesRange.sql</file>
+    <file>./SQL/PostgreSQL/select_messagesRange_filtered.sql</file>
     <file>./SQL/PostgreSQL/select_networkExists.sql</file>
     <file>./SQL/PostgreSQL/select_network_awaymsg.sql</file>
     <file>./SQL/PostgreSQL/select_network_usermode.sql</file>
@@ -166,9 +171,14 @@
     <file>./SQL/SQLite/select_internaluser.sql</file>
     <file>./SQL/SQLite/select_messagesAll.sql</file>
     <file>./SQL/SQLite/select_messagesAllNew.sql</file>
+    <file>./SQL/SQLite/select_messagesAllNew_filtered.sql</file>
+    <file>./SQL/SQLite/select_messagesAll_filtered.sql</file>
     <file>./SQL/SQLite/select_messagesNewerThan.sql</file>
+    <file>./SQL/SQLite/select_messagesNewerThan_filtered.sql</file>
     <file>./SQL/SQLite/select_messagesNewestK.sql</file>
+    <file>./SQL/SQLite/select_messagesNewestK_filtered.sql</file>
     <file>./SQL/SQLite/select_messagesRange.sql</file>
+    <file>./SQL/SQLite/select_messagesRange_filtered.sql</file>
     <file>./SQL/SQLite/select_networkExists.sql</file>
     <file>./SQL/SQLite/select_network_awaymsg.sql</file>
     <file>./SQL/SQLite/select_network_usermode.sql</file>

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1603,6 +1603,8 @@ bool SqliteStorage::logMessage(Message &msg)
                 QSqlQuery addSenderQuery(db);
                 addSenderQuery.prepare(queryString("insert_sender"));
                 addSenderQuery.bindValue(":sender", msg.sender());
+                addSenderQuery.bindValue(":realname", msg.realName());
+                addSenderQuery.bindValue(":avatarurl", msg.avatarUrl());
                 safeExec(addSenderQuery);
                 safeExec(logMessageQuery);
                 error = !watchQuery(logMessageQuery);
@@ -1640,17 +1642,20 @@ bool SqliteStorage::logMessages(MessageList &msgs)
     db.transaction();
 
     {
-        QSet<QString> senders;
+        QSet<SenderData> senders;
         QSqlQuery addSenderQuery(db);
         addSenderQuery.prepare(queryString("insert_sender"));
         lockForWrite();
         for (int i = 0; i < msgs.count(); i++) {
-            const QString &sender = msgs.at(i).sender();
+            auto &msg = msgs.at(i);
+            SenderData sender = { msg.sender(), msg.realName(), msg.avatarUrl() };
             if (senders.contains(sender))
                 continue;
             senders << sender;
 
-            addSenderQuery.bindValue(":sender", sender);
+            addSenderQuery.bindValue(":sender", sender.sender);
+            addSenderQuery.bindValue(":realname", sender.realname);
+            addSenderQuery.bindValue(":avatarurl", sender.avatarurl);
             safeExec(addSenderQuery);
         }
     }
@@ -1752,9 +1757,11 @@ QList<Message> SqliteStorage::requestMsgs(UserId user, BufferId bufferId, MsgId 
             Message msg(QDateTime::fromTime_t(query.value(1).toInt()),
                 bufferInfo,
                 (Message::Type)query.value(2).toUInt(),
-                query.value(6).toString(),
+                query.value(8).toString(),
                 query.value(4).toString(),
                 query.value(5).toString(),
+                query.value(6).toString(),
+                query.value(7).toString(),
                 (Message::Flags)query.value(3).toUInt());
             msg.setMsgId(query.value(0).toInt());
             messagelist << msg;
@@ -1807,9 +1814,11 @@ QList<Message> SqliteStorage::requestAllMsgs(UserId user, MsgId first, MsgId las
             Message msg(QDateTime::fromTime_t(query.value(2).toInt()),
                 bufferInfoHash[query.value(1).toInt()],
                 (Message::Type)query.value(3).toUInt(),
-                query.value(7).toString(),
+                query.value(9).toString(),
                 query.value(5).toString(),
                 query.value(6).toString(),
+                query.value(7).toString(),
+                query.value(8).toString(),
                 (Message::Flags)query.value(4).toUInt());
             msg.setMsgId(query.value(0).toInt());
             messagelist << msg;

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1774,6 +1774,82 @@ QList<Message> SqliteStorage::requestMsgs(UserId user, BufferId bufferId, MsgId 
 }
 
 
+QList<Message> SqliteStorage::requestMsgsFiltered(UserId user, BufferId bufferId, MsgId first, MsgId last, int limit, Message::Types type, Message::Flags flags)
+{
+    QList<Message> messagelist;
+
+    QSqlDatabase db = logDb();
+    db.transaction();
+
+    bool error = false;
+    BufferInfo bufferInfo;
+    {
+        // code dupication from getBufferInfo:
+        // this is due to the impossibility of nesting transactions and recursive locking
+        QSqlQuery bufferInfoQuery(db);
+        bufferInfoQuery.prepare(queryString("select_buffer_by_id"));
+        bufferInfoQuery.bindValue(":userid", user.toInt());
+        bufferInfoQuery.bindValue(":bufferid", bufferId.toInt());
+
+        lockForRead();
+        safeExec(bufferInfoQuery);
+        error = !watchQuery(bufferInfoQuery) || !bufferInfoQuery.first();
+        if (!error) {
+            bufferInfo = BufferInfo(bufferInfoQuery.value(0).toInt(), bufferInfoQuery.value(1).toInt(), (BufferInfo::Type)bufferInfoQuery.value(2).toInt(), 0, bufferInfoQuery.value(4).toString());
+            error = !bufferInfo.isValid();
+        }
+    }
+    if (error) {
+        db.rollback();
+        unlock();
+        return messagelist;
+    }
+
+    {
+        QSqlQuery query(db);
+        if (last == -1 && first == -1) {
+            query.prepare(queryString("select_messagesNewestK_filtered"));
+        }
+        else if (last == -1) {
+            query.prepare(queryString("select_messagesNewerThan_filtered"));
+            query.bindValue(":firstmsg", first.toInt());
+        }
+        else {
+            query.prepare(queryString("select_messagesRange_filtered"));
+            query.bindValue(":lastmsg", last.toInt());
+            query.bindValue(":firstmsg", first.toInt());
+        }
+        query.bindValue(":bufferid", bufferId.toInt());
+        query.bindValue(":limit", limit);
+        int typeRaw = type;
+        query.bindValue(":type", typeRaw);
+        int flagsRaw = flags;
+        query.bindValue(":flags", flagsRaw);
+
+        safeExec(query);
+        watchQuery(query);
+
+        while (query.next()) {
+            Message msg(QDateTime::fromTime_t(query.value(1).toInt()),
+                        bufferInfo,
+                        (Message::Type)query.value(2).toUInt(),
+                        query.value(8).toString(),
+                        query.value(4).toString(),
+                        query.value(5).toString(),
+                        query.value(6).toString(),
+                        query.value(7).toString(),
+                        Message::Flags{query.value(3).toInt()});
+            msg.setMsgId(query.value(0).toInt());
+            messagelist << msg;
+        }
+    }
+    db.commit();
+    unlock();
+
+    return messagelist;
+}
+
+
 QList<Message> SqliteStorage::requestAllMsgs(UserId user, MsgId first, MsgId last, int limit)
 {
     QList<Message> messagelist;
@@ -1829,6 +1905,64 @@ QList<Message> SqliteStorage::requestAllMsgs(UserId user, MsgId first, MsgId las
     return messagelist;
 }
 
+QList<Message> SqliteStorage::requestAllMsgsFiltered(UserId user, MsgId first, MsgId last, int limit, Message::Types type, Message::Flags flags)
+{
+    QList<Message> messagelist;
+
+    QSqlDatabase db = logDb();
+    db.transaction();
+
+    QHash<BufferId, BufferInfo> bufferInfoHash;
+    {
+        QSqlQuery bufferInfoQuery(db);
+        bufferInfoQuery.prepare(queryString("select_buffers"));
+        bufferInfoQuery.bindValue(":userid", user.toInt());
+
+        lockForRead();
+        safeExec(bufferInfoQuery);
+        watchQuery(bufferInfoQuery);
+        while (bufferInfoQuery.next()) {
+            BufferInfo bufferInfo = BufferInfo(bufferInfoQuery.value(0).toInt(), bufferInfoQuery.value(1).toInt(), (BufferInfo::Type)bufferInfoQuery.value(2).toInt(), bufferInfoQuery.value(3).toInt(), bufferInfoQuery.value(4).toString());
+            bufferInfoHash[bufferInfo.bufferId()] = bufferInfo;
+        }
+
+        QSqlQuery query(db);
+        if (last == -1) {
+            query.prepare(queryString("select_messagesAllNew_filtered"));
+        }
+        else {
+            query.prepare(queryString("select_messagesAll_filtered"));
+            query.bindValue(":lastmsg", last.toInt());
+        }
+        query.bindValue(":userid", user.toInt());
+        query.bindValue(":firstmsg", first.toInt());
+        query.bindValue(":limit", limit);
+        int typeRaw = type;
+        query.bindValue(":type", typeRaw);
+        int flagsRaw = flags;
+        query.bindValue(":flags", flagsRaw);
+        safeExec(query);
+
+        watchQuery(query);
+
+        while (query.next()) {
+            Message msg(QDateTime::fromTime_t(query.value(2).toInt()),
+                        bufferInfoHash[query.value(1).toInt()],
+                        (Message::Type)query.value(3).toUInt(),
+                        query.value(9).toString(),
+                        query.value(5).toString(),
+                        query.value(6).toString(),
+                        query.value(7).toString(),
+                        query.value(8).toString(),
+                        Message::Flags{query.value(4).toInt()});
+            msg.setMsgId(query.value(0).toInt());
+            messagelist << msg;
+        }
+    }
+    db.commit();
+    unlock();
+    return messagelist;
+}
 
 QMap<UserId, QString> SqliteStorage::getAllAuthUserNames()
 {

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -104,7 +104,13 @@ public slots:
     bool logMessage(Message &msg) override;
     bool logMessages(MessageList &msgs) override;
     QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) override;
+    QList<Message> requestMsgsFiltered(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1,
+                                       int limit = -1, Message::Types type = Message::Types{-1},
+                                       Message::Flags flags = Message::Flags{-1}) override;
     QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
+    QList<Message> requestAllMsgsFiltered(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1,
+                                          Message::Types type = Message::Types{-1},
+                                          Message::Flags flags = Message::Flags{-1}) override;
 
     /* Sysident handling */
     QMap<UserId, QString> getAllAuthUserNames() override;

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -434,6 +434,18 @@ public slots:
      */
     virtual QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) = 0;
 
+    //! Request a certain number messages stored in a given buffer, matching certain filters
+    /** \param buffer   The buffer we request messages from
+     *  \param first    if != -1 return only messages with a MsgId >= first
+     *  \param last     if != -1 return only messages with a MsgId < last
+     *  \param limit    if != -1 limit the returned list to a max of \limit entries
+     *  \param type     The Message::Types that should be returned
+     *  \return The requested list of messages
+     */
+    virtual QList<Message> requestMsgsFiltered(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1,
+                                               int limit = -1, Message::Types type = Message::Types{-1},
+                                               Message::Flags flags = Message::Flags{-1}) = 0;
+
     //! Request a certain number of messages across all buffers
     /** \param first    if != -1 return only messages with a MsgId >= first
      *  \param last     if != -1 return only messages with a MsgId < last
@@ -441,6 +453,17 @@ public slots:
      *  \return The requested list of messages
      */
     virtual QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) = 0;
+
+    //! Request a certain number of messages across all buffers, matching certain filters
+    /** \param first    if != -1 return only messages with a MsgId >= first
+     *  \param last     if != -1 return only messages with a MsgId < last
+     *  \param limit    Max amount of messages
+     *  \param type     The Message::Types that should be returned
+     *  \return The requested list of messages
+     */
+    virtual QList<Message> requestAllMsgsFiltered(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1,
+                                                  Message::Types type = Message::Types{-1},
+                                                  Message::Flags flags = Message::Flags{-1}) = 0;
 
     //! Fetch all authusernames
     /** \return      Map of all current UserIds to permitted idents


### PR DESCRIPTION
## In Short
* Introduces new sync calls into the backlogmanager:
  * `requestBacklogFiltered(BufferId bufferId, MsgId first, MsgId last, int limit, int additional, int type)`
  * `requestBacklogAllFiltered(MsgId first, MsgId last, int limit, int additional, int type)`
* Introduces a new version of each backlog loading query, which filters by type (with `backlog.type & :type != 0`)

## Status
- [x] Implement a new sync call
- [x] Implement SQL to support this call
- [ ] Make use of this call in the desktop client, optionally.

## Rationale
Currently when loading backlog with lots of types filtered in a channel with many joins/quits but little talk we need to load all the messages that will be filtered anyway. This is acceptable on desktop, but especially on mobile this leads to users being confused, or assuming the client is broken, when the client loads for many minutes without being able to show any loaded messages (as they are all filtered).

For this use case it is useful to support filtering messages on the core.

## Impact
All SQL changes are read-only, no schema upgrade is required. All changes are backwards compatible. No UI or client changes.