### PR TITLE
Improve containerization

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -162,6 +162,7 @@ int main(int argc, char **argv)
     cliParser->addSwitch("syslog", 0, "Log to syslog");
 #endif
     cliParser->addOption("logfile", 'l', "Log to a file", "path");
+    cliParser->addSwitch("config-from-environment", 0, "Load configuration from environment variables");
     cliParser->addOption("select-backend", 0, "Switch storage backend (migrating data if possible)", "backendidentifier");
     cliParser->addOption("select-authenticator", 0, "Select authentication backend", "authidentifier");
     cliParser->addSwitch("add-user", 0, "Starts an interactive session to add a new core user");

--- a/src/core/SQL/PostgreSQL/insert_core_state.sql
+++ b/src/core/SQL/PostgreSQL/insert_core_state.sql
@@ -1,0 +1,2 @@
+INSERT INTO core_state (key, value)
+VALUES (:key, :value)

--- a/src/core/SQL/PostgreSQL/migrate_write_corestate.sql
+++ b/src/core/SQL/PostgreSQL/migrate_write_corestate.sql
@@ -1,0 +1,2 @@
+INSERT INTO core_state (key, value)
+VALUES (?, ?)

--- a/src/core/SQL/PostgreSQL/select_core_state.sql
+++ b/src/core/SQL/PostgreSQL/select_core_state.sql
@@ -1,0 +1,3 @@
+SELECT value
+FROM core_state
+WHERE key = :key

--- a/src/core/SQL/PostgreSQL/setup_140_corestate.sql
+++ b/src/core/SQL/PostgreSQL/setup_140_corestate.sql
@@ -1,0 +1,5 @@
+CREATE TABLE core_state (
+    key TEXT NOT NULL,
+    value bytea,
+    PRIMARY KEY (key)
+)

--- a/src/core/SQL/PostgreSQL/update_core_state.sql
+++ b/src/core/SQL/PostgreSQL/update_core_state.sql
@@ -1,0 +1,3 @@
+UPDATE core_state
+SET value = :value
+WHERE key = :key

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_000_create_corestate.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_000_create_corestate.sql
@@ -1,0 +1,5 @@
+CREATE TABLE core_state (
+    key TEXT NOT NULL,
+    value bytea,
+    PRIMARY KEY (key)
+)

--- a/src/core/SQL/SQLite/insert_core_state.sql
+++ b/src/core/SQL/SQLite/insert_core_state.sql
@@ -1,0 +1,2 @@
+INSERT INTO core_state (key, value)
+VALUES (:key, :value)

--- a/src/core/SQL/SQLite/migrate_read_corestate.sql
+++ b/src/core/SQL/SQLite/migrate_read_corestate.sql
@@ -1,0 +1,3 @@
+SELECT key, value
+FROM core_state
+

--- a/src/core/SQL/SQLite/select_core_state.sql
+++ b/src/core/SQL/SQLite/select_core_state.sql
@@ -1,0 +1,3 @@
+SELECT value
+FROM core_state
+WHERE key = :key

--- a/src/core/SQL/SQLite/setup_150_corestate.sql
+++ b/src/core/SQL/SQLite/setup_150_corestate.sql
@@ -1,0 +1,5 @@
+CREATE TABLE core_state (
+    key TEXT NOT NULL,
+    value bytea,
+    PRIMARY KEY (key)
+)

--- a/src/core/SQL/SQLite/update_core_state.sql
+++ b/src/core/SQL/SQLite/update_core_state.sql
@@ -1,0 +1,3 @@
+UPDATE core_state
+SET value = :value
+WHERE key = :key

--- a/src/core/SQL/SQLite/version/27/upgrade_000_create_corestate.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_000_create_corestate.sql
@@ -1,0 +1,5 @@
+CREATE TABLE core_state (
+    key TEXT NOT NULL,
+    value bytea,
+    PRIMARY KEY (key)
+)

--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -409,6 +409,8 @@ QString AbstractSqlMigrator::migrationObject(MigrationObject moType)
         return "IrcServer";
     case UserSetting:
         return "UserSetting";
+    case CoreState:
+        return "CoreState";
     };
     return QString();
 }
@@ -500,6 +502,10 @@ bool AbstractSqlMigrationReader::migrateTo(AbstractSqlMigrationWriter *writer)
 
     UserSettingMO userSettingMo;
     if (!transferMo(UserSetting, userSettingMo))
+        return false;
+
+    CoreStateMO coreStateMO;
+    if (!transferMo(CoreState, coreStateMO))
         return false;
 
     if (!_writer->postProcess())

--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -116,9 +116,9 @@ void AbstractSqlStorage::dbConnect(QSqlDatabase &db)
 }
 
 
-Storage::State AbstractSqlStorage::init(const QVariantMap &settings, const QProcessEnvironment &environment)
+Storage::State AbstractSqlStorage::init(const QVariantMap &settings, const QProcessEnvironment &environment, bool loadFromEnvironment)
 {
-    setConnectionProperties(settings, environment);
+    setConnectionProperties(settings, environment, loadFromEnvironment);
 
     _debug = Quassel::isOptionSet("debug");
 
@@ -192,9 +192,9 @@ QStringList AbstractSqlStorage::setupQueries()
 }
 
 
