### PR TITLE
Avoid Y2038 problem

### DIFF
--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -127,6 +127,7 @@ public:
         SenderPrefixes,           ///< Show prefixes for senders in backlog
         RemoteDisconnect,         ///< Allow this peer to be remotely disconnected
         ExtendedFeatures,         ///< Extended features
+        LongMessageTime,          ///< Serialize message time as 64-bit
     };
     Q_ENUMS(Feature)
 


### PR DESCRIPTION
## In Short
* Add new feature flag for 64-bit time
* Serialize timestamp of messages as milliseconds since epoch

## Rationale
Currently, quassel will run into the year 2038 problem within of the next 20 years, this patch avoids that issue. Additionally, it allows higher accuracy of message times, which is something users have requested.

## Impact
This includes a major protocol change, guarded behind a feature flag. No UI or core changes are included.