### PR TITLE
Use 64-bit IDs for messages

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
     syncableobject.cpp
     transfer.cpp
     transfermanager.cpp
+    types.cpp
     util.cpp
 
     serializers/serializers.cpp

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -134,6 +134,7 @@ public:
 #if QT_VERSION >= 0x050500
         EcdsaCertfpKeys,          ///< ECDSA keys for CertFP in identities
 #endif
+        LongMessageId,            ///< 64-bit IDs for messages
     };
     Q_ENUMS(Feature)
 

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -18,42 +18,26 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#include "debugmessagemodelfilter.h"
+#include "peer.h"
+#include "types.h"
 
-#include "messagemodel.h"
-
-DebugMessageModelFilter::DebugMessageModelFilter(QObject *parent)
-    : QSortFilterProxyModel(parent)
-{
-}
-
-
-QVariant DebugMessageModelFilter::headerData(int section, Qt::Orientation orientation, int role) const
-{
-    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
-        return QVariant();
-
-    switch (section) {
-    case 0:
-        return "MessageId";
-    case 1:
-        return "Sender";
-    case 2:
-        return "Message";
-    default:
-        return QVariant();
+QDataStream &operator<<(QDataStream &out, const SignedId64 &signedId) {
+    if (!SignalProxy::current() || !SignalProxy::current()->targetPeer() || SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::LongMessageId)) {
+        out << signedId.toQint64();
+    } else {
+        out << (qint32) signedId.toQint64();
     }
+    
+    return out;
 }
 
-
-QVariant DebugMessageModelFilter::data(const QModelIndex &index, int role) const
-{
-    if (index.column() != 0 || role != Qt::DisplayRole)
-        return QSortFilterProxyModel::data(index, role);
-
-    if (!sourceModel())
-        return QVariant();
-
-    QModelIndex source_index = mapToSource(index);
-    return sourceModel()->data(source_index, MessageModel::MsgIdRole).value<MsgId>().toQint64();
+QDataStream &operator>>(QDataStream &in, SignedId64 &signedId) {
+    if (!SignalProxy::current() || !SignalProxy::current()->sourcePeer() || SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::LongMessageId)) {
+        in >> signedId.id;
+    } else {
+        qint32 id;
+        in >> id;
+        signedId.id = id;
+    }
+    return in;
 }

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -58,20 +58,53 @@ public:
     friend QDataStream &operator>>(QDataStream &in, SignedId &signedId);
 };
 
-
 inline QDataStream &operator<<(QDataStream &out, const SignedId &signedId) { out << signedId.toInt(); return out; }
 inline QDataStream &operator>>(QDataStream &in, SignedId &signedId) { in >> signedId.id; return in; }
 inline QTextStream &operator<<(QTextStream &out, const SignedId &signedId) { out << QString::number(signedId.toInt()); return out; }
 inline QDebug operator<<(QDebug dbg, const SignedId &signedId) { dbg.space() << signedId.toInt(); return dbg; }
 inline uint qHash(const SignedId &id) { return qHash(id.toInt()); }
 
+class SignedId64
+{
+protected:
+    qint64 id;
+
+public:
+    inline SignedId64(qint64 _id = 0) { id = _id; }
+    inline qint64 toQint64() const { return id; }
+    inline bool isValid() const { return id > 0; }
+
+    inline bool operator==(const SignedId64 &other) const { return id == other.id; }
+    inline bool operator!=(const SignedId64 &other) const { return id != other.id; }
+    inline bool operator<(const SignedId64 &other) const { return id < other.id; }
+    inline bool operator<=(const SignedId64 &other) const { return id <= other.id; }
+    inline bool operator>(const SignedId64 &other) const { return id > other.id; }
+    inline bool operator>=(const SignedId64 &other) const { return id >= other.id; }
+    inline bool operator==(qint64 i) const { return id == i; }
+    inline bool operator!=(qint64 i) const { return id != i; }
+    inline bool operator<(qint64 i) const { return id < i; }
+    inline bool operator>(qint64 i) const { return id > i; }
+    inline bool operator<=(qint64 i) const { return id <= i; }
+
+    inline SignedId64 operator++(int) { id++; return *this; }
+    //inline operator int() const { return toQint64(); } // no automatic conversion!
+
+    friend QDataStream &operator>>(QDataStream &in, SignedId64 &signedId);
+};
+
+QDataStream &operator<<(QDataStream &out, const SignedId64 &signedId);
+QDataStream &operator>>(QDataStream &in, SignedId64 &signedId);
+inline QTextStream &operator<<(QTextStream &out, const SignedId64 &signedId) { out << QString::number(signedId.toQint64()); return out; }
+inline QDebug operator<<(QDebug dbg, const SignedId64 &signedId) { dbg.space() << signedId.toQint64(); return dbg; }
+inline uint qHash(const SignedId64 &id) { return qHash(id.toQint64()); }
+
 struct UserId : public SignedId {
     inline UserId(int _id = 0) : SignedId(_id) {}
     //inline operator QVariant() const { return QVariant::fromValue<UserId>(*this); }  // no automatic conversion!
 };
 
