### PR TITLE
SslServer: Add support for Elliptic Curve keys

### DIFF
--- a/src/core/sslserver.h
+++ b/src/core/sslserver.h
@@ -27,6 +27,7 @@
 #include <QSslKey>
 #include <QTcpServer>
 #include <QLinkedList>
+#include <QFile>
 
 class SslServer : public QTcpServer
 {
@@ -71,6 +72,7 @@ private:
      * @return True if certificates loaded successfully, otherwise false.
      */
     bool loadCerts();
+    QSslKey loadKey(QFile *keyFile);
 
     QLinkedList<QTcpSocket *> _pendingConnections;
     QSslCertificate _cert;


### PR DESCRIPTION
If the key won't load as an RSA key, attempt to load it again as an
EC key.  DSA support was not added because DSA is obsolete and no-
one should be using it.

Note that this only works with Qt5.5 and up as EC support was added
in that version (https://github.com/qt/qtbase/commit/962ea569). An
if macro has been used to allow for continued compilation under Qt4
and Qt5<5.5.