-bool AbstractSqlStorage::setup(const QVariantMap &settings, const QProcessEnvironment &environment)
+bool AbstractSqlStorage::setup(const QVariantMap &settings, const QProcessEnvironment &environment, bool loadFromEnvironment)
 {
-    setConnectionProperties(settings);
+    setConnectionProperties(settings, environment, loadFromEnvironment);
     QSqlDatabase db = logDb();
     if (!db.isOpen()) {
         qCritical() << "Unable to setup Logging Backend!";

--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -116,9 +116,9 @@ void AbstractSqlStorage::dbConnect(QSqlDatabase &db)
 }
 
 
-Storage::State AbstractSqlStorage::init(const QVariantMap &settings)
+Storage::State AbstractSqlStorage::init(const QVariantMap &settings, const QProcessEnvironment &environment)
 {
-    setConnectionProperties(settings);
+    setConnectionProperties(settings, environment);
 
     _debug = Quassel::isOptionSet("debug");
 
@@ -192,7 +192,7 @@ QStringList AbstractSqlStorage::setupQueries()
 }
 
 
-bool AbstractSqlStorage::setup(const QVariantMap &settings)
+bool AbstractSqlStorage::setup(const QVariantMap &settings, const QProcessEnvironment &environment)
 {
     setConnectionProperties(settings);
     QSqlDatabase db = logDb();

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -43,8 +43,8 @@ public:
     virtual std::unique_ptr<AbstractSqlMigrationWriter> createMigrationWriter() { return {}; }
 
 public slots:
-    virtual State init(const QVariantMap &settings = QVariantMap());
-    virtual bool setup(const QVariantMap &settings = QVariantMap());
+    virtual State init(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {});
+    virtual bool setup(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {});
 
 protected:
     inline virtual void sync() {};
@@ -82,7 +82,7 @@ protected:
     virtual bool updateSchemaVersion(int newVersion) = 0;
     virtual bool setupSchemaVersion(int version) = 0;
 
-    virtual void setConnectionProperties(const QVariantMap &properties) = 0;
+    virtual void setConnectionProperties(const QVariantMap &properties, const QProcessEnvironment &environment = {}) = 0;
     virtual QString driverName() = 0;
     inline virtual QString hostName() { return QString(); }
     inline virtual int port() { return -1; }

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -273,6 +273,11 @@ public:
         QByteArray settingvalue;
     };
 
+    struct CoreStateMO {
+        QString key;
+        QByteArray value;
+    };
+
     enum MigrationObject {
         QuasselUser,
         Sender,
@@ -282,7 +287,8 @@ public:
         Buffer,
         Backlog,
         IrcServer,
-        UserSetting
+        UserSetting,
+        CoreState
     };
 
     AbstractSqlMigrator();
@@ -328,6 +334,7 @@ public:
     virtual bool readMo(BacklogMO &backlog) = 0;
     virtual bool readMo(IrcServerMO &ircserver) = 0;
     virtual bool readMo(UserSettingMO &userSetting) = 0;
+    virtual bool readMo(CoreStateMO &coreState) = 0;
 
     bool migrateTo(AbstractSqlMigrationWriter *writer);
 
@@ -353,6 +360,7 @@ public:
     virtual bool writeMo(const BacklogMO &backlog) = 0;
     virtual bool writeMo(const IrcServerMO &ircserver) = 0;
     virtual bool writeMo(const UserSettingMO &userSetting) = 0;
+    virtual bool writeMo(const CoreStateMO &coreState) = 0;
 
     inline bool migrateFrom(AbstractSqlMigrationReader *reader) { return reader->migrateTo(this); }
 

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -43,8 +43,8 @@ public:
     virtual std::unique_ptr<AbstractSqlMigrationWriter> createMigrationWriter() { return {}; }
 
 public slots:
-    virtual State init(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {});
-    virtual bool setup(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {});
+    virtual State init(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}, bool loadFromEnvironment = false);
+    virtual bool setup(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}, bool loadFromEnvironment = false);
 
 protected:
     inline virtual void sync() {};
@@ -82,7 +82,7 @@ protected:
     virtual bool updateSchemaVersion(int newVersion) = 0;
     virtual bool setupSchemaVersion(int version) = 0;
 
-    virtual void setConnectionProperties(const QVariantMap &properties, const QProcessEnvironment &environment = {}) = 0;
+    virtual void setConnectionProperties(const QVariantMap &properties, const QProcessEnvironment &environment, bool loadFromEnvironment) = 0;
     virtual QString driverName() = 0;
     inline virtual QString hostName() { return QString(); }
     inline virtual int port() { return -1; }

--- a/src/core/authenticator.h
+++ b/src/core/authenticator.h
@@ -82,13 +82,13 @@ public slots:
      *  \param settings   Hostname, port, username, password, ...
      *  \return True if and only if the authenticator provider was initialized successfully.
      */
-    virtual bool setup(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}) = 0;
+    virtual bool setup(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}, bool loadFromEnvironment = false) = 0;
 
     //! Initialize the authenticator provider
     /** \param settings   Hostname, port, username, password, ...
      *  \return the State the authenticator backend is now in (see authenticator::State)
      */
-    virtual State init(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}) = 0;
+    virtual State init(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}, bool loadFromEnvironment = false) = 0;
 
     //! Validate a username with a given password.
     /** \param user     The username to validate

--- a/src/core/authenticator.h
+++ b/src/core/authenticator.h
@@ -24,6 +24,7 @@
 #include <QString>
 #include <QStringList>
 #include <QVariant>
+#include <QProcessEnvironment>
 
 #include "types.h"
 
@@ -81,13 +82,13 @@ public slots:
      *  \param settings   Hostname, port, username, password, ...
      *  \return True if and only if the authenticator provider was initialized successfully.
      */
-    virtual bool setup(const QVariantMap &settings = QVariantMap()) = 0;
+    virtual bool setup(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}) = 0;
 
     //! Initialize the authenticator provider
     /** \param settings   Hostname, port, username, password, ...
      *  \return the State the authenticator backend is now in (see authenticator::State)
      */
-    virtual State init(const QVariantMap &settings = QVariantMap()) = 0;
+    virtual State init(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}) = 0;
 
     //! Validate a username with a given password.
     /** \param user     The username to validate

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -255,14 +255,10 @@ Core::~Core()
 
 void Core::saveState()
 {
-    CoreSettings s;
-    QVariantMap state;
     QVariantList activeSessions;
     foreach(UserId user, instance()->_sessions.keys())
         activeSessions << QVariant::fromValue<UserId>(user);
-    state["CoreStateVersion"] = 1;
-    state["ActiveSessions"] = activeSessions;
-    s.setCoreState(state);
+    instance()->_storage->setCoreState(activeSessions);
 }
 
 
@@ -285,7 +281,8 @@ void Core::restoreState()
     }
     */
 