-struct MsgId : public SignedId {
-    inline MsgId(int _id = 0) : SignedId(_id) {}
+struct MsgId : public SignedId64 {
+    inline MsgId(qint64 _id = 0) : SignedId64(_id) {}
     //inline operator QVariant() const { return QVariant::fromValue<MsgId>(*this); }
 };
 

--- a/src/core/SQL/PostgreSQL/setup_010_sender.sql
+++ b/src/core/SQL/PostgreSQL/setup_010_sender.sql
@@ -1,4 +1,4 @@
 CREATE TABLE sender ( -- THE SENDER OF IRC MESSAGES
-       senderid serial NOT NULL PRIMARY KEY,
+       senderid bigserial NOT NULL PRIMARY KEY,
        sender varchar(128) UNIQUE NOT NULL
 )

--- a/src/core/SQL/PostgreSQL/setup_050_buffer.sql
+++ b/src/core/SQL/PostgreSQL/setup_050_buffer.sql
@@ -6,9 +6,9 @@ create TABLE buffer (
 	buffername varchar(128) NOT NULL,
 	buffercname varchar(128) NOT NULL, -- CANONICAL BUFFER NAME (lowercase version)
 	buffertype integer NOT NULL DEFAULT 0,
-	lastmsgid integer NOT NULL DEFAULT 0,
-	lastseenmsgid integer NOT NULL DEFAULT 0,
-	markerlinemsgid integer NOT NULL DEFAULT 0,
+	lastmsgid bigint NOT NULL DEFAULT 0,
+	lastseenmsgid bigint NOT NULL DEFAULT 0,
+	markerlinemsgid bigint NOT NULL DEFAULT 0,
 	bufferactivity integer NOT NULL DEFAULT 0,
 	key varchar(128),
 	joined boolean NOT NULL DEFAULT FALSE, -- BOOL

--- a/src/core/SQL/PostgreSQL/setup_060_backlog.sql
+++ b/src/core/SQL/PostgreSQL/setup_060_backlog.sql
@@ -1,10 +1,10 @@
 CREATE TABLE backlog (
-	messageid serial PRIMARY KEY,
+	messageid bigserial PRIMARY KEY,
 	time timestamp NOT NULL,
 	bufferid integer NOT NULL REFERENCES buffer (bufferid) ON DELETE CASCADE,
 	type integer NOT NULL,
 	flags integer NOT NULL,
-	senderid integer NOT NULL REFERENCES sender (senderid) ON DELETE SET NULL,
+	senderid bigint NOT NULL REFERENCES sender (senderid) ON DELETE SET NULL,
 	senderprefixes TEXT,
 	message TEXT
 )

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_010_alter_sender_64bit_ids.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_010_alter_sender_64bit_ids.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sender
+ALTER COLUMN senderid TYPE bigint

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_060_alter_backlog_64bit_ids.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_060_alter_backlog_64bit_ids.sql
@@ -1,0 +1,3 @@
+ALTER TABLE backlog
+ALTER COLUMN messageid TYPE bigint,
+ALTER COLUMN senderid TYPE bigint

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -153,7 +153,7 @@ public:
     };
 
     struct SenderMO {
-        int senderId;
+        qint64 senderId;
         QString sender;
         SenderMO() : senderId(0) {}
     };
@@ -173,7 +173,7 @@ public:
         bool autoAwayReasonEnabled;
         bool detachAwayEnabled;
         QString detachAwayReason;
-        bool detchAwayReasonEnabled;
+        bool detachAwayReasonEnabled;
         QString ident;
         QString kickReason;
         QString partReason;
@@ -230,9 +230,9 @@ public:
         QString buffername;
         QString buffercname;
         int buffertype;
-        int lastmsgid;
-        int lastseenmsgid;
-        int markerlinemsgid;
+        qint64 lastmsgid;
+        qint64 lastseenmsgid;
+        qint64 markerlinemsgid;
         int bufferactivity;
         QString key;
         bool joined;
@@ -244,7 +244,7 @@ public:
         BufferId bufferid;
         int type;
         int flags;
-        int senderid;
+        qint64 senderid;
         QString senderprefixes;
         QString message;
     };

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -262,8 +262,12 @@ void CoreSession::restoreSessionState()
 
 void CoreSession::addClient(RemotePeer *peer)
 {
+    signalProxy()->setTargetPeer(peer);
+
     peer->dispatch(sessionState());
     signalProxy()->addPeer(peer);
+
+    signalProxy()->setTargetPeer(nullptr);
 }
 
 

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -109,6 +109,8 @@
     <file>./SQL/PostgreSQL/version/22/upgrade_000_alter_quasseluser_add_authenticator.sql</file>
     <file>./SQL/PostgreSQL/version/23/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/PostgreSQL/version/24/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_010_alter_sender_64bit_ids.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_060_alter_backlog_64bit_ids.sql</file>
     <file>./SQL/SQLite/delete_backlog_by_uid.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_buffer.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_network.sql</file>

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1414,7 +1414,7 @@ void SqliteStorage::setBufferLastSeenMsg(UserId user, const BufferId &bufferId, 
         query.prepare(queryString("update_buffer_lastseen"));
         query.bindValue(":userid", user.toInt());
         query.bindValue(":bufferid", bufferId.toInt());
-        query.bindValue(":lastseenmsgid", msgId.toInt());
+        query.bindValue(":lastseenmsgid", msgId.toQint64());
 
         lockForWrite();
         safeExec(query);
@@ -1443,7 +1443,7 @@ QHash<BufferId, MsgId> SqliteStorage::bufferLastSeenMsgIds(UserId user)
         error = !watchQuery(query);
         if (!error) {
             while (query.next()) {
-                lastSeenHash[query.value(0).toInt()] = query.value(1).toInt();
+                lastSeenHash[query.value(0).toInt()] = query.value(1).toLongLong();
             }
         }
     }
