### PR TITLE
Improve support for modern IRC formatting options

### DIFF
--- a/data/stylesheets/default.qss
+++ b/data/stylesheets/default.qss
@@ -77,9 +77,10 @@ ChatLine[fg-color="0f"] { foreground: #c0c0c0; }
 ChatLine[bg-color="0f"] { background: #c0c0c0; }
 
 // mIRC formats
-ChatLine[format="bold"]      { font-weight: bold; }
-ChatLine[format="italic"]    { font-style: italic; }
-ChatLine[format="underline"] { font-style: underline; }
+ChatLine[format="bold"]          { font-weight: bold; }
+ChatLine[format="italic"]        { font-style: italic; }
+ChatLine[format="underline"]     { font-style: underline; }
+ChatLine[format="strikethrough"] { font-style: strikethrough; }
 
 // ChatView message colors
 ChatLine#notice { foreground: #916409; }

--- a/data/stylesheets/default.qss
+++ b/data/stylesheets/default.qss
@@ -6,16 +6,22 @@
 // Basics
 ChatLine {
   foreground: palette(text);
+  // By default, allow color codes everywhere
+  allow-foreground-override: true;
+  allow-background-override: true;
 }
 
 ChatLine[label="highlight"] {
   foreground: black;
   background: #ff8000;
+  allow-background-override: false;
 }
 
 ChatLine[label="selected"] {
   foreground: palette(highlighted-text);
   background: palette(highlight);
+  allow-foreground-override: false;
+  allow-background-override: false;
 }
 
 // ChatLine::sender[sender="self"] {
@@ -28,6 +34,7 @@ ChatLine::timestamp {
 
 ChatLine::url {
   foreground: palette(link);
+  allow-foreground-override: false;
 }
 
 // Markerline gets a nice (and hardly visible) gradient

--- a/data/stylesheets/m4yer.qss
+++ b/data/stylesheets/m4yer.qss
@@ -80,40 +80,6 @@ ChatLine[bg-color="0e"] { background: #808080; }
 ChatLine[fg-color="0f"] { foreground: #c0c0c0; }
 ChatLine[bg-color="0f"] { background: #c0c0c0; }
 
-    // for sender
-    ChatLine[fg-color="00", sender="self"] { foreground: #ffffff; }
-    ChatLine[bg-color="00", sender="self"] { background: #ffffff; }
-    ChatLine[fg-color="01", sender="self"] { foreground: #000000; }
-    ChatLine[bg-color="01", sender="self"] { background: #000000; }
-    ChatLine[fg-color="02", sender="self"] { foreground: #000080; }
-    ChatLine[bg-color="02", sender="self"] { background: #000080; }
-    ChatLine[fg-color="03", sender="self"] { foreground: #008000; }
-    ChatLine[bg-color="03", sender="self"] { background: #008000; }
-    ChatLine[fg-color="04", sender="self"] { foreground: #ff0000; }
-    ChatLine[bg-color="04", sender="self"] { background: #ff0000; }
-    ChatLine[fg-color="05", sender="self"] { foreground: #800000; }
-    ChatLine[bg-color="05", sender="self"] { background: #800000; }
-    ChatLine[fg-color="06", sender="self"] { foreground: #800080; }
-    ChatLine[bg-color="06", sender="self"] { background: #800080; }
-    ChatLine[fg-color="07", sender="self"] { foreground: #ffa500; }
-    ChatLine[bg-color="07", sender="self"] { background: #ffa500; }
-    ChatLine[fg-color="08", sender="self"] { foreground: #ffff00; }
-    ChatLine[bg-color="08", sender="self"] { background: #ffff00; }
-    ChatLine[fg-color="09", sender="self"] { foreground: #00ff00; }
-    ChatLine[bg-color="09", sender="self"] { background: #00ff00; }
-    ChatLine[fg-color="0a", sender="self"] { foreground: #008080; }
-    ChatLine[bg-color="0a", sender="self"] { background: #008080; }
-    ChatLine[fg-color="0b", sender="self"] { foreground: #00ffff; }
-    ChatLine[bg-color="0b", sender="self"] { background: #00ffff; }
-    ChatLine[fg-color="0c", sender="self"] { foreground: #4169e1; }
-    ChatLine[bg-color="0c", sender="self"] { background: #4169e1; }
-    ChatLine[fg-color="0d", sender="self"] { foreground: #ff00ff; }
-    ChatLine[bg-color="0d", sender="self"] { background: #ff00ff; }
-    ChatLine[fg-color="0e", sender="self"] { foreground: #808080; }
-    ChatLine[bg-color="0e", sender="self"] { background: #808080; }
-    ChatLine[fg-color="0f", sender="self"] { foreground: #c0c0c0; }
-    ChatLine[bg-color="0f", sender="self"] { background: #c0c0c0; }
-
 // mIRC formats
 ChatLine[format="bold"]      { font-weight: bold;}
 ChatLine[format="italic"]    { font-style: italic; }

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -294,7 +294,7 @@ QVector<QTextLayout::FormatRange> ChatItem::selectionFormats() const
     if (!hasSelection())
         return QVector<QTextLayout::FormatRange>();
 
-    int start, end;
+    quint16 start, end;
     if (_selectionMode == FullSelection) {
         start = 0;
         end = data(MessageModel::DisplayRole).toString().length();

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -153,7 +153,7 @@ void ChatItem::initLayoutHelper(QTextLayout *layout, QTextOption::WrapMode wrapM
     layout->setTextOption(option);
 
     QList<QTextLayout::FormatRange> formatRanges
-        = QtUi::style()->toTextLayoutList(formatList(), layout->text().length(), data(ChatLineModel::MsgLabelRole).toUInt());
+        = QtUi::style()->toTextLayoutList(formatList(), layout->text().length(), data(ChatLineModel::MsgLabelRole).value<UiStyle::MessageLabel>());
     layout->setAdditionalFormats(formatRanges);
 }
 
@@ -257,11 +257,11 @@ void ChatItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
 }
 
 
-void ChatItem::overlayFormat(UiStyle::FormatList &fmtList, int start, int end, quint32 overlayFmt) const
+void ChatItem::overlayFormat(UiStyle::FormatList &fmtList, quint16 start, quint16 end, UiStyle::FormatType overlayFmt) const
 {
-    for (int i = 0; i < fmtList.count(); i++) {
+    for (size_t i = 0; i < fmtList.size(); i++) {
         int fmtStart = fmtList.at(i).first;
-        int fmtEnd = (i < fmtList.count()-1 ? fmtList.at(i+1).first : data(MessageModel::DisplayRole).toString().length());
+        int fmtEnd = (i < fmtList.size()-1 ? fmtList.at(i+1).first : data(MessageModel::DisplayRole).toString().length());
 
         if (fmtEnd <= start)
             continue;
@@ -270,15 +270,15 @@ void ChatItem::overlayFormat(UiStyle::FormatList &fmtList, int start, int end, q
 
         // split the format if necessary
         if (fmtStart < start) {
-            fmtList.insert(i, fmtList.at(i));
+            fmtList.insert(fmtList.begin() + i, fmtList.at(i));
             fmtList[++i].first = start;
         }
         if (end < fmtEnd) {
-            fmtList.insert(i, fmtList.at(i));
+            fmtList.insert(fmtList.begin() + i, fmtList.at(i));
             fmtList[i+1].first = end;
         }
 
-        fmtList[i].second |= overlayFmt;
+        fmtList[i].second.type |= overlayFmt;
     }
 }
 
@@ -306,15 +306,15 @@ QVector<QTextLayout::FormatRange> ChatItem::selectionFormats() const
 
     UiStyle::FormatList fmtList = formatList();
 
-    while (fmtList.count() > 1 && fmtList.at(1).first <= start)
-        fmtList.removeFirst();
+    while (fmtList.size() > 1 && fmtList.at(1).first <= start)
+        fmtList.erase(fmtList.begin());
 
-    fmtList.first().first = start;
+    fmtList.front().first = start;
 
-    while (fmtList.count() > 1 && fmtList.last().first >= end)
-        fmtList.removeLast();
+    while (fmtList.size() > 1 && fmtList.back().first >= end)
+        fmtList.pop_back();
 
-    return QtUi::style()->toTextLayoutList(fmtList, end, UiStyle::Selected|data(ChatLineModel::MsgLabelRole).toUInt()).toVector();
+    return QtUi::style()->toTextLayoutList(fmtList, end, data(ChatLineModel::MsgLabelRole).value<UiStyle::MessageLabel>()|UiStyle::MessageLabel::Selected).toVector();
 }
 
 
@@ -567,7 +567,7 @@ ContentsChatItem::ContentsChatItem(const QPointF &pos, const qreal &width, ChatL
 
 QFontMetricsF *ContentsChatItem::fontMetrics() const
 {
-    return QtUi::style()->fontMetrics(data(ChatLineModel::FormatRole).value<UiStyle::FormatList>().at(0).second, 0);
+    return QtUi::style()->fontMetrics(data(ChatLineModel::FormatRole).value<UiStyle::FormatList>().at(0).second.type, UiStyle::MessageLabel::None);
 }
 
 
@@ -674,7 +674,7 @@ UiStyle::FormatList ContentsChatItem::formatList() const
     for (int i = 0; i < privateData()->clickables.count(); i++) {
         Clickable click = privateData()->clickables.at(i);
         if (click.type() == Clickable::Url) {
-            overlayFormat(fmtList, click.start(), click.start() + click.length(), UiStyle::Url);
+            overlayFormat(fmtList, click.start(), click.start() + click.length(), UiStyle::FormatType::Url);
         }
     }
     return fmtList;

--- a/src/qtui/chatitem.h
+++ b/src/qtui/chatitem.h
@@ -114,7 +114,7 @@ protected:
     void paintBackground(QPainter *);
     QVector<QTextLayout::FormatRange> selectionFormats() const;
     virtual QVector<QTextLayout::FormatRange> additionalFormats() const;
-    void overlayFormat(UiStyle::FormatList &fmtList, int start, int end, quint32 overlayFmt) const;
+    void overlayFormat(UiStyle::FormatList &fmtList, quint16 start, quint16 end, UiStyle::FormatType overlayFmt) const;
 
     inline qint16 selectionStart() const { return _selectionStart; }
     inline void setSelectionStart(qint16 start) { _selectionStart = start; }

--- a/src/qtui/chatline.cpp
+++ b/src/qtui/chatline.cpp
@@ -215,7 +215,7 @@ void ChatLine::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
     const QAbstractItemModel *model_ = model();
     QModelIndex myIdx = model_->index(row(), 0);
     Message::Type type = (Message::Type)myIdx.data(MessageModel::TypeRole).toInt();
-    UiStyle::MessageLabel label = (UiStyle::MessageLabel)myIdx.data(ChatLineModel::MsgLabelRole).toInt();
+    UiStyle::MessageLabel label = myIdx.data(ChatLineModel::MsgLabelRole).value<UiStyle::MessageLabel>();
 
     QTextCharFormat msgFmt = QtUi::style()->format(UiStyle::formatType(type), label);
     if (msgFmt.hasProperty(QTextFormat::BackgroundBrush)) {
@@ -223,7 +223,7 @@ void ChatLine::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
     }
 
     if (_selection & Selected) {
-        QTextCharFormat selFmt = QtUi::style()->format(UiStyle::formatType(type), label | UiStyle::Selected);
+        QTextCharFormat selFmt = QtUi::style()->format(UiStyle::formatType(type), label | UiStyle::MessageLabel::Selected);
         if (selFmt.hasProperty(QTextFormat::BackgroundBrush)) {
             qreal left = item((ChatLineModel::ColumnType)(_selection & ItemMask))->pos().x();
             QRectF selectRect(left, 0, width() - left, height());

--- a/src/qtui/chatline.cpp
+++ b/src/qtui/chatline.cpp
@@ -217,13 +217,13 @@ void ChatLine::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
     Message::Type type = (Message::Type)myIdx.data(MessageModel::TypeRole).toInt();
     UiStyle::MessageLabel label = myIdx.data(ChatLineModel::MsgLabelRole).value<UiStyle::MessageLabel>();
 
-    QTextCharFormat msgFmt = QtUi::style()->format(UiStyle::formatType(type), label);
+    QTextCharFormat msgFmt = QtUi::style()->format({UiStyle::formatType(type), {}, {}}, label);
     if (msgFmt.hasProperty(QTextFormat::BackgroundBrush)) {
         painter->fillRect(boundingRect(), msgFmt.background());
     }
 
     if (_selection & Selected) {
-        QTextCharFormat selFmt = QtUi::style()->format(UiStyle::formatType(type), label | UiStyle::MessageLabel::Selected);
+        QTextCharFormat selFmt = QtUi::style()->format({UiStyle::formatType(type), {}, {}}, label | UiStyle::MessageLabel::Selected);
         if (selFmt.hasProperty(QTextFormat::BackgroundBrush)) {
             qreal left = item((ChatLineModel::ColumnType)(_selection & ItemMask))->pos().x();
             QRectF selectRect(left, 0, width() - left, height());

--- a/src/qtui/chatlinemodelitem.cpp
+++ b/src/qtui/chatlinemodelitem.cpp
@@ -111,7 +111,7 @@ QVariant ChatLineModelItem::timestampData(int role) const
     case ChatLineModel::SelectedBackgroundRole:
         return backgroundBrush(UiStyle::FormatType::Timestamp, true);
     case ChatLineModel::FormatRole:
-        return QVariant::fromValue<UiStyle::FormatList>({std::make_pair(quint16{0}, UiStyle::Format{UiStyle::formatType(_styledMsg.type()) | UiStyle::FormatType::Timestamp})});
+        return QVariant::fromValue<UiStyle::FormatList>({std::make_pair(quint16{0}, UiStyle::Format{UiStyle::formatType(_styledMsg.type()) | UiStyle::FormatType::Timestamp, {}, {}})});
     }
     return QVariant();
 }
@@ -129,7 +129,7 @@ QVariant ChatLineModelItem::senderData(int role) const
     case ChatLineModel::SelectedBackgroundRole:
         return backgroundBrush(UiStyle::FormatType::Sender, true);
     case ChatLineModel::FormatRole:
-        return QVariant::fromValue<UiStyle::FormatList>({std::make_pair(quint16{0}, UiStyle::Format{UiStyle::formatType(_styledMsg.type()) | UiStyle::FormatType::Sender})});
+        return QVariant::fromValue<UiStyle::FormatList>({std::make_pair(quint16{0}, UiStyle::Format{UiStyle::formatType(_styledMsg.type()) | UiStyle::FormatType::Sender, {}, {}})});
     }
     return QVariant();
 }
@@ -171,7 +171,7 @@ UiStyle::MessageLabel ChatLineModelItem::messageLabel() const
 
 QVariant ChatLineModelItem::backgroundBrush(UiStyle::FormatType subelement, bool selected) const
 {
-    QTextCharFormat fmt = QtUi::style()->format(UiStyle::formatType(_styledMsg.type()) | subelement,
+    QTextCharFormat fmt = QtUi::style()->format({UiStyle::formatType(_styledMsg.type()) | subelement, {}, {}},
                                                 messageLabel() | (selected ? UiStyle::MessageLabel::Selected : UiStyle::MessageLabel::None));
     if (fmt.hasProperty(QTextFormat::BackgroundBrush))
         return QVariant::fromValue<QBrush>(fmt.background());

--- a/src/qtui/chatlinemodelitem.h
+++ b/src/qtui/chatlinemodelitem.h
@@ -18,8 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef CHATLINEMODELITEM_H_
-#define CHATLINEMODELITEM_H_
+#pragma once
 
 #include "messagemodel.h"
 
@@ -58,7 +57,7 @@ private:
     QVariant contentsData(int role) const;
 
     QVariant backgroundBrush(UiStyle::FormatType subelement, bool selected = false) const;
-    quint32 messageLabel() const;
+    UiStyle::MessageLabel messageLabel() const;
 
     void computeWrapList() const;
 
@@ -68,6 +67,3 @@ private:
     static unsigned char *TextBoundaryFinderBuffer;
     static int TextBoundaryFinderBufferSize;
 };
-
-
-#endif

--- a/src/qtui/markerlineitem.cpp
+++ b/src/qtui/markerlineitem.cpp
@@ -45,13 +45,13 @@ void MarkerLineItem::setChatLine(ChatLine *line)
 
 void MarkerLineItem::styleChanged()
 {
-    _brush = QtUi::style()->brush(UiStyle::MarkerLine);
+    _brush = QtUi::style()->brush(UiStyle::ColorRole::MarkerLine);
 
     // if this is a solid color, we assume 1px because wesurely  don't surely don't want to fill the entire chatline.
     // else, use the height of a single line of text to play around with gradients etc.
     qreal height = 1.;
     if (_brush.style() != Qt::SolidPattern)
-        height = QtUi::style()->fontMetrics(QtUiStyle::PlainMsg, 0)->lineSpacing();
+        height = QtUi::style()->fontMetrics(QtUiStyle::FormatType::PlainMsg, UiStyle::MessageLabel::None)->lineSpacing();
 
     prepareGeometryChange();
     _boundingRect = QRectF(0, 0, scene() ? scene()->width() : 100, height);

--- a/src/qtui/topicwidget.cpp
+++ b/src/qtui/topicwidget.cpp
@@ -202,7 +202,7 @@ void TopicWidget::updateResizeMode()
 void TopicWidget::clickableActivated(const Clickable &click)
 {
     NetworkId networkId = selectionModel()->currentIndex().data(NetworkModel::NetworkIdRole).value<NetworkId>();
-    UiStyle::StyledString sstr = GraphicalUi::uiStyle()->styleString(GraphicalUi::uiStyle()->mircToInternal(_topic), UiStyle::PlainMsg);
+    UiStyle::StyledString sstr = GraphicalUi::uiStyle()->styleString(GraphicalUi::uiStyle()->mircToInternal(_topic), UiStyle::FormatType::PlainMsg);
     click.activate(networkId, sstr.plainText);
 }
 

--- a/src/uisupport/qssparser.cpp
+++ b/src/uisupport/qssparser.cpp
@@ -322,8 +322,6 @@ std::pair<UiStyle::FormatType, UiStyle::MessageLabel> QssParser::parseFormatType
                     fmtType |= FormatType::Italic;
                 else if (condValue == "underline")
                     fmtType |= FormatType::Underline;
-                else if (condValue == "reverse")
-                    fmtType |= FormatType::Reverse;
                 else {
                     qWarning() << Q_FUNC_INFO << tr("Invalid format name: %1").arg(condValue);
                     return invalid;

--- a/src/uisupport/qssparser.cpp
+++ b/src/uisupport/qssparser.cpp
@@ -451,6 +451,20 @@ QTextCharFormat QssParser::parseFormat(const QString &qss)
         else if (property == "foreground" || property == "color")
             format.setForeground(parseBrush(value));
 
+        // Color code overrides
+        else if (property == "allow-foreground-override") {
+            bool ok;
+            bool v = parseBoolean(value, &ok);
+            if (ok)
+                format.setProperty(static_cast<int>(UiStyle::FormatProperty::AllowForegroundOverride), v);
+        }
+        else if (property == "allow-background-override") {
+            bool ok;
+            bool v = parseBoolean(value, &ok);
+            if (ok)
+                format.setProperty(static_cast<int>(UiStyle::FormatProperty::AllowBackgroundOverride), v);
+        }
+
         // font-related properties
         else if (property.startsWith("font")) {
             if (property == "font")
@@ -477,6 +491,23 @@ QTextCharFormat QssParser::parseFormat(const QString &qss)
     return format;
 }
 
+/******** Boolean value ********/
+
+bool QssParser::parseBoolean(const QString &str, bool *ok) const
+{
+    if (ok)
+        *ok = true;
+
+    if (str == "true")
+        return true;
+    if (str == "false")
+        return false;
+
+    qWarning() << Q_FUNC_INFO << tr("Invalid boolean value: %1").arg(str);
+    if (ok)
+        *ok = false;
+    return false;
+}
 
 /******** Brush ********/
 

--- a/src/uisupport/qssparser.cpp
+++ b/src/uisupport/qssparser.cpp
@@ -322,6 +322,8 @@ std::pair<UiStyle::FormatType, UiStyle::MessageLabel> QssParser::parseFormatType
                     fmtType |= FormatType::Italic;
                 else if (condValue == "underline")
                     fmtType |= FormatType::Underline;
+                else if (condValue == "strikethrough")
+                    fmtType |= FormatType::Strikethrough;
                 else {
                     qWarning() << Q_FUNC_INFO << tr("Invalid format name: %1").arg(condValue);
                     return invalid;
@@ -713,7 +715,7 @@ QGradientStops QssParser::parseGradientStops(const QString &str_)
 
 void QssParser::parseFont(const QString &value, QTextCharFormat *format)
 {
-    static const QRegExp rx("((?:(?:normal|italic|oblique|underline|bold|100|200|300|400|500|600|700|800|900) ){0,2}) ?(\\d+)(pt|px)? \"(.*)\"");
+    static const QRegExp rx("((?:(?:normal|italic|oblique|underline|strikethrough|bold|100|200|300|400|500|600|700|800|900) ){0,2}) ?(\\d+)(pt|px)? \"(.*)\"");
     if (!rx.exactMatch(value)) {
         qWarning() << Q_FUNC_INFO << tr("Invalid font specification: %1").arg(value);
         return;
@@ -726,6 +728,7 @@ void QssParser::parseFont(const QString &value, QTextCharFormat *format)
             format->setFontItalic(true);
         else if (prop == "underline")
             format->setFontUnderline(true);
+        // Oblique is not a property supported by QTextCharFormat
         //else if(prop == "oblique")
         //  format->setStyle(QFont::StyleOblique);
         else if (prop == "bold")
@@ -753,6 +756,9 @@ void QssParser::parseFontStyle(const QString &value, QTextCharFormat *format)
         format->setFontItalic(true);
     else if (value == "underline")
         format->setFontUnderline(true);
+    else if (value == "strikethrough")
+        format->setFontStrikeOut(true);
+    // Oblique is not a property supported by QTextCharFormat
     //else if(value == "oblique")
     //  format->setStyle(QFont::StyleOblique);
     else {

--- a/src/uisupport/qssparser.h
+++ b/src/uisupport/qssparser.h
@@ -18,8 +18,9 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef QSSPARSER_H_
-#define QSSPARSER_H_
+#pragma once
+
+#include <utility>
 
 #include "uistyle.h"
 
@@ -35,7 +36,7 @@ public:
     inline QPalette palette() const { return _palette; }
     inline QVector<QBrush> uiStylePalette() const { return _uiStylePalette; }
     inline const QHash<quint64, QTextCharFormat> &formats() const { return _formats; }
-    inline const QHash<quint32, QTextCharFormat> &listItemFormats() const { return _listItemFormats; }
+    inline const QHash<UiStyle::ItemFormatType, QTextCharFormat> &listItemFormats() const { return _listItemFormats; }
 
 protected:
     typedef QList<qreal> ColorTuple;
@@ -44,8 +45,8 @@ protected:
     void parsePaletteBlock(const QString &decl, const QString &contents);
     void parseListItemBlock(const QString &decl, const QString &contents);
 
-    quint64 parseFormatType(const QString &decl);
-    quint32 parseItemFormatType(const QString &decl);
+    std::pair<UiStyle::FormatType, UiStyle::MessageLabel> parseFormatType(const QString &decl);
+    UiStyle::ItemFormatType parseItemFormatType(const QString &decl);
 
     QTextCharFormat parseFormat(const QString &qss);
 
@@ -69,8 +70,5 @@ private:
     QPalette _palette;
     QVector<QBrush> _uiStylePalette;
     QHash<quint64, QTextCharFormat> _formats;
-    QHash<quint32, QTextCharFormat> _listItemFormats;
+    QHash<UiStyle::ItemFormatType, QTextCharFormat> _listItemFormats;
 };
-
-
-#endif

--- a/src/uisupport/qssparser.h
+++ b/src/uisupport/qssparser.h
@@ -50,8 +50,11 @@ protected:
 
     QTextCharFormat parseFormat(const QString &qss);
 
+    // Parse boolean properties
+    bool parseBoolean(const QString &str, bool *ok = nullptr) const;
+
     // Parse color/brush-related properties
-    QBrush parseBrush(const QString &str, bool *ok = 0);
+    QBrush parseBrush(const QString &str, bool *ok = nullptr);
     QColor parseColor(const QString &str);
     ColorTuple parseColorTuple(const QString &str);
     QGradientStops parseGradientStops(const QString &str);

--- a/src/uisupport/styledlabel.cpp
+++ b/src/uisupport/styledlabel.cpp
@@ -122,8 +122,8 @@ void StyledLabel::setText(const QString &text)
 {
     UiStyle *style = GraphicalUi::uiStyle();
 
-    UiStyle::StyledString sstr = style->styleString(style->mircToInternal(text), UiStyle::PlainMsg);
-    QList<QTextLayout::FormatRange> layoutList = style->toTextLayoutList(sstr.formatList, sstr.plainText.length(), 0);
+    UiStyle::StyledString sstr = style->styleString(style->mircToInternal(text), UiStyle::FormatType::PlainMsg);
+    QList<QTextLayout::FormatRange> layoutList = style->toTextLayoutList(sstr.formatList, sstr.plainText.length(), UiStyle::MessageLabel::None);
 
     // Use default font rather than the style's
     QTextLayout::FormatRange fmtRange;

--- a/src/uisupport/uisettings.cpp
+++ b/src/uisupport/uisettings.cpp
@@ -39,19 +39,19 @@ UiStyleSettings::UiStyleSettings(const QString &subGroup) : UiSettings(QString("
 
 void UiStyleSettings::setCustomFormat(UiStyle::FormatType ftype, QTextCharFormat format)
 {
-    setLocalValue(QString("Format/%1").arg(ftype), format);
+    setLocalValue(QString("Format/%1").arg(static_cast<quint32>(ftype)), format);
 }
 
 
 QTextCharFormat UiStyleSettings::customFormat(UiStyle::FormatType ftype)
 {
-    return localValue(QString("Format/%1").arg(ftype), QTextFormat()).value<QTextFormat>().toCharFormat();
+    return localValue(QString("Format/%1").arg(static_cast<quint32>(ftype)), QTextFormat()).value<QTextFormat>().toCharFormat();
 }
 
 
 void UiStyleSettings::removeCustomFormat(UiStyle::FormatType ftype)
 {
-    removeLocalKey(QString("Format/%1").arg(ftype));
+    removeLocalKey(QString("Format/%1").arg(static_cast<quint32>(ftype)));
 }
 
 

--- a/src/uisupport/uistyle.cpp
+++ b/src/uisupport/uistyle.cpp
@@ -757,6 +757,9 @@ QString UiStyle::mircToInternal(const QString &mirc_)
                 case '\x09':
                     mirc += "        ";
                     break;
+                case '\x11':
+                    // Monospace not supported yet
+                    break;
                 case '\x12':
                 case '\x16':
                     mirc += "%R";

--- a/src/uisupport/uistyle.cpp
+++ b/src/uisupport/uistyle.cpp
@@ -18,6 +18,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
+#include <vector>
+
 #include <QApplication>
 #include <QIcon>
 
@@ -55,20 +57,20 @@ UiStyle::UiStyle(QObject *parent)
         Q_ASSERT(QVariant::nameToType("UiStyle::FormatList") != QVariant::Invalid);
     }
 
-    _uiStylePalette = QVector<QBrush>(NumRoles, QBrush());
+    _uiStylePalette = QVector<QBrush>(static_cast<int>(ColorRole::NumRoles), QBrush());
 
     // Now initialize the mapping between FormatCodes and FormatTypes...
-    _formatCodes["%O"] = Base;
-    _formatCodes["%B"] = Bold;
-    _formatCodes["%S"] = Italic;
-    _formatCodes["%U"] = Underline;
-    _formatCodes["%R"] = Reverse;
+    _formatCodes["%O"] = FormatType::Base;
+    _formatCodes["%B"] = FormatType::Bold;
+    _formatCodes["%S"] = FormatType::Italic;
+    _formatCodes["%U"] = FormatType::Underline;
+    _formatCodes["%R"] = FormatType::Reverse;
 
-    _formatCodes["%DN"] = Nick;
-    _formatCodes["%DH"] = Hostmask;
-    _formatCodes["%DC"] = ChannelName;
-    _formatCodes["%DM"] = ModeFlags;
-    _formatCodes["%DU"] = Url;
+    _formatCodes["%DN"] = FormatType::Nick;
+    _formatCodes["%DH"] = FormatType::Hostmask;
+    _formatCodes["%DC"] = FormatType::ChannelName;
+    _formatCodes["%DM"] = FormatType::ModeFlags;
+    _formatCodes["%DU"] = FormatType::Url;
 
     // Initialize fallback defaults
     // NOTE: If you change this, update qtui/chatviewsettings.h, too.  More explanations available
@@ -283,44 +285,44 @@ QVariant UiStyle::bufferViewItemData(const QModelIndex &index, int role) const
         }
     }
 
-    quint32 fmtType = BufferViewItem;
+    ItemFormatType fmtType = ItemFormatType::BufferViewItem;
     switch (type) {
     case BufferInfo::StatusBuffer:
-        fmtType |= NetworkItem;
+        fmtType |= ItemFormatType::NetworkItem;
         break;
     case BufferInfo::ChannelBuffer:
-        fmtType |= ChannelBufferItem;
+        fmtType |= ItemFormatType::ChannelBufferItem;
         break;
     case BufferInfo::QueryBuffer:
-        fmtType |= QueryBufferItem;
+        fmtType |= ItemFormatType::QueryBufferItem;
         break;
     default:
         return QVariant();
     }
 
-    QTextCharFormat fmt = _listItemFormats.value(BufferViewItem);
+    QTextCharFormat fmt = _listItemFormats.value(ItemFormatType::BufferViewItem);
     fmt.merge(_listItemFormats.value(fmtType));
 
     BufferInfo::ActivityLevel activity = (BufferInfo::ActivityLevel)index.data(NetworkModel::BufferActivityRole).toInt();
     if (activity & BufferInfo::Highlight) {
-        fmt.merge(_listItemFormats.value(BufferViewItem | HighlightedBuffer));
-        fmt.merge(_listItemFormats.value(fmtType | HighlightedBuffer));
+        fmt.merge(_listItemFormats.value(ItemFormatType::BufferViewItem | ItemFormatType::HighlightedBuffer));
+        fmt.merge(_listItemFormats.value(fmtType | ItemFormatType::HighlightedBuffer));
     }
     else if (activity & BufferInfo::NewMessage) {
-        fmt.merge(_listItemFormats.value(BufferViewItem | UnreadBuffer));
-        fmt.merge(_listItemFormats.value(fmtType | UnreadBuffer));
+        fmt.merge(_listItemFormats.value(ItemFormatType::BufferViewItem | ItemFormatType::UnreadBuffer));
+        fmt.merge(_listItemFormats.value(fmtType | ItemFormatType::UnreadBuffer));
     }
     else if (activity & BufferInfo::OtherActivity) {
-        fmt.merge(_listItemFormats.value(BufferViewItem | ActiveBuffer));
-        fmt.merge(_listItemFormats.value(fmtType | ActiveBuffer));
+        fmt.merge(_listItemFormats.value(ItemFormatType::BufferViewItem | ItemFormatType::ActiveBuffer));
+        fmt.merge(_listItemFormats.value(fmtType | ItemFormatType::ActiveBuffer));
     }
     else if (!isActive) {
-        fmt.merge(_listItemFormats.value(BufferViewItem | InactiveBuffer));
-        fmt.merge(_listItemFormats.value(fmtType | InactiveBuffer));
+        fmt.merge(_listItemFormats.value(ItemFormatType::BufferViewItem | ItemFormatType::InactiveBuffer));
+        fmt.merge(_listItemFormats.value(fmtType | ItemFormatType::InactiveBuffer));
     }
     else if (index.data(NetworkModel::UserAwayRole).toBool()) {
-        fmt.merge(_listItemFormats.value(BufferViewItem | UserAway));
-        fmt.merge(_listItemFormats.value(fmtType | UserAway));
+        fmt.merge(_listItemFormats.value(ItemFormatType::BufferViewItem | ItemFormatType::UserAway));
+        fmt.merge(_listItemFormats.value(fmtType | ItemFormatType::UserAway));
     }
 
     return itemData(role, fmt);
@@ -355,18 +357,18 @@ QVariant UiStyle::nickViewItemData(const QModelIndex &index, int role) const
         }
     }
 
-    QTextCharFormat fmt = _listItemFormats.value(NickViewItem);
+    QTextCharFormat fmt = _listItemFormats.value(ItemFormatType::NickViewItem);
 
     switch (type) {
     case NetworkModel::IrcUserItemType:
-        fmt.merge(_listItemFormats.value(NickViewItem | IrcUserItem));
+        fmt.merge(_listItemFormats.value(ItemFormatType::NickViewItem | ItemFormatType::IrcUserItem));
         if (!index.data(NetworkModel::ItemActiveRole).toBool()) {
-            fmt.merge(_listItemFormats.value(NickViewItem | UserAway));
-            fmt.merge(_listItemFormats.value(NickViewItem | IrcUserItem | UserAway));
+            fmt.merge(_listItemFormats.value(ItemFormatType::NickViewItem | ItemFormatType::UserAway));
+            fmt.merge(_listItemFormats.value(ItemFormatType::NickViewItem | ItemFormatType::IrcUserItem | ItemFormatType::UserAway));
         }
         break;
     case NetworkModel::UserCategoryItemType:
-        fmt.merge(_listItemFormats.value(NickViewItem | UserCategoryItem));
+        fmt.merge(_listItemFormats.value(ItemFormatType::NickViewItem | ItemFormatType::UserCategoryItem));
         break;
     default:
         return QVariant();
@@ -399,22 +401,22 @@ QTextCharFormat UiStyle::format(quint64 key) const
 }
 
 
-QTextCharFormat UiStyle::cachedFormat(quint32 formatType, quint32 messageLabel) const
+QTextCharFormat UiStyle::cachedFormat(FormatType formatType, MessageLabel messageLabel) const
 {
-    return _formatCache.value(formatType | ((quint64)messageLabel << 32), QTextCharFormat());
+    return _formatCache.value(formatType | messageLabel, QTextCharFormat());
 }
 
 
-void UiStyle::setCachedFormat(const QTextCharFormat &format, quint32 formatType, quint32 messageLabel) const
+void UiStyle::setCachedFormat(const QTextCharFormat &format, FormatType formatType, MessageLabel messageLabel) const
 {
-    _formatCache[formatType | ((quint64)messageLabel << 32)] = format;
+    _formatCache[formatType | messageLabel] = format;
 }
 
 
-QFontMetricsF *UiStyle::fontMetrics(quint32 ftype, quint32 label) const
+QFontMetricsF *UiStyle::fontMetrics(FormatType ftype, MessageLabel label) const
 {
     // QFontMetricsF is not assignable, so we need to store pointers :/
-    quint64 key = ftype | ((quint64)label << 32);
+    quint64 key = ftype | label;
 
     if (_metricsCache.contains(key))
         return _metricsCache.value(key);
@@ -427,39 +429,37 @@ QFontMetricsF *UiStyle::fontMetrics(quint32 ftype, quint32 label) const
 
 // NOTE: This and the following functions are intimately tied to the values in FormatType. Don't change this
 //       until you _really_ know what you do!
-QTextCharFormat UiStyle::format(quint32 ftype, quint32 label_) const
+QTextCharFormat UiStyle::format(FormatType ftype, MessageLabel label) const
 {
-    if (ftype == Invalid)
-        return QTextCharFormat();
-
-    quint64 label = (quint64)label_ << 32;
+    if (ftype == FormatType::Invalid)
+        return {};
 
     // check if we have exactly this format readily cached already
-    QTextCharFormat fmt = cachedFormat(ftype, label_);
+    QTextCharFormat fmt = cachedFormat(ftype, label);
     if (fmt.properties().count())
         return fmt;
 
-    mergeFormat(fmt, ftype, label & Q_UINT64_C(0xffff000000000000));
+    mergeFormat(fmt, ftype, label & 0xffff0000);  // keep nickhash in label
 
-    for (quint64 mask = Q_UINT64_C(0x0000000100000000); mask <= (quint64)Selected << 32; mask <<= 1) {
-        if (label & mask)
-            mergeFormat(fmt, ftype, mask | Q_UINT64_C(0xffff000000000000));
+    for (quint32 mask = 0x00000001; mask <= static_cast<quint32>(MessageLabel::Selected); mask <<= 1) {
+        if (static_cast<quint32>(label) & mask)
+            mergeFormat(fmt, ftype, label & (mask | 0xffff0000));
     }
 
-    setCachedFormat(fmt, ftype, label_);
+    setCachedFormat(fmt, ftype, label);
     return fmt;
 }
 
 
-void UiStyle::mergeFormat(QTextCharFormat &fmt, quint32 ftype, quint64 label) const
+void UiStyle::mergeFormat(QTextCharFormat &fmt, FormatType ftype, MessageLabel label) const
 {
     mergeSubElementFormat(fmt, ftype & 0x00ff, label);
 
     // TODO: allow combinations for mirc formats and colors (each), e.g. setting a special format for "bold and italic"
     //       or "foreground 01 and background 03"
-    if ((ftype & 0xfff00)) { // element format
+    if ((ftype & 0xfff00) != FormatType::Base) { // element format
         for (quint32 mask = 0x00100; mask <= 0x40000; mask <<= 1) {
-            if (ftype & mask) {
+            if ((ftype & mask) != FormatType::Base) {
                 mergeSubElementFormat(fmt, ftype & (mask | 0xff), label);
             }
         }
@@ -468,28 +468,28 @@ void UiStyle::mergeFormat(QTextCharFormat &fmt, quint32 ftype, quint64 label) co
     // Now we handle color codes
     // We assume that those can't be combined with subelement and message types.
     if (_allowMircColors) {
-        if (ftype & 0x00400000)
+        if ((ftype & 0x00400000) != FormatType::Base)
             mergeSubElementFormat(fmt, ftype & 0x0f400000, label);  // foreground
-        if (ftype & 0x00800000)
+        if ((ftype & 0x00800000) != FormatType::Base)
             mergeSubElementFormat(fmt, ftype & 0xf0800000, label);  // background
-        if ((ftype & 0x00c00000) == 0x00c00000)
+        if ((ftype & 0x00c00000) == static_cast<FormatType>(0x00c00000))
             mergeSubElementFormat(fmt, ftype & 0xffc00000, label);  // combination
     }
 
     // URL
-    if (ftype & Url)
-        mergeSubElementFormat(fmt, ftype & (Url | 0x000000ff), label);
+    if ((ftype & FormatType::Url) != FormatType::Base)
+        mergeSubElementFormat(fmt, ftype & (FormatType::Url | static_cast<FormatType>(0x000000ff)), label);
 }
 
 
 // Merge a subelement format into an existing message format
-void UiStyle::mergeSubElementFormat(QTextCharFormat &fmt, quint32 ftype, quint64 label) const
+void UiStyle::mergeSubElementFormat(QTextCharFormat &fmt, FormatType ftype, MessageLabel label) const
 {
     quint64 key = ftype | label;
-    fmt.merge(format(key & Q_UINT64_C(0x0000ffffffffff00))); // label + subelement
-    fmt.merge(format(key & Q_UINT64_C(0x0000ffffffffffff))); // label + subelement + msgtype
-    fmt.merge(format(key & Q_UINT64_C(0xffffffffffffff00))); // label + subelement + nickhash
-    fmt.merge(format(key & Q_UINT64_C(0xffffffffffffffff))); // label + subelement + nickhash + msgtype
+    fmt.merge(format(key & 0x0000ffffffffff00ull)); // label + subelement
+    fmt.merge(format(key & 0x0000ffffffffffffull)); // label + subelement + msgtype
+    fmt.merge(format(key & 0xffffffffffffff00ull)); // label + subelement + nickhash
+    fmt.merge(format(key & 0xffffffffffffffffull)); // label + subelement + nickhash + msgtype
 }
 
 
@@ -497,52 +497,53 @@ UiStyle::FormatType UiStyle::formatType(Message::Type msgType)
 {
     switch (msgType) {
     case Message::Plain:
-        return PlainMsg;
+        return FormatType::PlainMsg;
     case Message::Notice:
-        return NoticeMsg;
+        return FormatType::NoticeMsg;
     case Message::Action:
-        return ActionMsg;
+        return FormatType::ActionMsg;
     case Message::Nick:
-        return NickMsg;
+        return FormatType::NickMsg;
     case Message::Mode:
-        return ModeMsg;
+        return FormatType::ModeMsg;
     case Message::Join:
-        return JoinMsg;
+        return FormatType::JoinMsg;
     case Message::Part:
-        return PartMsg;
+        return FormatType::PartMsg;
     case Message::Quit:
-        return QuitMsg;
+        return FormatType::QuitMsg;
     case Message::Kick:
-        return KickMsg;
+        return FormatType::KickMsg;
     case Message::Kill:
-        return KillMsg;
+        return FormatType::KillMsg;
     case Message::Server:
-        return ServerMsg;
+        return FormatType::ServerMsg;
     case Message::Info:
-        return InfoMsg;
+        return FormatType::InfoMsg;
     case Message::Error:
-        return ErrorMsg;
+        return FormatType::ErrorMsg;
     case Message::DayChange:
-        return DayChangeMsg;
+        return FormatType::DayChangeMsg;
     case Message::Topic:
-        return TopicMsg;
+        return FormatType::TopicMsg;
     case Message::NetsplitJoin:
-        return NetsplitJoinMsg;
+        return FormatType::NetsplitJoinMsg;
     case Message::NetsplitQuit:
-        return NetsplitQuitMsg;
+        return FormatType::NetsplitQuitMsg;
     case Message::Invite:
-        return InviteMsg;
+        return FormatType::InviteMsg;
     }
     //Q_ASSERT(false); // we need to handle all message types
     qWarning() << Q_FUNC_INFO << "Unknown message type:" << msgType;
-    return ErrorMsg;
+    return FormatType::ErrorMsg;
 }
 
 
 UiStyle::FormatType UiStyle::formatType(const QString &code)
 {
-    if (_formatCodes.contains(code)) return _formatCodes.value(code);
-    return Invalid;
+    if (_formatCodes.contains(code))
+        return _formatCodes.value(code);
+    return FormatType::Invalid;
 }
 
 
@@ -552,29 +553,31 @@ QString UiStyle::formatCode(FormatType ftype)
 }
 
 
-QList<QTextLayout::FormatRange> UiStyle::toTextLayoutList(const FormatList &formatList, int textLength, quint32 messageLabel) const
+QList<QTextLayout::FormatRange> UiStyle::toTextLayoutList(const FormatList &formatList, int textLength, MessageLabel messageLabel) const
 {
     QList<QTextLayout::FormatRange> formatRanges;
     QTextLayout::FormatRange range;
-    int i = 0;
-    for (i = 0; i < formatList.count(); i++) {
-        range.format = format(formatList.at(i).second, messageLabel);
+    size_t i = 0;
+    for (i = 0; i < formatList.size(); i++) {
+        range.format = format(formatList.at(i).second.type, messageLabel);
         range.start = formatList.at(i).first;
-        if (i > 0) formatRanges.last().length = range.start - formatRanges.last().start;
+        if (i > 0)
+            formatRanges.last().length = range.start - formatRanges.last().start;
         formatRanges.append(range);
     }
-    if (i > 0) formatRanges.last().length = textLength - formatRanges.last().start;
+    if (i > 0)
+        formatRanges.last().length = textLength - formatRanges.last().start;
     return formatRanges;
 }
 
 
 // This method expects a well-formatted string, there is no error checking!
 // Since we create those ourselves, we should be pretty safe that nobody does something crappy here.
-UiStyle::StyledString UiStyle::styleString(const QString &s_, quint32 baseFormat)
+UiStyle::StyledString UiStyle::styleString(const QString &s_, FormatType baseFormat)
 {
     QString s = s_;
     StyledString result;
-    result.formatList.append(qMakePair((quint16)0, baseFormat));
+    result.formatList.emplace_back(std::make_pair(quint16{0}, Format{baseFormat}));
 
     if (s.length() > 65535) {
         // We use quint16 for indexes
@@ -583,7 +586,8 @@ UiStyle::StyledString UiStyle::styleString(const QString &s_, quint32 baseFormat
         return result;
     }
 
-    quint32 curfmt = baseFormat;
+    FormatType curfmt = baseFormat;
+
     int pos = 0; quint16 length = 0;
     for (;;) {
         pos = s.indexOf('%', pos);
@@ -626,7 +630,7 @@ UiStyle::StyledString UiStyle::styleString(const QString &s_, quint32 baseFormat
             QString code = QString("%") + s[pos+1];
             if (s[pos+1] == 'D') code += s[pos+2];
             FormatType ftype = formatType(code);
-            if (ftype == Invalid) {
+            if (ftype == FormatType::Invalid) {
                 pos++;
                 qWarning() << (QString("Invalid format code in string: %1").arg(s));
                 continue;
@@ -635,10 +639,10 @@ UiStyle::StyledString UiStyle::styleString(const QString &s_, quint32 baseFormat
             length = code.length();
         }
         s.remove(pos, length);
-        if (pos == result.formatList.last().first)
-            result.formatList.last().second = curfmt;
+        if (pos == result.formatList.back().first)
+            result.formatList.back().second.type = curfmt;
         else
-            result.formatList.append(qMakePair((quint16)pos, curfmt));
+            result.formatList.emplace_back(std::make_pair(pos, Format{curfmt}));
     }
     result.plainText = s;
     return result;
@@ -928,44 +932,43 @@ QString UiStyle::StyledMessage::decoratedSender() const
             return QString("<%1%2>").arg(_senderPrefixes, plainSender());
         else
             return QString("%1%2").arg(_senderPrefixes, plainSender());
-        break;
     case Message::Notice:
-        return QString("[%1%2]").arg(_senderPrefixes, plainSender()); break;
+        return QString("[%1%2]").arg(_senderPrefixes, plainSender());
     case Message::Action:
-        return "-*-"; break;
+        return "-*-";
     case Message::Nick:
-        return "<->"; break;
+        return "<->";
     case Message::Mode:
-        return "***"; break;
+        return "***";
     case Message::Join:
-        return "-->"; break;
+        return "-->";
     case Message::Part:
-        return "<--"; break;
+        return "<--";
     case Message::Quit:
-        return "<--"; break;
+        return "<--";
     case Message::Kick:
-        return "<-*"; break;
+        return "<-*";
     case Message::Kill:
-        return "<-x"; break;
+        return "<-x";
     case Message::Server:
-        return "*"; break;
+        return "*";
     case Message::Info:
-        return "*"; break;
+        return "*";
     case Message::Error:
-        return "*"; break;
+        return "*";
     case Message::DayChange:
-        return "-"; break;
+        return "-";
     case Message::Topic:
-        return "*"; break;
+        return "*";
     case Message::NetsplitJoin:
-        return "=>"; break;
+        return "=>";
     case Message::NetsplitQuit:
-        return "<="; break;
+        return "<=";
     case Message::Invite:
-        return "->"; break;
-    default:
-        return QString("%1%2").arg(_senderPrefixes, plainSender());
+        return "->";
     }
+
+    return QString("%1%2").arg(_senderPrefixes, plainSender());
 }
 
 
@@ -999,15 +1002,132 @@ quint8 UiStyle::StyledMessage::senderHash() const
     return (_senderHash = (hash & 0xf) + 1);
 }
 
+/***********************************************************************************/
+
+#if QT_VERSION < 0x050000
+uint qHash(UiStyle::ItemFormatType key)
+{
+    return qHash(static_cast<quint32>(key));
+}
+
+#else
+
+uint qHash(UiStyle::ItemFormatType key, uint seed)
+{
+    return qHash(static_cast<quint32>(key), seed);
+}
+#endif
+
+UiStyle::FormatType operator|(UiStyle::FormatType lhs, UiStyle::FormatType rhs)
+{
+    return static_cast<UiStyle::FormatType>(static_cast<quint32>(lhs) | static_cast<quint32>(rhs));
+}
+
+UiStyle::FormatType& operator|=(UiStyle::FormatType& lhs, UiStyle::FormatType rhs)
+{
+    lhs = static_cast<UiStyle::FormatType>(static_cast<quint32>(lhs) | static_cast<quint32>(rhs));
+    return lhs;
+}
+
+
+UiStyle::FormatType operator|(UiStyle::FormatType lhs, quint32 rhs)
+{
+    return static_cast<UiStyle::FormatType>(static_cast<quint32>(lhs) | rhs);
+}
+
+
+UiStyle::FormatType& operator|=(UiStyle::FormatType &lhs, quint32 rhs)
+{
+    lhs = static_cast<UiStyle::FormatType>(static_cast<quint32>(lhs) | rhs);
+    return lhs;
+}
+
+
+UiStyle::FormatType operator&(UiStyle::FormatType lhs, UiStyle::FormatType rhs)
+{
+    return static_cast<UiStyle::FormatType>(static_cast<quint32>(lhs) & static_cast<quint32>(rhs));
+}
+
+
+UiStyle::FormatType& operator&=(UiStyle::FormatType &lhs, UiStyle::FormatType rhs)
+{
+    lhs = static_cast<UiStyle::FormatType>(static_cast<quint32>(lhs) & static_cast<quint32>(rhs));
+    return lhs;
+}
+
+
+UiStyle::FormatType operator&(UiStyle::FormatType lhs, quint32 rhs)
+{
+    return static_cast<UiStyle::FormatType>(static_cast<quint32>(lhs) & rhs);
+}
+
+
+UiStyle::FormatType& operator&=(UiStyle::FormatType &lhs, quint32 rhs)
+{
+    lhs = static_cast<UiStyle::FormatType>(static_cast<quint32>(lhs) & rhs);
+    return lhs;
+}
+
+
+UiStyle::FormatType& operator^=(UiStyle::FormatType &lhs, UiStyle::FormatType rhs)
+{
+    lhs = static_cast<UiStyle::FormatType>(static_cast<quint32>(lhs) ^ static_cast<quint32>(rhs));
+    return lhs;
+}
+
+
+UiStyle::MessageLabel operator|(UiStyle::MessageLabel lhs, UiStyle::MessageLabel rhs)
+{
+    return static_cast<UiStyle::MessageLabel>(static_cast<quint32>(lhs) | static_cast<quint32>(rhs));
+}
+
+
+UiStyle::MessageLabel& operator|=(UiStyle::MessageLabel &lhs, UiStyle::MessageLabel rhs)
+{
+    lhs = static_cast<UiStyle::MessageLabel>(static_cast<quint32>(lhs) | static_cast<quint32>(rhs));
+    return lhs;
+}
+
+
+UiStyle::MessageLabel operator&(UiStyle::MessageLabel lhs, quint32 rhs)
+{
+    return static_cast<UiStyle::MessageLabel>(static_cast<quint32>(lhs) & rhs);
+}
+
+
+UiStyle::MessageLabel& operator&=(UiStyle::MessageLabel &lhs, UiStyle::MessageLabel rhs)
+{
+    lhs = static_cast<UiStyle::MessageLabel>(static_cast<quint32>(lhs) & static_cast<quint32>(rhs));
+    return lhs;
+}
+
+
+quint64 operator|(UiStyle::FormatType lhs, UiStyle::MessageLabel rhs)
+{
+    return static_cast<quint64>(lhs) | (static_cast<quint64>(rhs) << 32ull);
+}
+
+
+UiStyle::ItemFormatType operator|(UiStyle::ItemFormatType lhs, UiStyle::ItemFormatType rhs)
+{
+    return static_cast<UiStyle::ItemFormatType>(static_cast<quint32>(lhs) | static_cast<quint32>(rhs));
+}
+
+
+UiStyle::ItemFormatType& operator|=(UiStyle::ItemFormatType &lhs, UiStyle::ItemFormatType rhs)
+{
+    lhs = static_cast<UiStyle::ItemFormatType>(static_cast<quint32>(lhs) | static_cast<quint32>(rhs));
+    return lhs;
+}
 
 /***********************************************************************************/
 
 QDataStream &operator<<(QDataStream &out, const UiStyle::FormatList &formatList)
 {
-    out << formatList.count();
+    out << static_cast<quint16>(formatList.size());
     UiStyle::FormatList::const_iterator it = formatList.begin();
     while (it != formatList.end()) {
-        out << (*it).first << (*it).second;
+        out << it->first << static_cast<quint32>(it->second.type);
         ++it;
     }
     return out;
@@ -1021,7 +1141,7 @@ QDataStream &operator>>(QDataStream &in, UiStyle::FormatList &formatList)
     for (quint16 i = 0; i < cnt; i++) {
         quint16 pos; quint32 ftype;
         in >> pos >> ftype;
-        formatList.append(qMakePair((quint16)pos, ftype));
+        formatList.emplace_back(std::make_pair(quint16{pos}, UiStyle::Format{static_cast<UiStyle::FormatType>(ftype)}));
     }
     return in;
 }

--- a/src/uisupport/uistyle.cpp
+++ b/src/uisupport/uistyle.cpp
@@ -72,13 +72,12 @@ UiStyle::UiStyle(QObject *parent)
     _opIconLimit(UserCategoryItem::categoryFromModes("o")),
     _voiceIconLimit(UserCategoryItem::categoryFromModes("v"))
 {
-    // register FormatList if that hasn't happened yet
-    // FIXME I don't think this actually avoids double registration... then again... does it hurt?
-    if (QVariant::nameToType("UiStyle::FormatList") == QVariant::Invalid) {
-        qRegisterMetaType<FormatList>("UiStyle::FormatList");
-        qRegisterMetaTypeStreamOperators<FormatList>("UiStyle::FormatList");
-        Q_ASSERT(QVariant::nameToType("UiStyle::FormatList") != QVariant::Invalid);
-    }
+    static bool registered = []() {
+        qRegisterMetaType<FormatList>();
+        qRegisterMetaTypeStreamOperators<FormatList>();
+        return true;
+    }();
+    Q_UNUSED(registered)
 
     _uiStylePalette = QVector<QBrush>(static_cast<int>(ColorRole::NumRoles), QBrush());
 

--- a/src/uisupport/uistyle.cpp
+++ b/src/uisupport/uistyle.cpp
@@ -85,8 +85,9 @@ UiStyle::UiStyle(QObject *parent)
     // Now initialize the mapping between FormatCodes and FormatTypes...
     _formatCodes["%O"] = FormatType::Base;
     _formatCodes["%B"] = FormatType::Bold;
-    _formatCodes["%S"] = FormatType::Italic;
+    _formatCodes["%I"] = FormatType::Italic;
     _formatCodes["%U"] = FormatType::Underline;
+    _formatCodes["%S"] = FormatType::Strikethrough;
 
     _formatCodes["%DN"] = FormatType::Nick;
     _formatCodes["%DH"] = FormatType::Hostmask;
@@ -761,6 +762,9 @@ QString UiStyle::mircToInternal(const QString &mirc_)
                     mirc += "%R";
                     break;
                 case '\x1d':
+                    mirc += "%I";
+                    break;
+                case '\x1e':
                     mirc += "%S";
                     break;
                 case '\x1f':

--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -81,6 +81,7 @@ public:
         Bold            = 0x00000100,
         Italic          = 0x00000200,
         Underline       = 0x00000400,
+        Strikethrough   = 0x00000800,
 
         // Individual parts of a message
         Timestamp       = 0x00001000,

--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include <QColor>
 #include <QDataStream>
 #include <QFontMetricsF>
 #include <QHash>
@@ -158,6 +159,8 @@ public:
 
     struct Format {
         FormatType type;
+        QColor foreground;
+        QColor background;
     };
 
     using FormatList = std::vector<std::pair<quint16, Format>>;
@@ -242,7 +245,7 @@ public:
      */
     static QString timestampFormatString();
 
-    QTextCharFormat format(FormatType formatType, MessageLabel messageLabel) const;
+    QTextCharFormat format(const Format &format, MessageLabel messageLabel) const;
     QFontMetricsF *fontMetrics(FormatType formatType, MessageLabel messageLabel) const;
 
     QList<QTextLayout::FormatRange> toTextLayoutList(const FormatList &, int textLength, MessageLabel messageLabel) const;
@@ -264,10 +267,10 @@ protected:
     QString loadStyleSheet(const QString &name, bool shouldExist = false);
 
     QTextCharFormat format(quint64 key) const;
-    QTextCharFormat cachedFormat(FormatType formatType, MessageLabel messageLabel) const;
-    void setCachedFormat(const QTextCharFormat &format, FormatType formatType, MessageLabel messageLabel) const;
-    void mergeFormat(QTextCharFormat &format, FormatType formatType, MessageLabel messageLabel) const;
-    void mergeSubElementFormat(QTextCharFormat &format, FormatType formatType, MessageLabel messageLabel) const;
+    QTextCharFormat cachedFormat(const Format &format, MessageLabel messageLabel) const;
+    void setCachedFormat(const QTextCharFormat &charFormat, const Format &format, MessageLabel messageLabel) const;
+    void mergeFormat(QTextCharFormat &charFormat, const Format &format, MessageLabel messageLabel) const;
+    void mergeSubElementFormat(QTextCharFormat &charFormat, FormatType formatType, MessageLabel messageLabel) const;
 
     static FormatType formatType(const QString &code);
     static QString formatCode(FormatType);
@@ -319,7 +322,7 @@ private:
     QVector<QBrush> _uiStylePalette;
     QBrush _markerLineBrush;
     QHash<quint64, QTextCharFormat> _formats;
-    mutable QHash<quint64, QTextCharFormat> _formatCache;
+    mutable QHash<QString, QTextCharFormat> _formatCache;
     mutable QHash<quint64, QFontMetricsF *> _metricsCache;
     QHash<UiStyle::ItemFormatType, QTextCharFormat> _listItemFormats;
     static QHash<QString, FormatType> _formatCodes;

--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -128,6 +128,11 @@ public:
         Invalid           = 0xffffffff
     };
 
+    enum class FormatProperty {
+        AllowForegroundOverride = QTextFormat::UserProperty,
+        AllowBackgroundOverride
+    };
+
     enum class ColorRole {
         MarkerLine,
         // Sender colors (16 + self)
@@ -266,11 +271,12 @@ protected:
     void loadStyleSheet();
     QString loadStyleSheet(const QString &name, bool shouldExist = false);
 
-    QTextCharFormat format(quint64 key) const;
+    QTextCharFormat parsedFormat(quint64 key) const;
     QTextCharFormat cachedFormat(const Format &format, MessageLabel messageLabel) const;
     void setCachedFormat(const QTextCharFormat &charFormat, const Format &format, MessageLabel messageLabel) const;
     void mergeFormat(QTextCharFormat &charFormat, const Format &format, MessageLabel messageLabel) const;
     void mergeSubElementFormat(QTextCharFormat &charFormat, FormatType formatType, MessageLabel messageLabel) const;
+    void mergeColors(QTextCharFormat &charFormat, const Format &format, MessageLabel messageLabel) const;
 
     static FormatType formatType(const QString &code);
     static QString formatCode(FormatType);

--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -18,8 +18,10 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef UISTYLE_H_
-#define UISTYLE_H_
+#pragma once
+
+#include <utility>
+#include <vector>
 
 #include <QDataStream>
 #include <QFontMetricsF>
@@ -43,8 +45,6 @@ public:
     UiStyle(QObject *parent = 0);
     virtual ~UiStyle();
 
-    typedef QList<QPair<quint16, quint32> > FormatList;
-
     //! This enumerates the possible formats a text element may have. */
     /** These formats are ordered on increasing importance, in cases where a given property is specified
      *  by multiple active formats.
@@ -52,7 +52,7 @@ public:
      *         methods in this class (in particular mergedFormat())!
      *         Also, we _do_ rely on certain properties of these values in styleString() and friends!
      */
-    enum FormatType {
+    enum class FormatType : quint32 {
         Base            = 0x00000000,
         Invalid         = 0xffffffff,
 
@@ -99,13 +99,16 @@ public:
                           // background: 0x.0800000
     };
 
-    enum MessageLabel {
+    enum class MessageLabel : quint32 {
+        None            = 0x00000000,
         OwnMsg          = 0x00000001,
         Highlight       = 0x00000002,
         Selected        = 0x00000004 // must be last!
     };
 
-    enum ItemFormatType {
+    enum class ItemFormatType : quint32 {
+        None              = 0x00000000,
+
         BufferViewItem    = 0x00000001,
         NickViewItem      = 0x00000002,
 
@@ -119,10 +122,12 @@ public:
         ActiveBuffer      = 0x00002000,
         UnreadBuffer      = 0x00004000,
         HighlightedBuffer = 0x00008000,
-        UserAway          = 0x00010000
+        UserAway          = 0x00010000,
+
+        Invalid           = 0xffffffff
     };
 
-    enum ColorRole {
+    enum class ColorRole {
         MarkerLine,
         // Sender colors (16 + self)
         // These aren't used directly to avoid having storing all of the sender color options in the
@@ -150,6 +155,12 @@ public:
         SenderColor0f,
         NumRoles // must be last!
     };
+
+    struct Format {
+        FormatType type;
+    };
+
+    using FormatList = std::vector<std::pair<quint16, Format>>;
 
     struct StyledString {
         QString plainText;
@@ -201,7 +212,7 @@ public:
     const QColor defaultSenderColorSelf = QColor(0, 0, 0);
 
     static FormatType formatType(Message::Type msgType);
-    static StyledString styleString(const QString &string, quint32 baseFormat = Base);
+    static StyledString styleString(const QString &string, FormatType baseFormat = FormatType::Base);
     static QString mircToInternal(const QString &);
 
     /**
@@ -231,10 +242,10 @@ public:
      */
     static QString timestampFormatString();
 
-    QTextCharFormat format(quint32 formatType, quint32 messageLabel) const;
-    QFontMetricsF *fontMetrics(quint32 formatType, quint32 messageLabel) const;
+    QTextCharFormat format(FormatType formatType, MessageLabel messageLabel) const;
+    QFontMetricsF *fontMetrics(FormatType formatType, MessageLabel messageLabel) const;
 
-    QList<QTextLayout::FormatRange> toTextLayoutList(const FormatList &, int textLength, quint32 messageLabel) const;
+    QList<QTextLayout::FormatRange> toTextLayoutList(const FormatList &, int textLength, MessageLabel messageLabel) const;
 
     inline const QBrush &brush(ColorRole role) const { return _uiStylePalette.at((int)role); }
     inline void setBrush(ColorRole role, const QBrush &brush) { _uiStylePalette[(int)role] = brush; }
@@ -253,10 +264,10 @@ protected:
     QString loadStyleSheet(const QString &name, bool shouldExist = false);
 
     QTextCharFormat format(quint64 key) const;
-    QTextCharFormat cachedFormat(quint32 formatType, quint32 messageLabel) const;
-    void setCachedFormat(const QTextCharFormat &format, quint32 formatType, quint32 messageLabel) const;
-    void mergeFormat(QTextCharFormat &format, quint32 formatType, quint64 messageLabel) const;
-    void mergeSubElementFormat(QTextCharFormat &format, quint32 formatType, quint64 messageLabel) const;
+    QTextCharFormat cachedFormat(FormatType formatType, MessageLabel messageLabel) const;
+    void setCachedFormat(const QTextCharFormat &format, FormatType formatType, MessageLabel messageLabel) const;
+    void mergeFormat(QTextCharFormat &format, FormatType formatType, MessageLabel messageLabel) const;
+    void mergeSubElementFormat(QTextCharFormat &format, FormatType formatType, MessageLabel messageLabel) const;
 
     static FormatType formatType(const QString &code);
     static QString formatCode(FormatType);
@@ -310,7 +321,7 @@ private:
     QHash<quint64, QTextCharFormat> _formats;
     mutable QHash<quint64, QTextCharFormat> _formatCache;
     mutable QHash<quint64, QFontMetricsF *> _metricsCache;
-    QHash<quint32, QTextCharFormat> _listItemFormats;
+    QHash<UiStyle::ItemFormatType, QTextCharFormat> _listItemFormats;
     static QHash<QString, FormatType> _formatCodes;
     static bool _useCustomTimestampFormat;        /// If true, use the custom timestamp format
     static QString _systemTimestampFormatString;  /// Cached copy of system locale timestamp format
@@ -357,10 +368,39 @@ private:
     mutable quint8 _senderHash;
 };
 
+#if QT_VERSION < 0x050000
+uint qHash(UiStyle::ItemFormatType key);
+#else
+uint qHash(UiStyle::ItemFormatType key, uint seed);
+#endif
+
+// ---- Operators for dealing with enums ----------------------------------------------------------
+
+UiStyle::FormatType operator|(UiStyle::FormatType lhs, UiStyle::FormatType rhs);
+UiStyle::FormatType& operator|=(UiStyle::FormatType &lhs, UiStyle::FormatType rhs);
+UiStyle::FormatType operator|(UiStyle::FormatType lhs, quint32 rhs);
+UiStyle::FormatType& operator|=(UiStyle::FormatType &lhs, quint32 rhs);
+UiStyle::FormatType operator&(UiStyle::FormatType lhs, UiStyle::FormatType rhs);
+UiStyle::FormatType& operator&=(UiStyle::FormatType &lhs, UiStyle::FormatType rhs);
+UiStyle::FormatType operator&(UiStyle::FormatType lhs, quint32 rhs);
+UiStyle::FormatType& operator&=(UiStyle::FormatType &lhs, quint32 rhs);
+UiStyle::FormatType& operator^=(UiStyle::FormatType &lhs, UiStyle::FormatType rhs);
+
+UiStyle::MessageLabel operator|(UiStyle::MessageLabel lhs, UiStyle::MessageLabel rhs);
+UiStyle::MessageLabel& operator|=(UiStyle::MessageLabel &lhs, UiStyle::MessageLabel rhs);
+UiStyle::MessageLabel operator&(UiStyle::MessageLabel lhs, quint32 rhs);
+UiStyle::MessageLabel& operator&=(UiStyle::MessageLabel &lhs, UiStyle::MessageLabel rhs);
+
+// Shifts the label into the upper half of the return value
+quint64 operator|(UiStyle::FormatType lhs, UiStyle::MessageLabel rhs);
+
+UiStyle::ItemFormatType operator|(UiStyle::ItemFormatType lhs, UiStyle::ItemFormatType rhs);
+UiStyle::ItemFormatType& operator|=(UiStyle::ItemFormatType &lhs, UiStyle::ItemFormatType rhs);
+
+// ---- Allow for FormatList in QVariant ----------------------------------------------------------
 
 QDataStream &operator<<(QDataStream &out, const UiStyle::FormatList &formatList);
 QDataStream &operator>>(QDataStream &in, UiStyle::FormatList &formatList);
 
 Q_DECLARE_METATYPE(UiStyle::FormatList)
-
-#endif
+Q_DECLARE_METATYPE(UiStyle::MessageLabel)

--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -81,7 +81,6 @@ public:
         Bold            = 0x00000100,
         Italic          = 0x00000200,
         Underline       = 0x00000400,
-        Reverse         = 0x00000800,
 
         // Individual parts of a message
         Timestamp       = 0x00001000,


### PR DESCRIPTION
As part of the ongoing efforts to modernize and consolidate the IRC protocol, the various options for formatting IRC messages have been collected in a nice document: https://modern.ircdocs.horse/formatting.html

This document specifies various format codes that Quassel didn't support yet. This pull request adds support for rendering almost all of them properly, so Quassel does not get confused if other clients send such format codes. No support is added for sending out the new formats, however.

This PR adds support for rendering
- extended mIRC colors (i.e. colors 16-98)
- hex colors (0x04)
- reversed/swapped colors (0x16)
- struck through text (0x1e)

Additionally, although rendering monospace text is not currently supported, the format code for it (0x11) is now ignored, as to not render weird artifacts if other clients send it.