-    QVariantList activeSessions = s.coreState().toMap()["ActiveSessions"].toList();
+    QVariantList activeSessions = instance()->_storage->getCoreState(s.coreState().toMap()["ActiveSessions"].toList());
+
     if (activeSessions.count() > 0) {
         quInfo() << "Restoring previous core state...";
         foreach(QVariant v, activeSessions) {

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -184,15 +184,39 @@ Core::Core()
 
 void Core::init()
 {
-    CoreSettings cs;
+    QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+
+    QString db_backend;
+    QVariantMap db_connectionProperties;
+
+    QString auth_authenticator;
+    QVariantMap auth_properties;
+
+    bool writeError = false;
+
+    if (environment.value("CONFIGURE_FROM_ENVIRONMENT", "false").compare("true", Qt::CaseInsensitive) == 0) {
+        db_backend = environment.value("DB_BACKEND");
+        auth_authenticator = environment.value("AUTH_AUTHENTICATOR");
+    } else {
+        CoreSettings cs;
+
+        QVariantMap dbsettings = cs.storageSettings().toMap();
+        db_backend = dbsettings.value("Backend").toString();
+        db_connectionProperties = dbsettings.value("ConnectionProperties").toMap();
+
+        QVariantMap authSettings = cs.authSettings().toMap();
+        auth_authenticator = authSettings.value("Authenticator", "Database").toString();
+        auth_properties = authSettings.value("AuthProperties").toMap();
+
+        writeError = !cs.isWritable();
+    }
+
     // legacy
-    QVariantMap dbsettings = cs.storageSettings().toMap();
-    _configured = initStorage(dbsettings.value("Backend").toString(), dbsettings.value("ConnectionProperties").toMap());
+    _configured = initStorage(db_backend, db_connectionProperties, environment);
 
     // Not entirely sure what is 'legacy' about the above, but it seems to be the way things work!
     if (_configured) {
-        QVariantMap authSettings = cs.authSettings().toMap();
-        initAuthenticator(authSettings.value("Authenticator", "Database").toString(), authSettings.value("AuthProperties").toMap());
+        initAuthenticator(auth_authenticator, auth_properties, environment);
     }
 
     if (Quassel::isOptionSet("select-backend") || Quassel::isOptionSet("select-authenticator")) {
@@ -206,20 +230,31 @@ void Core::init()
     }
 
     if (!_configured) {
-        if (_registeredStorageBackends.size() == 0) {
-            quWarning() << qPrintable(tr("Could not initialize any storage backend! Exiting..."));
-            quWarning() << qPrintable(tr("Currently, Quassel supports SQLite3 and PostgreSQL. You need to build your\n"
-                                        "Qt library with the sqlite or postgres plugin enabled in order for quasselcore\n"
-                                        "to work."));
-            exit(EXIT_FAILURE); // TODO make this less brutal (especially for mono client -> popup)
-        }
-        quWarning() << "Core is currently not configured! Please connect with a Quassel Client for basic setup.";
+        if (environment.value("CONFIGURE_FROM_ENVIRONMENT", "false").compare("true", Qt::CaseInsensitive) == 0) {
+            _configured = initStorage(db_backend, db_connectionProperties, environment, true);
+            initAuthenticator(auth_authenticator, auth_properties, environment, true);
 
-        if (!cs.isWritable()) {
-            qWarning() << "Cannot write quasselcore configuration; probably a permission problem.";
-            exit(EXIT_FAILURE);
-        }
+            if (!_configured) {
+                qWarning() << "Cannot configure from environment";
+                exit(EXIT_FAILURE);
+            }
+        } else {
+            if (_registeredStorageBackends.empty()) {
+                quWarning() << qPrintable(tr("Could not initialize any storage backend! Exiting..."));
+                quWarning()
+                        << qPrintable(tr("Currently, Quassel supports SQLite3 and PostgreSQL. You need to build your\n"
+                                                 "Qt library with the sqlite or postgres plugin enabled in order for quasselcore\n"
+                                                 "to work."));
+                exit(EXIT_FAILURE); // TODO make this less brutal (especially for mono client -> popup)
+            }
+            quWarning() << "Core is currently not configured! Please connect with a Quassel Client for basic setup.";
 
+            if (writeError) {
+                qWarning() << "Cannot write quasselcore configuration; probably a permission problem.";
+                exit(EXIT_FAILURE);
+            }
+
+        }
     }
 
     if (Quassel::isOptionSet("add-user")) {
@@ -309,12 +344,12 @@ QString Core::setupCore(const QString &adminUser, const QString &adminPassword, 
     if (adminUser.isEmpty() || adminPassword.isEmpty()) {
         return tr("Admin user or password not set.");
     }
-    if (!(_configured = initStorage(backend, setupData, true))) {
+    if (!(_configured = initStorage(backend, setupData, {}, true))) {
         return tr("Could not setup storage!");
     }
 
     quInfo() << "Selected authenticator:" << authenticator;
-    if (!(_configured = initAuthenticator(authenticator, authSetupData, true)))
+    if (!(_configured = initAuthenticator(authenticator, authSetupData, {}, true)))
     {
         return tr("Could not setup authenticator!");
     }
@@ -380,7 +415,7 @@ DeferredSharedPtr<Storage> Core::storageBackend(const QString &backendId) const
 
 // old db settings:
 // "Type" => "sqlite"
-bool Core::initStorage(const QString &backend, const QVariantMap &settings, bool setup)
+bool Core::initStorage(const QString &backend, const QVariantMap &settings, const QProcessEnvironment &environment, bool setup)
 {
     if (backend.isEmpty()) {
         quWarning() << "No storage backend selected!";
@@ -393,13 +428,13 @@ bool Core::initStorage(const QString &backend, const QVariantMap &settings, bool
         return false;
     }
 
-    Storage::State storageState = storage->init(settings);
+    Storage::State storageState = storage->init(settings, environment);
     switch (storageState) {
     case Storage::NeedsSetup:
         if (!setup)
             return false;  // trigger setup process
         if (storage->setup(settings))
-            return initStorage(backend, settings, false);
+            return initStorage(backend, settings, environment, false);
         return false;
 
     // if initialization wasn't successful, we quit to keep from coming up unconfigured
@@ -477,7 +512,7 @@ DeferredSharedPtr<Authenticator> Core::authenticator(const QString &backendId) c
 
 // FIXME: Apparently, this is the legacy way of initting storage backends?
 // If there's a not-legacy way, it should be used here
-bool Core::initAuthenticator(const QString &backend, const QVariantMap &settings, bool setup)
+bool Core::initAuthenticator(const QString &backend, const QVariantMap &settings, const QProcessEnvironment &environment, bool setup)
 {
     if (backend.isEmpty()) {
         quWarning() << "No authenticator selected!";
@@ -490,13 +525,13 @@ bool Core::initAuthenticator(const QString &backend, const QVariantMap &settings
         return false;
     }
 
-    Authenticator::State authState = auth->init(settings);
+    Authenticator::State authState = auth->init(settings, environment);
     switch (authState) {
     case Authenticator::NeedsSetup:
         if (!setup)
             return false;  // trigger setup process
-        if (auth->setup(settings))
-            return initAuthenticator(backend, settings, false);
+        if (auth->setup(settings, environment))
+            return initAuthenticator(backend, settings, environment, false);
         return false;
 
     // if initialization wasn't successful, we quit to keep from coming up unconfigured

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -317,7 +317,8 @@ void Core::restoreState()
     }
     */
 
-    QVariantList activeSessions = instance()->_storage->getCoreState(s.coreState().toMap()["ActiveSessions"].toList());
+    const QList<QVariant> &activeSessionsFallback = s.coreState().toMap()["ActiveSessions"].toList();
+    QVariantList activeSessions = instance()->_storage->getCoreState(activeSessionsFallback);
 
     if (activeSessions.count() > 0) {
         quInfo() << "Restoring previous core state...";

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -611,8 +611,8 @@ private slots:
     void incomingConnection();
     void clientDisconnected();
 
-    bool initStorage(const QString &backend, const QVariantMap &settings, const QProcessEnvironment &environment, bool setup = false);
-    bool initAuthenticator(const QString &backend, const QVariantMap &settings, const QProcessEnvironment &environment, bool setup = false);
+    bool initStorage(const QString &backend, const QVariantMap &settings, const QProcessEnvironment &environment, bool loadFromEnvironment, bool setup = false);
+    bool initAuthenticator(const QString &backend, const QVariantMap &settings, const QProcessEnvironment &environment, bool loadFromEnvironment, bool setup = false);
 
     void socketError(QAbstractSocket::SocketError err, const QString &errorString);
     void setupClientSession(RemotePeer *, UserId);

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -611,8 +611,8 @@ private slots:
     void incomingConnection();
     void clientDisconnected();
 
-    bool initStorage(const QString &backend, const QVariantMap &settings, bool setup = false);
-    bool initAuthenticator(const QString &backend, const QVariantMap &settings, bool setup = false);
+    bool initStorage(const QString &backend, const QVariantMap &settings, const QProcessEnvironment &environment, bool setup = false);
+    bool initAuthenticator(const QString &backend, const QVariantMap &settings, const QProcessEnvironment &environment, bool setup = false);
 
     void socketError(QAbstractSocket::SocketError err, const QString &errorString);
     void setupClientSession(RemotePeer *, UserId);

--- a/src/core/ldapauthenticator.cpp
+++ b/src/core/ldapauthenticator.cpp
@@ -100,16 +100,16 @@ QVariantList LdapAuthenticator::setupData() const
 }
 
 
-void LdapAuthenticator::setAuthProperties(const QVariantMap &properties, const QProcessEnvironment &environment)
+void LdapAuthenticator::setAuthProperties(const QVariantMap &properties, const QProcessEnvironment &environment, bool loadFromEnvironment)
 {
-    if (environment.value("CONFIGURE_FROM_ENVIRONMENT", "false").compare("true", Qt::CaseInsensitive) == 0) {
-        _hostName = environment.value("AUTH_HOSTNAME");
-        _port = environment.value("AUTH_PORT").toInt();
-        _bindDN = environment.value("AUTH_BIND_DN");
-        _bindPassword = environment.value("AUTH_BIND_PASSWORD");
-        _baseDN = environment.value("AUTH_BASE_DN");
-        _filter = environment.value("AUTH_FILTER");
-        _uidAttribute = environment.value("AUTH_UID_ATTRIBUTE");
+    if (loadFromEnvironment) {
+        _hostName = environment.value("AUTH_LDAP_HOSTNAME");
+        _port = environment.value("AUTH_LDAP_PORT").toInt();
+        _bindDN = environment.value("AUTH_LDAP_BIND_DN");
+        _bindPassword = environment.value("AUTH_LDAP_BIND_PASSWORD");
+        _baseDN = environment.value("AUTH_LDAP_BASE_DN");
+        _filter = environment.value("AUTH_LDAP_FILTER");
+        _uidAttribute = environment.value("AUTH_LDAP_UID_ATTRIBUTE");
     } else {
         _hostName = properties["Hostname"].toString();
         _port = properties["Port"].toInt();
@@ -152,17 +152,17 @@ UserId LdapAuthenticator::validateUser(const QString &username, const QString &p
 }
 
 
-bool LdapAuthenticator::setup(const QVariantMap &settings, const QProcessEnvironment &environment)
+bool LdapAuthenticator::setup(const QVariantMap &settings, const QProcessEnvironment &environment, bool loadFromEnvironment)
 {
-    setAuthProperties(settings, environment);
+    setAuthProperties(settings, environment, loadFromEnvironment);
     bool status = ldapConnect();
     return status;
 }
 
 
-Authenticator::State LdapAuthenticator::init(const QVariantMap &settings, const QProcessEnvironment &environment)
+Authenticator::State LdapAuthenticator::init(const QVariantMap &settings, const QProcessEnvironment &environment, bool loadFromEnvironment)
 {
-    setAuthProperties(settings, environment);
+    setAuthProperties(settings, environment, loadFromEnvironment);
 
     bool status = ldapConnect();
     if (!status) {

--- a/src/core/ldapauthenticator.cpp
+++ b/src/core/ldapauthenticator.cpp
@@ -100,15 +100,25 @@ QVariantList LdapAuthenticator::setupData() const
 }
 
 
-void LdapAuthenticator::setAuthProperties(const QVariantMap &properties)
+void LdapAuthenticator::setAuthProperties(const QVariantMap &properties, const QProcessEnvironment &environment)
 {
-    _hostName = properties["Hostname"].toString();
-    _port = properties["Port"].toInt();
-    _bindDN = properties["BindDN"].toString();
-    _bindPassword = properties["BindPassword"].toString();
-    _baseDN = properties["BaseDN"].toString();
-    _filter = properties["Filter"].toString();
-    _uidAttribute = properties["UidAttribute"].toString();
+    if (environment.value("CONFIGURE_FROM_ENVIRONMENT", "false").compare("true", Qt::CaseInsensitive) == 0) {
+        _hostName = environment.value("AUTH_HOSTNAME");
+        _port = environment.value("AUTH_PORT").toInt();
+        _bindDN = environment.value("AUTH_BIND_DN");
+        _bindPassword = environment.value("AUTH_BIND_PASSWORD");
+        _baseDN = environment.value("AUTH_BASE_DN");
+        _filter = environment.value("AUTH_FILTER");
+        _uidAttribute = environment.value("AUTH_UID_ATTRIBUTE");
+    } else {
+        _hostName = properties["Hostname"].toString();
+        _port = properties["Port"].toInt();
+        _bindDN = properties["BindDN"].toString();
+        _bindPassword = properties["BindPassword"].toString();
+        _baseDN = properties["BaseDN"].toString();
+        _filter = properties["Filter"].toString();
+        _uidAttribute = properties["UidAttribute"].toString();
+    }
 }
 
 // TODO: this code is sufficiently general that in the future, perhaps an abstract
@@ -142,17 +152,17 @@ UserId LdapAuthenticator::validateUser(const QString &username, const QString &p
 }
 
 
-bool LdapAuthenticator::setup(const QVariantMap &settings)
+bool LdapAuthenticator::setup(const QVariantMap &settings, const QProcessEnvironment &environment)
 {
-    setAuthProperties(settings);
+    setAuthProperties(settings, environment);
     bool status = ldapConnect();
     return status;
 }
 
 
-Authenticator::State LdapAuthenticator::init(const QVariantMap &settings)
+Authenticator::State LdapAuthenticator::init(const QVariantMap &settings, const QProcessEnvironment &environment)
 {
-    setAuthProperties(settings);
+    setAuthProperties(settings, environment);
 
     bool status = ldapConnect();
     if (!status) {

--- a/src/core/ldapauthenticator.h
+++ b/src/core/ldapauthenticator.h
@@ -63,12 +63,12 @@ public slots:
 
     bool canChangePassword() const override { return false; }
 
-    bool setup(const QVariantMap &settings = {}, const QProcessEnvironment &environment = {}) override;
-    State init(const QVariantMap &settings = {}, const QProcessEnvironment &environment = {}) override;
+    bool setup(const QVariantMap &settings, const QProcessEnvironment &environment, bool loadFromEnvironment) override;
+    State init(const QVariantMap &settings, const QProcessEnvironment &environment, bool loadFromEnvironment) override;
     UserId validateUser(const QString &user, const QString &password) override;
 
 protected:
-    void setAuthProperties(const QVariantMap &properties, const QProcessEnvironment &environment = {});
+    void setAuthProperties(const QVariantMap &properties, const QProcessEnvironment &environment, bool loadFromEnvironment);
     bool ldapConnect();
     void ldapDisconnect();
     bool ldapAuth(const QString &username, const QString &password);

--- a/src/core/ldapauthenticator.h
+++ b/src/core/ldapauthenticator.h
@@ -63,12 +63,12 @@ public slots:
 
     bool canChangePassword() const override { return false; }
 
-    bool setup(const QVariantMap &settings = {}) override;
-    State init(const QVariantMap &settings = {}) override;
+    bool setup(const QVariantMap &settings = {}, const QProcessEnvironment &environment = {}) override;
+    State init(const QVariantMap &settings = {}, const QProcessEnvironment &environment = {}) override;
     UserId validateUser(const QString &user, const QString &password) override;
 
 protected:
-    void setAuthProperties(const QVariantMap &properties);
+    void setAuthProperties(const QVariantMap &properties, const QProcessEnvironment &environment = {});
     bool ldapConnect();
     void ldapDisconnect();
     bool ldapAuth(const QString &username, const QString &password);

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -397,6 +397,59 @@ QVariant PostgreSqlStorage::getUserSetting(UserId userId, const QString &setting
 }
 
 
+void PostgreSqlStorage::setCoreState(const QVariantList &data)
+{
+    QByteArray rawData;
+    QDataStream out(&rawData, QIODevice::WriteOnly);
+    out.setVersion(QDataStream::Qt_4_2);
+    out << data;
+
+    QSqlDatabase db = logDb();
+    QSqlQuery selectQuery(db);
+    selectQuery.prepare(queryString("select_core_state"));
+    selectQuery.bindValue(":key", "active_sessions");
+    safeExec(selectQuery);
+    watchQuery(selectQuery);
+
+    QString setQueryString;
+    if (!selectQuery.first()) {
+        setQueryString = queryString("insert_core_state");
+    }
+    else {
+        setQueryString = queryString("update_core_state");
+    }
+
+    QSqlQuery setQuery(db);
+    setQuery.prepare(setQueryString);
+    setQuery.bindValue(":key", "active_sessions");
+    setQuery.bindValue(":value", rawData);
+    safeExec(setQuery);
+    watchQuery(setQuery);
+}
+
+
+QVariantList PostgreSqlStorage::getCoreState(const QVariantList &defaultData)
+{
+    QSqlQuery query(logDb());
+    query.prepare(queryString("select_core_state"));
+    query.bindValue(":key", "active_sessions");
+    safeExec(query);
+    watchQuery(query);
+
+    if (query.first()) {
+        QVariantList data;
+        QByteArray rawData = query.value(0).toByteArray();
+        QDataStream in(&rawData, QIODevice::ReadOnly);
+        in.setVersion(QDataStream::Qt_4_2);
+        in >> data;
+        return data;
+    }
+    else {
+        return defaultData;
+    }
+}
+
+
 IdentityId PostgreSqlStorage::createIdentity(UserId user, CoreIdentity &identity)
 {
     IdentityId identityId;
@@ -1914,6 +1967,9 @@ bool PostgreSqlMigrationWriter::prepareQuery(MigrationObject mo)
     case UserSetting:
         query = queryString("migrate_write_usersetting");
         break;
+    case CoreState:
+        query = queryString("migrate_write_corestate");
+        break;
     }
     newQuery(query, logDb());
     return true;
@@ -2083,6 +2139,13 @@ bool PostgreSqlMigrationWriter::writeMo(const UserSettingMO &userSetting)
     bindValue(0, userSetting.userid.toInt());
     bindValue(1, userSetting.settingname);
     bindValue(2, userSetting.settingvalue);
+    return exec();
+}
+
+bool PostgreSqlMigrationWriter::writeMo(const CoreStateMO &coreState)
+{
+    bindValue(0, coreState.key);
+    bindValue(1, coreState.value);
     return exec();
 }
 

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<AbstractSqlMigrationWriter> PostgreSqlStorage::createMigrationWr
     properties["Hostname"] = _hostName;
     properties["Port"] = _port;
     properties["Database"] = _databaseName;
-    writer->setConnectionProperties(properties);
+    writer->setConnectionProperties(properties, {}, false);
     return std::unique_ptr<AbstractSqlMigrationWriter>{writer};
 }
 
@@ -147,14 +147,14 @@ bool PostgreSqlStorage::initDbSession(QSqlDatabase &db)
 }
 
 
-void PostgreSqlStorage::setConnectionProperties(const QVariantMap &properties, const QProcessEnvironment &environment)
+void PostgreSqlStorage::setConnectionProperties(const QVariantMap &properties, const QProcessEnvironment &environment, bool loadFromEnvironment)
 {
-    if (environment.value("CONFIGURE_FROM_ENVIRONMENT", "false").compare("true", Qt::CaseInsensitive) == 0) {
-        _userName = environment.value("DB_USERNAME");
-        _password = environment.value("DB_PASSWORD");
-        _hostName = environment.value("DB_HOSTNAME");
-        _port = environment.value("DB_PORT").toInt();
-        _databaseName = environment.value("DB_DATABASE");
+    if (loadFromEnvironment) {
+        _userName = environment.value("DB_PGSQL_USERNAME");
+        _password = environment.value("DB_PGSQL_PASSWORD");
+        _hostName = environment.value("DB_PGSQL_HOSTNAME");
+        _port = environment.value("DB_PGSQL_PORT").toInt();
+        _databaseName = environment.value("DB_PGSQL_DATABASE");
     } else {
         _userName = properties["Username"].toString();
         _password = properties["Password"].toString();

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -147,13 +147,21 @@ bool PostgreSqlStorage::initDbSession(QSqlDatabase &db)
 }
 
 
-void PostgreSqlStorage::setConnectionProperties(const QVariantMap &properties)
+void PostgreSqlStorage::setConnectionProperties(const QVariantMap &properties, const QProcessEnvironment &environment)
 {
-    _userName = properties["Username"].toString();
-    _password = properties["Password"].toString();
-    _hostName = properties["Hostname"].toString();
-    _port = properties["Port"].toInt();
-    _databaseName = properties["Database"].toString();
+    if (environment.value("CONFIGURE_FROM_ENVIRONMENT", "false").compare("true", Qt::CaseInsensitive) == 0) {
+        _userName = environment.value("DB_USERNAME");
+        _password = environment.value("DB_PASSWORD");
+        _hostName = environment.value("DB_HOSTNAME");
+        _port = environment.value("DB_PORT").toInt();
+        _databaseName = environment.value("DB_DATABASE");
+    } else {
+        _userName = properties["Username"].toString();
+        _password = properties["Password"].toString();
+        _hostName = properties["Hostname"].toString();
+        _port = properties["Port"].toInt();
+        _databaseName = properties["Database"].toString();
+    }
 }
 
 

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -451,8 +451,7 @@ QVariantList PostgreSqlStorage::getCoreState(const QVariantList &defaultData)
         in.setVersion(QDataStream::Qt_4_2);
         in >> data;
         return data;
-    }
-    else {
+    } else {
         return defaultData;
     }
 }

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -109,7 +109,7 @@ public slots:
 
 protected:
     bool initDbSession(QSqlDatabase &db) override;
-    void setConnectionProperties(const QVariantMap &properties) override;
+    void setConnectionProperties(const QVariantMap &properties, const QProcessEnvironment &environment = {}) override;
     QString driverName()  override { return "QPSQL"; }
     QString hostName()  override { return _hostName; }
     int port()  override { return _port; }

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -57,6 +57,8 @@ public slots:
     void delUser(UserId user) override;
     void setUserSetting(UserId userId, const QString &settingName, const QVariant &data) override;
     QVariant getUserSetting(UserId userId, const QString &settingName, const QVariant &defaultData = QVariant()) override;
+    void setCoreState(const QVariantList &data) override;
+    QVariantList getCoreState(const QVariantList &data) override;
 
     /* Identity handling */
     IdentityId createIdentity(UserId user, CoreIdentity &identity) override;
@@ -163,6 +165,7 @@ public:
     bool writeMo(const BacklogMO &backlog) override;
     bool writeMo(const IrcServerMO &ircserver) override;
     bool writeMo(const UserSettingMO &userSetting) override;
+    bool writeMo(const CoreStateMO &coreState) override;
 
     bool prepareQuery(MigrationObject mo) override;
 

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -109,7 +109,7 @@ public slots:
 
 protected:
     bool initDbSession(QSqlDatabase &db) override;
-    void setConnectionProperties(const QVariantMap &properties, const QProcessEnvironment &environment = {}) override;
+    void setConnectionProperties(const QVariantMap &properties, const QProcessEnvironment &environment, bool loadFromEnvironment) override;
     QString driverName()  override { return "QPSQL"; }
     QString hostName()  override { return _hostName; }
     int port()  override { return _port; }

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -13,6 +13,7 @@
     <file>./SQL/PostgreSQL/delete_nicks.sql</file>
     <file>./SQL/PostgreSQL/delete_quasseluser.sql</file>
     <file>./SQL/PostgreSQL/insert_buffer.sql</file>
+    <file>./SQL/PostgreSQL/insert_core_state.sql</file>
     <file>./SQL/PostgreSQL/insert_identity.sql</file>
     <file>./SQL/PostgreSQL/insert_message.sql</file>
     <file>./SQL/PostgreSQL/insert_network.sql</file>
@@ -23,6 +24,7 @@
     <file>./SQL/PostgreSQL/insert_user_setting.sql</file>
     <file>./SQL/PostgreSQL/migrate_write_backlog.sql</file>
     <file>./SQL/PostgreSQL/migrate_write_buffer.sql</file>
+    <file>./SQL/PostgreSQL/migrate_write_corestate.sql</file>
     <file>./SQL/PostgreSQL/migrate_write_identity.sql</file>
     <file>./SQL/PostgreSQL/migrate_write_identity_nick.sql</file>
     <file>./SQL/PostgreSQL/migrate_write_ircserver.sql</file>
@@ -43,6 +45,7 @@
     <file>./SQL/PostgreSQL/select_buffers_for_network.sql</file>
     <file>./SQL/PostgreSQL/select_checkidentity.sql</file>
     <file>./SQL/PostgreSQL/select_connected_networks.sql</file>
+    <file>./SQL/PostgreSQL/select_core_state.sql</file>
     <file>./SQL/PostgreSQL/select_identities.sql</file>
     <file>./SQL/PostgreSQL/select_internaluser.sql</file>
     <file>./SQL/PostgreSQL/select_messagesAll.sql</file>
@@ -76,6 +79,7 @@
     <file>./SQL/PostgreSQL/setup_110_alter_sender_seq.sql</file>
     <file>./SQL/PostgreSQL/setup_120_alter_messageid_seq.sql</file>
     <file>./SQL/PostgreSQL/setup_130_function_lastmsgid.sql</file>
+    <file>./SQL/PostgreSQL/setup_140_corestate.sql</file>
     <file>./SQL/PostgreSQL/update_backlog_bufferid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_bufferactivity.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_lastseen.sql</file>
@@ -83,6 +87,7 @@
     <file>./SQL/PostgreSQL/update_buffer_name.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_persistent_channel.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_set_channel_key.sql</file>
+    <file>./SQL/PostgreSQL/update_core_state.sql</file>
     <file>./SQL/PostgreSQL/update_identity.sql</file>
     <file>./SQL/PostgreSQL/update_network.sql</file>
     <file>./SQL/PostgreSQL/update_network_connected.sql</file>
@@ -109,6 +114,7 @@
     <file>./SQL/PostgreSQL/version/22/upgrade_000_alter_quasseluser_add_authenticator.sql</file>
     <file>./SQL/PostgreSQL/version/23/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/PostgreSQL/version/24/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_000_create_corestate.sql</file>
     <file>./SQL/SQLite/delete_backlog_by_uid.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_buffer.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_network.sql</file>
@@ -122,6 +128,7 @@
     <file>./SQL/SQLite/delete_nicks.sql</file>
     <file>./SQL/SQLite/delete_quasseluser.sql</file>
     <file>./SQL/SQLite/insert_buffer.sql</file>
+    <file>./SQL/SQLite/insert_core_state.sql</file>
     <file>./SQL/SQLite/insert_identity.sql</file>
     <file>./SQL/SQLite/insert_message.sql</file>
     <file>./SQL/SQLite/insert_network.sql</file>
@@ -132,6 +139,7 @@
     <file>./SQL/SQLite/insert_user_setting.sql</file>
     <file>./SQL/SQLite/migrate_read_backlog.sql</file>
     <file>./SQL/SQLite/migrate_read_buffer.sql</file>
+    <file>./SQL/SQLite/migrate_read_corestate.sql</file>
     <file>./SQL/SQLite/migrate_read_identity.sql</file>
     <file>./SQL/SQLite/migrate_read_identity_nick.sql</file>
     <file>./SQL/SQLite/migrate_read_ircserver.sql</file>
@@ -153,6 +161,7 @@
     <file>./SQL/SQLite/select_buffers_for_network.sql</file>
     <file>./SQL/SQLite/select_checkidentity.sql</file>
     <file>./SQL/SQLite/select_connected_networks.sql</file>
+    <file>./SQL/SQLite/select_core_state.sql</file>
     <file>./SQL/SQLite/select_identities.sql</file>
     <file>./SQL/SQLite/select_internaluser.sql</file>
     <file>./SQL/SQLite/select_messagesAll.sql</file>
@@ -187,6 +196,7 @@
     <file>./SQL/SQLite/setup_120_user_setting.sql</file>
     <file>./SQL/SQLite/setup_130_identity.sql</file>
     <file>./SQL/SQLite/setup_140_identity_nick.sql</file>
+    <file>./SQL/SQLite/setup_150_corestate.sql</file>
     <file>./SQL/SQLite/update_backlog_bufferid.sql</file>
     <file>./SQL/SQLite/update_buffer_bufferactivity.sql</file>
     <file>./SQL/SQLite/update_buffer_lastseen.sql</file>
@@ -194,6 +204,7 @@
     <file>./SQL/SQLite/update_buffer_name.sql</file>
     <file>./SQL/SQLite/update_buffer_persistent_channel.sql</file>
     <file>./SQL/SQLite/update_buffer_set_channel_key.sql</file>
+    <file>./SQL/SQLite/update_core_state.sql</file>
     <file>./SQL/SQLite/update_identity.sql</file>
     <file>./SQL/SQLite/update_network.sql</file>
     <file>./SQL/SQLite/update_network_connected.sql</file>
@@ -293,5 +304,6 @@
     <file>./SQL/SQLite/version/24/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/SQLite/version/25/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
     <file>./SQL/SQLite/version/26/upgrade_000_create_buffer_idx.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_000_create_corestate.sql</file>
 </qresource>
 </RCC>

--- a/src/core/sqlauthenticator.cpp
+++ b/src/core/sqlauthenticator.cpp
@@ -72,14 +72,14 @@ UserId SqlAuthenticator::validateUser(const QString &user, const QString &passwo
 }
 
 
-bool SqlAuthenticator::setup(const QVariantMap &settings)
+bool SqlAuthenticator::setup(const QVariantMap &settings, const QProcessEnvironment &environment)
 {
     Q_UNUSED(settings)
     return true;
 }
 
 
-Authenticator::State SqlAuthenticator::init(const QVariantMap &settings)
+Authenticator::State SqlAuthenticator::init(const QVariantMap &settings, const QProcessEnvironment &environment)
 {
     Q_UNUSED(settings)
 

--- a/src/core/sqlauthenticator.cpp
+++ b/src/core/sqlauthenticator.cpp
@@ -72,14 +72,14 @@ UserId SqlAuthenticator::validateUser(const QString &user, const QString &passwo
 }
 
 
-bool SqlAuthenticator::setup(const QVariantMap &settings, const QProcessEnvironment &environment)
+bool SqlAuthenticator::setup(const QVariantMap &settings, const QProcessEnvironment &environment, bool loadFromEnvironment)
 {
     Q_UNUSED(settings)
     return true;
 }
 
 
-Authenticator::State SqlAuthenticator::init(const QVariantMap &settings, const QProcessEnvironment &environment)
+Authenticator::State SqlAuthenticator::init(const QVariantMap &settings, const QProcessEnvironment &environment, bool loadFromEnvironment)
 {
     Q_UNUSED(settings)
 

--- a/src/core/sqlauthenticator.h
+++ b/src/core/sqlauthenticator.h
@@ -40,8 +40,8 @@ public slots:
 
     virtual inline bool canChangePassword() const { return true; }
 
-    bool setup(const QVariantMap &settings = QVariantMap());
-    State init(const QVariantMap &settings = QVariantMap());
+    bool setup(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {});
+    State init(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {});
     UserId validateUser(const QString &user, const QString &password);
 
     /* User handling */

--- a/src/core/sqlauthenticator.h
+++ b/src/core/sqlauthenticator.h
@@ -40,8 +40,8 @@ public slots:
 
     virtual inline bool canChangePassword() const { return true; }
 
-    bool setup(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {});
-    State init(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {});
+    bool setup(const QVariantMap &settings, const QProcessEnvironment &environment, bool loadFromEnvironment);
+    State init(const QVariantMap &settings, const QProcessEnvironment &environment, bool loadFromEnvironment);
     UserId validateUser(const QString &user, const QString &password);
 
     /* User handling */

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -408,7 +408,7 @@ void SqliteStorage::setCoreState(const QVariantList &data)
 
 QVariantList SqliteStorage::getCoreState(const QVariantList &defaultData)
 {
-    QVariantList data = defaultData;
+    QVariantList data;
     {
         QSqlQuery query(logDb());
         query.prepare(queryString("select_core_state"));
@@ -421,6 +421,8 @@ QVariantList SqliteStorage::getCoreState(const QVariantList &defaultData)
             QDataStream in(&rawData, QIODevice::ReadOnly);
             in.setVersion(QDataStream::Qt_4_2);
             in >> data;
+        } else {
+            data = defaultData;
         }
     }
     unlock();

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -376,6 +376,58 @@ QVariant SqliteStorage::getUserSetting(UserId userId, const QString &settingName
 }
 
 
+void SqliteStorage::setCoreState(const QVariantList &data)
+{
+    QByteArray rawData;
+    QDataStream out(&rawData, QIODevice::WriteOnly);
+    out.setVersion(QDataStream::Qt_4_2);
+    out << data;
+
+    QSqlDatabase db = logDb();
+    db.transaction();
+    {
+        QSqlQuery query(db);
+        query.prepare(queryString("insert_core_state"));
+        query.bindValue(":key", "active_sessions");
+        query.bindValue(":value", rawData);
+        lockForWrite();
+        safeExec(query);
+
+        if (query.lastError().isValid()) {
+            QSqlQuery updateQuery(db);
+            updateQuery.prepare(queryString("update_core_state"));
+            updateQuery.bindValue(":key", "active_sessions");
+            updateQuery.bindValue(":value", rawData);
+            safeExec(updateQuery);
+        }
+        db.commit();
+    }
+    unlock();
+}
+
+
+QVariantList SqliteStorage::getCoreState(const QVariantList &defaultData)
+{
+    QVariantList data = defaultData;
+    {
+        QSqlQuery query(logDb());
+        query.prepare(queryString("select_core_state"));
+        query.bindValue(":key", "active_sessions");
+        lockForRead();
+        safeExec(query);
+
+        if (query.first()) {
+            QByteArray rawData = query.value(0).toByteArray();
+            QDataStream in(&rawData, QIODevice::ReadOnly);
+            in.setVersion(QDataStream::Qt_4_2);
+            in >> data;
+        }
+    }
+    unlock();
+    return data;
+}
+
+
 IdentityId SqliteStorage::createIdentity(UserId user, CoreIdentity &identity)
 {
     IdentityId identityId;
@@ -1914,6 +1966,9 @@ bool SqliteMigrationReader::prepareQuery(MigrationObject mo)
     case UserSetting:
         newQuery(queryString("migrate_read_usersetting"), logDb());
         break;
+    case CoreState:
+        newQuery(queryString("migrate_read_corestate"), logDb());
+        break;
     }
     return exec();
 }
@@ -2118,6 +2173,18 @@ bool SqliteMigrationReader::readMo(UserSettingMO &userSetting)
     userSetting.userid = value(0).toInt();
     userSetting.settingname = value(1).toString();
     userSetting.settingvalue = value(2).toByteArray();
+
+    return true;
+}
+
+
+bool SqliteMigrationReader::readMo(CoreStateMO &coreState)
+{
+    if (!next())
+        return false;
+
+    coreState.key = value(0).toString();
+    coreState.value = value(1).toByteArray();
 
     return true;
 }

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -109,7 +109,7 @@ public slots:
     QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
 
 protected:
-    void setConnectionProperties(const QVariantMap &properties, const QProcessEnvironment &environment = {})  override {}
+    void setConnectionProperties(const QVariantMap &properties, const QProcessEnvironment &environment, bool loadFromEnvironment) override {}
     QString driverName()  override { return "QSQLITE"; }
     QString databaseName()  override { return backlogFile(); }
     int installedSchemaVersion() override;

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -109,7 +109,7 @@ public slots:
     QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
 
 protected:
-    void setConnectionProperties(const QVariantMap & /* properties */)  override {}
+    void setConnectionProperties(const QVariantMap &properties, const QProcessEnvironment &environment = {})  override {}
     QString driverName()  override { return "QSQLITE"; }
     QString databaseName()  override { return backlogFile(); }
     int installedSchemaVersion() override;

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -58,6 +58,8 @@ public slots:
     void delUser(UserId user) override;
     void setUserSetting(UserId userId, const QString &settingName, const QVariant &data) override;
     QVariant getUserSetting(UserId userId, const QString &settingName, const QVariant &defaultData = QVariant()) override;
+    void setCoreState(const QVariantList &data) override;
+    QVariantList getCoreState(const QVariantList &data) override;
 
     /* Identity handling */
     IdentityId createIdentity(UserId user, CoreIdentity &identity) override;
@@ -147,6 +149,7 @@ public:
     bool readMo(BacklogMO &backlog) override;
     bool readMo(IrcServerMO &ircserver) override;
     bool readMo(UserSettingMO &userSetting) override;
+    bool readMo(CoreStateMO &coreState) override;
 
     bool prepareQuery(MigrationObject mo) override;
 

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -171,6 +171,19 @@ public slots:
      */
     virtual QVariant getUserSetting(UserId userId, const QString &settingName, const QVariant &data = QVariant()) = 0;
 
+    //! Store core state
+    /**
+     * \param data         Active Sessions
+     */
+    virtual void setCoreState(const QVariantList &data) = 0;
+
+    //! Retrieve core state
+    /**
+     * \param default      Value to return in case it's unset.
+     * \return Active Sessions
+     */
+    virtual QVariantList getCoreState(const QVariantList &data = QVariantList()) = 0;
+
     /* Identity handling */
     virtual IdentityId createIdentity(UserId user, CoreIdentity &identity) = 0;
     virtual bool updateIdentity(UserId user, const CoreIdentity &identity) = 0;

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -85,13 +85,13 @@ public slots:
      *  \param settings   Hostname, port, username, password, ...
      *  \return True if and only if the storage provider was initialized successfully.
      */
-    virtual bool setup(const QVariantMap &settings = QVariantMap()) = 0;
+    virtual bool setup(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}) = 0;
 
     //! Initialize the storage provider
     /** \param settings   Hostname, port, username, password, ...
      *  \return the State the storage backend is now in (see Storage::State)
      */
-    virtual State init(const QVariantMap &settings = QVariantMap()) = 0;
+    virtual State init(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}) = 0;
 
     //! Makes temp data persistent
     /** This Method is periodically called by the Quassel Core to make temporary

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -85,13 +85,13 @@ public slots:
      *  \param settings   Hostname, port, username, password, ...
      *  \return True if and only if the storage provider was initialized successfully.
      */
-    virtual bool setup(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}) = 0;
+    virtual bool setup(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}, bool loadFromEnvironment = false) = 0;
 
     //! Initialize the storage provider
     /** \param settings   Hostname, port, username, password, ...
      *  \return the State the storage backend is now in (see Storage::State)
      */
-    virtual State init(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}) = 0;
+    virtual State init(const QVariantMap &settings = QVariantMap(), const QProcessEnvironment &environment = {}, bool loadFromEnvironment = false) = 0;
 
     //! Makes temp data persistent
     /** This Method is periodically called by the Quassel Core to make temporary


### PR DESCRIPTION
## In Short
* Move CoreState / Active Sessions into the database
  * New database table "core_state"
  * Read state from quasselCore.conf and database
  * Write exclusively to database
* Add new CLI switch to enable environment configuration
* Add new environment variables to configure database and authenticator

## Rationale
In containerized and other automated improvements it’s usually common to configure software through environment variables or config files automatically. Quassel’s existing binary config format does not allow this.

## Impact
No changes for normal setup flow, new database table

## Changes
The CLI switch --config-from-environment enables loading of configuration from environment, unless select-backend or a similar option is given.  
There are global configuration options DB_BACKEND and AUTH_AUTHENTICATOR to select a database and authentication backend. Additionally, each backend has its own additional environment variables.

**PostgreSQL Backend**
 * `DB_PGSQL_USERNAME`
 * `DB_PGSQL_PASSWORD`
 * `DB_PGSQL_HOSTNAME`
 * `DB_PGSQL_PORT`
 * `DB_PGSQL_DATABASE`

**SQLite Backend**
No options

**LDAP Authenticator**
 * `AUTH_LDAP_HOSTNAME`
 * `AUTH_LDAP_PORT`
 * `AUTH_LDAP_BIND_DN`
 * `AUTH_LDAP_BIND_PASSWORD`
 * `AUTH_LDAP_BASE_DN`
 * `AUTH_LDAP_FILTER`
 * `AUTH_LDAP_UID_ATTRIBUTE`

**Database Authenticator**
No options