@@ -1464,7 +1464,7 @@ void SqliteStorage::setBufferMarkerLineMsg(UserId user, const BufferId &bufferId
         query.prepare(queryString("update_buffer_markerlinemsgid"));
         query.bindValue(":userid", user.toInt());
         query.bindValue(":bufferid", bufferId.toInt());
-        query.bindValue(":markerlinemsgid", msgId.toInt());
+        query.bindValue(":markerlinemsgid", msgId.toQint64());
 
         lockForWrite();
         safeExec(query);
@@ -1493,7 +1493,7 @@ QHash<BufferId, MsgId> SqliteStorage::bufferMarkerLineMsgIds(UserId user)
         error = !watchQuery(query);
         if (!error) {
             while (query.next()) {
-                markerLineHash[query.value(0).toInt()] = query.value(1).toInt();
+                markerLineHash[query.value(0).toInt()] = query.value(1).toLongLong();
             }
         }
     }
@@ -1563,7 +1563,7 @@ Message::Types SqliteStorage::bufferActivity(BufferId bufferId, MsgId lastSeenMs
         QSqlQuery query(db);
         query.prepare(queryString("select_buffer_bufferactivity"));
         query.bindValue(":bufferid", bufferId.toInt());
-        query.bindValue(":lastseenmsgid", lastSeenMsgId.toInt());
+        query.bindValue(":lastseenmsgid", lastSeenMsgId.toQint64());
 
         lockForRead();
         safeExec(query);
@@ -1612,7 +1612,7 @@ bool SqliteStorage::logMessage(Message &msg)
             }
         }
         if (!error) {
-            MsgId msgId = logMessageQuery.lastInsertId().toInt();
+            MsgId msgId = logMessageQuery.lastInsertId().toLongLong();
             if (msgId.isValid()) {
                 msg.setMsgId(msgId);
             }
@@ -1676,7 +1676,7 @@ bool SqliteStorage::logMessages(MessageList &msgs)
                 break;
             }
             else {
-                msg.setMsgId(logMessageQuery.lastInsertId().toInt());
+                msg.setMsgId(logMessageQuery.lastInsertId().toLongLong());
             }
         }
     }
@@ -1707,7 +1707,7 @@ QList<Message> SqliteStorage::requestMsgs(UserId user, BufferId bufferId, MsgId 
     bool error = false;
     BufferInfo bufferInfo;
     {
-        // code dupication from getBufferInfo:
+        // code duplication from getBufferInfo:
         // this is due to the impossibility of nesting transactions and recursive locking
         QSqlQuery bufferInfoQuery(db);
         bufferInfoQuery.prepare(queryString("select_buffer_by_id"));
@@ -1735,12 +1735,12 @@ QList<Message> SqliteStorage::requestMsgs(UserId user, BufferId bufferId, MsgId 
         }
         else if (last == -1) {
             query.prepare(queryString("select_messagesNewerThan"));
-            query.bindValue(":firstmsg", first.toInt());
+            query.bindValue(":firstmsg", first.toQint64());
         }
         else {
             query.prepare(queryString("select_messagesRange"));
-            query.bindValue(":lastmsg", last.toInt());
-            query.bindValue(":firstmsg", first.toInt());
+            query.bindValue(":lastmsg", last.toQint64());
+            query.bindValue(":firstmsg", first.toQint64());
         }
         query.bindValue(":bufferid", bufferId.toInt());
         query.bindValue(":limit", limit);
@@ -1756,7 +1756,7 @@ QList<Message> SqliteStorage::requestMsgs(UserId user, BufferId bufferId, MsgId 
                 query.value(4).toString(),
                 query.value(5).toString(),
                 (Message::Flags)query.value(3).toUInt());
-            msg.setMsgId(query.value(0).toInt());
+            msg.setMsgId(query.value(0).toLongLong());
             messagelist << msg;
         }
     }
@@ -1794,10 +1794,10 @@ QList<Message> SqliteStorage::requestAllMsgs(UserId user, MsgId first, MsgId las
         }
         else {
             query.prepare(queryString("select_messagesAll"));
-            query.bindValue(":lastmsg", last.toInt());
+            query.bindValue(":lastmsg", last.toQint64());
         }
         query.bindValue(":userid", user.toInt());
-        query.bindValue(":firstmsg", first.toInt());
+        query.bindValue(":firstmsg", first.toQint64());
         query.bindValue(":limit", limit);
         safeExec(query);
 
@@ -1811,7 +1811,7 @@ QList<Message> SqliteStorage::requestAllMsgs(UserId user, MsgId first, MsgId las
                 query.value(5).toString(),
                 query.value(6).toString(),
                 (Message::Flags)query.value(4).toUInt());
-            msg.setMsgId(query.value(0).toInt());
+            msg.setMsgId(query.value(0).toLongLong());
             messagelist << msg;
         }
     }
@@ -1874,7 +1874,7 @@ void SqliteMigrationReader::setMaxId(MigrationObject mo)
     }
     QSqlQuery query = logDb().exec(queryString);
     query.first();
-    _maxId = query.value(0).toInt();
+    _maxId = query.value(0).toLongLong();
 }
 
 
@@ -1952,7 +1952,7 @@ bool SqliteMigrationReader::readMo(IdentityMO &identity)
     identity.autoAwayReasonEnabled = value(11).toInt() == 1 ? true : false;
     identity.detachAwayEnabled = value(12).toInt() == 1 ? true : false;
     identity.detachAwayReason = value(13).toString();
-    identity.detchAwayReasonEnabled = value(14).toInt() == 1 ? true : false;
+    identity.detachAwayReasonEnabled = value(14).toInt() == 1 ? true : false;
     identity.ident = value(15).toString();
     identity.kickReason = value(16).toString();
     identity.partReason = value(17).toString();
@@ -2026,9 +2026,9 @@ bool SqliteMigrationReader::readMo(BufferMO &buffer)
     buffer.buffername = value(4).toString();
     buffer.buffercname = value(5).toString();
     buffer.buffertype = value(6).toInt();
-    buffer.lastmsgid = value(7).toInt();
-    buffer.lastseenmsgid = value(8).toInt();
-    buffer.markerlinemsgid = value(9).toInt();
+    buffer.lastmsgid = value(7).toLongLong();
+    buffer.lastseenmsgid = value(8).toLongLong();
+    buffer.markerlinemsgid = value(9).toLongLong();
     buffer.bufferactivity = value(10).toInt();
     buffer.key = value(11).toString();
     buffer.joined = value(12).toInt() == 1 ? true : false;
@@ -2052,7 +2052,7 @@ bool SqliteMigrationReader::readMo(SenderMO &sender)
         }
     }
 
-    sender.senderId = value(0).toInt();
+    sender.senderId = value(0).toLongLong();
     sender.sender = value(1).toString();
     return true;
 }
@@ -2063,8 +2063,8 @@ bool SqliteMigrationReader::readMo(BacklogMO &backlog)
     int skipSteps = 0;
     while (!next()) {
         if (backlog.messageid < _maxId) {
-            bindValue(0, backlog.messageid.toInt() + (skipSteps * stepSize()));
-            bindValue(1, backlog.messageid.toInt() + ((skipSteps + 1) * stepSize()));
+            bindValue(0, backlog.messageid.toQint64() + (skipSteps * stepSize()));
+            bindValue(1, backlog.messageid.toQint64() + ((skipSteps + 1) * stepSize()));
             skipSteps++;
             if (!exec())
                 return false;
@@ -2079,7 +2079,7 @@ bool SqliteMigrationReader::readMo(BacklogMO &backlog)
     backlog.bufferid = value(2).toInt();
     backlog.type = value(3).toInt();
     backlog.flags = value(4).toInt();
-    backlog.senderid = value(5).toInt();
+    backlog.senderid = value(5).toLongLong();
     backlog.senderprefixes = value(6).toString();
     backlog.message = value(7).toString();
     return true;

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -159,7 +159,7 @@ protected:
 
 private:
     void setMaxId(MigrationObject mo);
-    int _maxId;
+    qint64 _maxId;
 };
 
 

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -245,7 +245,7 @@ void ChatItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
 //   }
 // 2) draw MsgId over the time column
 //   if(column() == 0) {
-//     QString msgIdString = QString::number(data(MessageModel::MsgIdRole).value<MsgId>().toInt());
+//     QString msgIdString = QString::number(data(MessageModel::MsgIdRole).value<MsgId>().toLongLong());
 //     QPointF bottomPoint = boundingRect().bottomLeft();
 //     bottomPoint.ry() -= 2;
 //     painter->drawText(bottomPoint, msgIdString);


### PR DESCRIPTION
Increase the length of message IDs from 32 to 64 bits, allowing for
many more total messages be stored.  Because messages are synced to
the client, this requires a protocol change.  The protocol change is
guarded behind a new feature flag that will retain backwards
compatibility with existing clients, at least until the IDs go above
the maximum for a 32-bit number.  At this point, legacy clients will
behave incorrectly or perhaps crash, but this is an acceptable risk
because in the the current implementation, this event would cause
the core to behave incorrectly or crash.  The client is also still
limited to 32 bits worth of backlog per buffer displayed at once
(due to Qt limitations), but it would be highly unlikely to hit
this limit because the client becomes unusably slow with a small
fraction of that amount of backlog loaded in a single buffer.

For SQLite, no schema change was necessary as SQLite makes no
differentiation between the bitnesses of integers.

For PostgreSQL, this patch also changes senderId to 64-bit, but
this has no effect outside the PostgreSQL database driver.

This patch only changes the message ID to 64-bit.  All other IDs
are left at 32 bits because it is either exceedingly unlikely or
technically infeasible to have more than 32 bits worth of entries
in any of the other tables.  If, at some point, it is decided that
other IDs should also be 64-bit, the way in which the feature flag
affects (de)serialization will need to be changed.  This is because
the flag LongMsgId currently acts upon all IDs inheriting from
SignedId64 and it would be necessary to independently control the
(de)serialization of each ID if other IDs became 64-bit in order to
continue to maintain backwards compatibility.  One possible method
of doing this would be to subclass the SignedId64 class for each
ID that inherits from it to allow for separately controlling
(de)serialization for each of the types.  I have not implemented
this, however, because of the unlikelihood of any of the other IDs
ever being made 64-bit.