### PR TITLE
Represent core/client features as string list in the protocol

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -56,7 +56,6 @@
 #include <stdlib.h>
 
 QPointer<Client> Client::instanceptr = 0;
-Quassel::Features Client::_coreFeatures = 0;
 
 /*** Initialization/destruction ***/
 
@@ -188,9 +187,9 @@ AbstractUi *Client::mainUi()
 }
 
 
-void Client::setCoreFeatures(Quassel::Features features)
+bool Client::isCoreFeatureEnabled(Quassel::Feature feature)
 {
-    _coreFeatures = features;
+    return coreConnection()->peer() ? coreConnection()->peer()->hasFeature(feature) : false;
 }
 
 
@@ -430,7 +429,7 @@ void Client::setSyncedToCore()
     // create TransferManager and DccConfig if core supports them
     Q_ASSERT(!_dccConfig);
     Q_ASSERT(!_transferManager);
-    if (coreFeatures() & Quassel::DccFileTransfer) {
+    if (isCoreFeatureEnabled(Quassel::Feature::DccFileTransfer)) {
         _dccConfig = new DccConfig(this);
         p->synchronize(dccConfig());
         _transferManager = new ClientTransferManager(this);
@@ -461,7 +460,7 @@ void Client::finishConnectionInitialization()
     disconnect(bufferSyncer(), SIGNAL(initDone()), this, SLOT(finishConnectionInitialization()));
 
     requestInitialBacklog();
-    if (coreFeatures().testFlag(Quassel::BufferActivitySync))
+    if (isCoreFeatureEnabled(Quassel::Feature::BufferActivitySync))
         bufferSyncer()->markActivitiesChanged();
 }
 
@@ -484,7 +483,6 @@ void Client::disconnectFromCore()
 void Client::setDisconnectedFromCore()
 {
     _connected = false;
-    _coreFeatures = 0;
 
     emit disconnected();
     emit coreConnectionStateChanged(false);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -131,9 +131,7 @@ public:
     static inline CoreAccountModel *coreAccountModel() { return instance()->_coreAccountModel; }
     static inline CoreConnection *coreConnection() { return instance()->_coreConnection; }
     static inline CoreAccount currentCoreAccount() { return coreConnection()->currentAccount(); }
-    static inline Quassel::Features coreFeatures() { return _coreFeatures; }
-
-    static void setCoreFeatures(Quassel::Features features);
+    static bool isCoreFeatureEnabled(Quassel::Feature feature);
 
     static bool isConnected();
     static bool internalCore();
@@ -282,7 +280,6 @@ private:
     QHash<IdentityId, Identity *> _identities;
 
     bool _connected;
-    static Quassel::Features _coreFeatures;
 
     QString _debugLogBuffer;
     QTextStream _debugLog;

--- a/src/client/clientauthhandler.h
+++ b/src/client/clientauthhandler.h
@@ -18,8 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef CLIENTAUTHHANDLER_H
-#define CLIENTAUTHHANDLER_H
+#pragma once
 
 #include "compressor.h"
 #include "authhandler.h"
@@ -34,13 +33,15 @@ class ClientAuthHandler : public AuthHandler
     Q_OBJECT
 
 public:
-    ClientAuthHandler(CoreAccount account, QObject *parent = 0);
-
     enum DigestVersion {
         Md5,
         Sha2_512,
         Latest=Sha2_512
     };
+
+    ClientAuthHandler(CoreAccount account, QObject *parent = 0);
+
+    Peer *peer() const;
 
 public slots:
     void connectToCore();
@@ -119,5 +120,3 @@ private:
     bool _legacy;
     quint8 _connectionFeatures;
 };
-
-#endif

--- a/src/client/coreconnection.cpp
+++ b/src/client/coreconnection.cpp
@@ -184,6 +184,15 @@ void CoreConnection::onlineStateChanged(bool isOnline)
 }
 
 
+QPointer<Peer> CoreConnection::peer() const
+{
+    if (_peer) {
+        return _peer;
+    }
+    return _authHandler ? _authHandler->peer() : nullptr;
+}
+
+
 bool CoreConnection::isEncrypted() const
 {
     return _peer && _peer->isSecure();
@@ -463,9 +472,6 @@ void CoreConnection::onHandshakeComplete(RemotePeer *peer, const Protocol::Sessi
 void CoreConnection::internalSessionStateReceived(const Protocol::SessionState &sessionState)
 {
     updateProgress(100, 100);
-
-    Client::setCoreFeatures(Quassel::features()); // mono connection...
-
     setState(Synchronizing);
     syncToCore(sessionState);
 }

--- a/src/client/coreconnection.h
+++ b/src/client/coreconnection.h
@@ -73,7 +73,7 @@ public:
     //! Check if we consider the last connect as reconnect
     bool wasReconnect() const { return _wasReconnect; }
 
-    QPointer<Peer> peer() { return _peer; }
+    QPointer<Peer> peer() const;
 
 public slots:
     bool connectToCore(AccountId = 0);

--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -298,7 +298,7 @@ void BufferItem::setActivityLevel(BufferInfo::ActivityLevel level)
 
 void BufferItem::clearActivityLevel()
 {
-    if (Client::coreFeatures().testFlag(Quassel::Feature::BufferActivitySync)) {
+    if (Client::isCoreFeatureEnabled(Quassel::Feature::BufferActivitySync)) {
         // If the core handles activity sync, clear only the highlight flag
         _activity &= ~BufferInfo::Highlight;
     } else {
@@ -307,7 +307,7 @@ void BufferItem::clearActivityLevel()
     _firstUnreadMsgId = MsgId();
 
     // FIXME remove with core proto v11
-    if (!(Client::coreFeatures() & Quassel::SynchronizedMarkerLine)) {
+    if (!Client::isCoreFeatureEnabled(Quassel::Feature::SynchronizedMarkerLine)) {
         _markerLineMsgId = _lastSeenMsgId;
     }
 
@@ -318,7 +318,7 @@ void BufferItem::clearActivityLevel()
 void BufferItem::updateActivityLevel(const Message &msg)
 {
     // If the core handles activity, and this message is not a highlight, ignore this
-    if (Client::coreFeatures().testFlag(Quassel::Feature::BufferActivitySync) && !msg.flags().testFlag(Message::Highlight)) {
+    if (Client::isCoreFeatureEnabled(Quassel::Feature::BufferActivitySync) && !msg.flags().testFlag(Message::Highlight)) {
         return;
     }
 
@@ -344,7 +344,7 @@ void BufferItem::updateActivityLevel(const Message &msg)
 
     Message::Types type;
     // If the core handles activities, ignore types
-    if (Client::coreFeatures().testFlag(Quassel::Feature::BufferActivitySync)) {
+    if (Client::isCoreFeatureEnabled(Quassel::Feature::BufferActivitySync)) {
         type = Message::Types();
     } else {
         type = msg.type();
@@ -434,7 +434,7 @@ void BufferItem::setLastSeenMsgId(MsgId msgId)
     _lastSeenMsgId = msgId;
 
     // FIXME remove with core protocol v11
-    if (!(Client::coreFeatures() & Quassel::SynchronizedMarkerLine)) {
+    if (!Client::isCoreFeatureEnabled(Quassel::Feature::SynchronizedMarkerLine)) {
         if (!isCurrentBuffer())
             _markerLineMsgId = msgId;
     }

--- a/src/common/internalpeer.cpp
+++ b/src/common/internalpeer.cpp
@@ -30,7 +30,9 @@ class PeerMessageEvent : public QEvent
 {
 public:
     PeerMessageEvent(InternalPeer *sender, InternalPeer::EventType eventType, const T &message)
-    : QEvent(QEvent::Type(eventType)), sender(sender), message(message) {}
+        : QEvent(QEvent::Type(eventType)), sender(sender), message(message)
+    {}
+
     InternalPeer *sender;
     T message;
 };
@@ -172,6 +174,18 @@ void InternalPeer::dispatch(const InitData &msg)
 }
 
 
+namespace {
+
+void setSourcePeer(Peer* peer)
+{
+    auto p = SignalProxy::current();
+    if (p)
+        p->setSourcePeer(peer);
+}
+
+}  // anon
+
+
 template<class T>
 void InternalPeer::dispatch(EventType eventType, const T &msg)
 {
@@ -180,41 +194,39 @@ void InternalPeer::dispatch(EventType eventType, const T &msg)
         return;
     }
 
-    if(QThread::currentThread() == _peer->thread())
-        _peer->handle(msg);
-    else
-        QCoreApplication::postEvent(_peer, new PeerMessageEvent<T>(this, eventType, msg));
+    // The peers always live in different threads, so use an event for thread-safety
+    QCoreApplication::postEvent(_peer, new PeerMessageEvent<T>(this, eventType, msg));
 }
 
 
 void InternalPeer::customEvent(QEvent *event)
 {
+    setSourcePeer(this);
+
     switch ((int)event->type()) {
         case SyncMessageEvent: {
-            PeerMessageEvent<SyncMessage> *e = static_cast<PeerMessageEvent<SyncMessage> *>(event);
-            handle(e->message);
+            handle(static_cast<PeerMessageEvent<SyncMessage> *>(event)->message);
             break;
         }
         case RpcCallEvent: {
-            PeerMessageEvent<RpcCall> *e = static_cast<PeerMessageEvent<RpcCall> *>(event);
-            handle(e->message);
+            handle(static_cast<PeerMessageEvent<RpcCall> *>(event)->message);
             break;
         }
         case InitRequestEvent: {
-            PeerMessageEvent<InitRequest> *e = static_cast<PeerMessageEvent<InitRequest> *>(event);
-            handle(e->message);
+            handle(static_cast<PeerMessageEvent<InitRequest> *>(event)->message);
             break;
         }
         case InitDataEvent: {
-            PeerMessageEvent<InitData> *e = static_cast<PeerMessageEvent<InitData> *>(event);
-            handle(e->message);
+            handle(static_cast<PeerMessageEvent<InitData> *>(event)->message);
             break;
         }
 
         default:
             qWarning() << Q_FUNC_INFO << "Received unknown custom event:" << event->type();
+            setSourcePeer(nullptr);
             return;
     }
 
+    setSourcePeer(nullptr);
     event->accept();
 }

--- a/src/common/internalpeer.cpp
+++ b/src/common/internalpeer.cpp
@@ -42,7 +42,7 @@ InternalPeer::InternalPeer(QObject *parent)
     _peer(0),
     _isOpen(true)
 {
-
+    setFeatures(Quassel::Features{});
 }
 
 

--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -19,6 +19,7 @@
  ***************************************************************************/
 
 #include <cstdlib>
+#include <memory>
 
 #include <QTextCodec>
 
@@ -109,7 +110,7 @@ int main(int argc, char **argv)
 # endif
 #endif
 
-    AbstractCliParser *cliParser;
+    std::shared_ptr<AbstractCliParser> cliParser;
 
 #ifdef HAVE_KDE4
     // We need to init KCmdLineArgs first
@@ -121,11 +122,11 @@ int main(int argc, char **argv)
     aboutData.setOrganizationDomain(Quassel::buildInfo().organizationDomain.toUtf8());
     KCmdLineArgs::init(argc, argv, &aboutData);
 
-    cliParser = new KCmdLineWrapper();
+    cliParser = std::make_shared<KCmdLineWrapper>();
 #elif defined HAVE_QT5
-    cliParser = new Qt5CliParser();
+    cliParser = std::make_shared<Qt5CliParser>();
 #else
-    cliParser = new CliParser();
+    cliParser = std::make_shared<CliParser>();
 #endif
     Quassel::setCliParser(cliParser);
 

--- a/src/common/message.cpp
+++ b/src/common/message.cpp
@@ -60,7 +60,7 @@ QDataStream &operator<<(QDataStream &out, const Message &msg)
         << msg.bufferInfo()
         << msg.sender().toUtf8();
 
-    if (SignalProxy::current()->targetPeer()->features().testFlag(Quassel::Feature::SenderPrefixes))
+    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::SenderPrefixes))
         out << msg.senderPrefixes().toUtf8();
 
     out << msg.contents().toUtf8();
@@ -91,7 +91,7 @@ QDataStream &operator>>(QDataStream &in, Message &msg)
     msg._sender = QString::fromUtf8(sender);
 
     QByteArray senderPrefixes;
-    if (SignalProxy::current()->sourcePeer()->features().testFlag(Quassel::Feature::SenderPrefixes))
+    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::SenderPrefixes))
         in >> senderPrefixes;
     msg._senderPrefixes = QString::fromUtf8(senderPrefixes);
 

--- a/src/common/peer.cpp
+++ b/src/common/peer.cpp
@@ -57,12 +57,17 @@ void Peer::setClientVersion(const QString &clientVersion) {
     _clientVersion = clientVersion;
 }
 
-Quassel::Features Peer::features() const {
+bool Peer::hasFeature(Quassel::Feature feature) const {
+    return _features.isEnabled(feature);
+}
+
+Quassel::Features Peer::features() const
+{
     return _features;
 }
 
 void Peer::setFeatures(Quassel::Features features) {
-    _features = features;
+    _features = std::move(features);
 }
 
 int Peer::id() const {

--- a/src/common/peer.h
+++ b/src/common/peer.h
@@ -51,6 +51,7 @@ public:
     QString clientVersion() const;
     void setClientVersion(const QString &clientVersion);
 
+    bool hasFeature(Quassel::Feature feature) const;
     Quassel::Features features() const;
     void setFeatures(Quassel::Features features);
 

--- a/src/common/protocol.h
+++ b/src/common/protocol.h
@@ -24,6 +24,8 @@
 #include <QDateTime>
 #include <QVariantList>
 
+#include "quassel.h"
+
 namespace Protocol {
 
 const quint32 magic = 0x42b33f00;
@@ -56,18 +58,19 @@ struct HandshakeMessage {
 
 struct RegisterClient : public HandshakeMessage
 {
-    inline RegisterClient(const QString &clientVersion, const QString &buildDate, bool sslSupported = false, quint32 features = 0)
-    : clientVersion(clientVersion)
-    , buildDate(buildDate)
-    , sslSupported(sslSupported)
-    , clientFeatures(features) {}
+    inline RegisterClient(Quassel::Features clientFeatures, const QString &clientVersion, const QString &buildDate, bool sslSupported = false)
+        : features(std::move(clientFeatures))
+        , clientVersion(clientVersion)
+        , buildDate(buildDate)
+        , sslSupported(sslSupported)
+    {}
 
+    Quassel::Features features;
     QString clientVersion;
     QString buildDate;
 
     // this is only used by the LegacyProtocol in compat mode
     bool sslSupported;
-    quint32 clientFeatures;
 };
 
 
@@ -82,19 +85,19 @@ struct ClientDenied : public HandshakeMessage
 
 struct ClientRegistered : public HandshakeMessage
 {
-    inline ClientRegistered(quint32 coreFeatures, bool coreConfigured, const QVariantList &backendInfo, bool sslSupported, const QVariantList &authenticatorInfo)
-    : coreFeatures(coreFeatures)
-    , coreConfigured(coreConfigured)
-    , backendInfo(backendInfo)
-    , authenticatorInfo(authenticatorInfo)
-    , sslSupported(sslSupported)
+    inline ClientRegistered(Quassel::Features coreFeatures, bool coreConfigured, const QVariantList &backendInfo, const QVariantList &authenticatorInfo, bool sslSupported)
+        : features(std::move(coreFeatures))
+        , coreConfigured(coreConfigured)
+        , backendInfo(backendInfo)
+        , authenticatorInfo(authenticatorInfo)
+        , sslSupported(sslSupported)
     {}
 
-    quint32 coreFeatures;
+    Quassel::Features features;
     bool coreConfigured;
+    QVariantList backendInfo; // TODO: abstract this better
 
     // The authenticatorInfo should be optional!
-    QVariantList backendInfo; // TODO: abstract this better
     QVariantList authenticatorInfo;
 
     // this is only used by the LegacyProtocol in compat mode

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -829,7 +829,7 @@ void SignalProxy::updateSecureState()
 
 QVariantList SignalProxy::peerData() {
     QVariantList result;
-    for (auto peer : _peerMap.values()) {
+    for (auto &&peer : _peerMap.values()) {
         QVariantMap data;
         data["id"] = peer->id();
         data["clientVersion"] = peer->clientVersion();
@@ -839,8 +839,8 @@ QVariantList SignalProxy::peerData() {
         data["remoteAddress"] = peer->address();
         data["connectedSince"] = peer->connectedSince();
         data["secure"] = peer->isSecure();
-        int features = peer->features();
-        data["features"] = features;
+        data["features"] = static_cast<quint32>(peer->features().toLegacyFeatures());
+        data["featureList"] = peer->features().toStringList();
         result << data;
     }
     return result;

--- a/src/core/SQL/upgradeSchema.sh
+++ b/src/core/SQL/upgradeSchema.sh
@@ -89,7 +89,7 @@
 #
 # Newer clients need to detect when they're on an older core to disable the
 # feature.  Use 'enum Feature' in 'quassel.h'.  In client-side code, test with
-# 'if (Client::coreFeatures() & Quassel::FeatureName) { ... }'
+# 'if (Client::isCoreFeatureEnabled(Quassel::Feature::FeatureName)) { ... }'
 #
 # 9.  Test everything!  Upgrade, migrate, new setups, new client/old core,
 # old client/new core, etc.

--- a/src/core/coreapplication.cpp
+++ b/src/core/coreapplication.cpp
@@ -84,6 +84,7 @@ CoreApplication::CoreApplication(int &argc, char **argv)
 CoreApplication::~CoreApplication()
 {
     delete _internal;
+    Quassel::destroy();
 }
 
 

--- a/src/core/coreapplication.cpp
+++ b/src/core/coreapplication.cpp
@@ -55,6 +55,11 @@ bool CoreApplicationInternal::init()
     Core::instance(); // create and init the core
     _coreCreated = true;
 
+    Quassel::registerReloadHandler([]() {
+        // Currently, only reloading SSL certificates is supported
+        return Core::reloadCerts();
+    });
+
     if (!Quassel::isOptionSet("norestore"))
         Core::restoreState();
 
@@ -62,27 +67,16 @@ bool CoreApplicationInternal::init()
 }
 
 
-bool CoreApplicationInternal::reloadConfig()
-{
-    if (_coreCreated) {
-        // Currently, only reloading SSL certificates is supported
-        return Core::reloadCerts();
-    } else {
-        return false;
-    }
-}
-
-
 /*****************************************************************************/
 
 CoreApplication::CoreApplication(int &argc, char **argv)
-    : QCoreApplication(argc, argv), Quassel()
+    : QCoreApplication(argc, argv)
 {
 #ifdef Q_OS_MAC
-    disableCrashhandler();
+    Quassel::disableCrashHandler();
 #endif /* Q_OS_MAC */
 
-    setRunMode(Quassel::CoreOnly);
+    Quassel::setRunMode(Quassel::CoreOnly);
     _internal = new CoreApplicationInternal();
 }
 
@@ -104,14 +98,4 @@ bool CoreApplication::init()
         return true;
     }
     return false;
-}
-
-
-bool CoreApplication::reloadConfig()
-{
-    if (_internal) {
-        return _internal->reloadConfig();
-    } else {
-        return false;
-    }
 }

--- a/src/core/coreapplication.h
+++ b/src/core/coreapplication.h
@@ -18,8 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef COREAPPLICATION_H_
-#define COREAPPLICATION_H_
+#pragma once
 
 #include <QCoreApplication>
 
@@ -38,21 +37,12 @@ public:
 
     bool init();
 
-    /**
-     * Requests a reload of relevant runtime configuration.
-     *
-     * In particular, signals to the Core to reload SSL certificates.
-     *
-     * @return True if configuration reload successful, otherwise false
-     */
-    bool reloadConfig();
-
 private:
     bool _coreCreated;
 };
 
 
-class CoreApplication : public QCoreApplication, public Quassel
+class CoreApplication : public QCoreApplication
 {
     Q_OBJECT
 public:
@@ -61,18 +51,6 @@ public:
 
     bool init();
 
-    /**
-     * Requests a reload of relevant runtime configuration.
-     *
-     * @see Quassel::reloadConfig()
-     *
-     * @return True if configuration reload successful, otherwise false
-     */
-    bool reloadConfig();
-
 private:
     CoreApplicationInternal *_internal;
 };
-
-
-#endif

--- a/src/qtui/coreconfigwizard.cpp
+++ b/src/qtui/coreconfigwizard.cpp
@@ -188,7 +188,7 @@ void CoreConfigWizard::prepareCoreSetup(const QString &backend, const QVariantMa
 
     // FIXME? We need to be able to set up older cores that don't have auth backend support.
     // So if the core doesn't support that feature, don't pass those parameters.
-    if (!(Client::coreFeatures() & Quassel::Authenticators)) {
+    if (!Client::isCoreFeatureEnabled(Quassel::Feature::Authenticators)) {
         coreConnection()->setupCore(Protocol::SetupData(field("adminUser.user").toString(), field("adminUser.password").toString(), backend, properties));
     }
     else {
@@ -267,7 +267,7 @@ AdminUserPage::AdminUserPage(QWidget *parent) : QWizardPage(parent)
 int AdminUserPage::nextId() const
 {
     // If the core doesn't support auth backends, skip that page!
-    if (!(Client::coreFeatures() & Quassel::Authenticators)) {
+    if (!Client::isCoreFeatureEnabled(Quassel::Feature::Authenticators)) {
         return CoreConfigWizard::StorageSelectionPage;
     }
     else {

--- a/src/qtui/coresessionwidget.cpp
+++ b/src/qtui/coresessionwidget.cpp
@@ -44,8 +44,8 @@ void CoreSessionWidget::setData(QMap<QString, QVariant> map)
     }
     ui.labelSecure->setText(map["secure"].toBool() ? tr("Yes") : tr("No"));
 
-    auto features = Quassel::Features(map["features"].toInt());
-    ui.disconnectButton->setVisible(features.testFlag(Quassel::Feature::RemoteDisconnect));
+    auto features = Quassel::Features{map["featureList"].toStringList(), static_cast<Quassel::LegacyFeatures>(map["features"].toUInt())};
+    ui.disconnectButton->setVisible(features.isEnabled(Quassel::Feature::RemoteDisconnect));
 
     bool success = false;
     _peerId = map["id"].toInt(&success);

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -774,7 +774,7 @@ void MainWin::changeActiveBufferView(int bufferViewId)
 
 void MainWin::showPasswordChangeDlg()
 {
-    if((Client::coreFeatures() & Quassel::PasswordChange)) {
+    if(Client::isCoreFeatureEnabled(Quassel::Feature::PasswordChange)) {
         PasswordChangeDlg dlg(this);
         dlg.exec();
     }

--- a/src/qtui/monoapplication.cpp
+++ b/src/qtui/monoapplication.cpp
@@ -32,25 +32,26 @@ MonolithicApplication::MonolithicApplication(int &argc, char **argv)
 {
     _internal = new CoreApplicationInternal(); // needed for parser options
 #if defined(HAVE_KDE4) || defined(Q_OS_MAC)
-    disableCrashhandler();
+    Quassel::disableCrashHandler();
 #endif /* HAVE_KDE4 || Q_OS_MAC */
-    setRunMode(Quassel::Monolithic);
+
+    Quassel::setRunMode(Quassel::Monolithic);
 }
 
 
 bool MonolithicApplication::init()
 {
-    if (!Quassel::init()) // parse args
+    if (!QtUiApplication::init())
         return false;
 
     connect(Client::coreConnection(), SIGNAL(startInternalCore()), SLOT(startInternalCore()));
 
-    // FIXME what's this for?
-    if (isOptionSet("port")) {
+    // If port is given, start core so it can listen to incoming connections
+    if (Quassel::isOptionSet("port")) {
         startInternalCore();
     }
 
-    return QtUiApplication::init();
+    return true;
 }
 
 
@@ -72,14 +73,4 @@ void MonolithicApplication::startInternalCore()
     CoreConnection *connection = Client::coreConnection();
     connect(connection, SIGNAL(connectToInternalCore(InternalPeer*)), core, SLOT(setupInternalClientSession(InternalPeer*)));
     connect(core, SIGNAL(sessionState(Protocol::SessionState)), connection, SLOT(internalSessionStateReceived(Protocol::SessionState)));
-}
-
-
-bool MonolithicApplication::reloadConfig()
-{
-    if (_internal) {
-        return _internal->reloadConfig();
-    } else {
-        return false;
-    }
 }

--- a/src/qtui/monoapplication.h
+++ b/src/qtui/monoapplication.h
@@ -18,8 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef MONOAPPLICATION_H_
-#define MONOAPPLICATION_H_
+#pragma once
 
 #include "qtuiapplication.h"
 
@@ -32,16 +31,7 @@ public:
     MonolithicApplication(int &, char **);
     ~MonolithicApplication();
 
-    bool init();
-
-    /**
-     * Requests a reload of relevant runtime configuration.
-     *
-     * @see Quassel::reloadConfig()
-     *
-     * @return True if configuration reload successful, otherwise false
-     */
-    bool reloadConfig();
+    bool init() override;
 
 private slots:
     void startInternalCore();
@@ -50,6 +40,3 @@ private:
     CoreApplicationInternal *_internal;
     bool _internalInitDone;
 };
-
-
-#endif

--- a/src/qtui/qtuiapplication.cpp
+++ b/src/qtui/qtuiapplication.cpp
@@ -189,6 +189,7 @@ bool QtUiApplication::init()
 QtUiApplication::~QtUiApplication()
 {
     Client::destroy();
+    Quassel::destroy();
 }
 
 

--- a/src/qtui/qtuiapplication.h
+++ b/src/qtui/qtuiapplication.h
@@ -18,8 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef QTUIAPPLICATION_H_
-#define QTUIAPPLICATION_H_
+#pragma once
 
 #ifdef HAVE_KDE4
 #  include <KApplication>
@@ -36,10 +35,10 @@
 class QtUi;
 
 #ifdef HAVE_KDE4
-class QtUiApplication : public KApplication, public Quassel
+class QtUiApplication : public KApplication
 {
 #else
-class QtUiApplication : public QApplication, public Quassel
+class QtUiApplication : public QApplication
 {
 #endif
 
@@ -60,9 +59,6 @@ public:
     void commitData(QSessionManager &manager);
     void saveState(QSessionManager &manager);
 #endif
-
-protected:
-    virtual void quit();
 
 private:
     /**
@@ -87,8 +83,11 @@ private:
      */
     bool applySettingsMigration(QtUiSettings settings, const uint newVersion);
 
-    bool _aboutToQuit;
+private slots:
+    void initUi();
+
+private:
+    bool _aboutToQuit{false};
+
+    Quassel _quasselInstance;
 };
-
-
-#endif

--- a/src/qtui/qtuimessageprocessor.cpp
+++ b/src/qtui/qtuimessageprocessor.cpp
@@ -57,7 +57,7 @@ void QtUiMessageProcessor::reset()
 
 void QtUiMessageProcessor::process(Message &msg)
 {
-    if (!Client::coreFeatures().testFlag(Quassel::Feature::CoreSideHighlights))
+    if (!Client::isCoreFeatureEnabled(Quassel::Feature::CoreSideHighlights))
         checkForHighlight(msg);
     preProcess(msg);
     Client::messageModel()->insertMessage(msg);
@@ -69,7 +69,7 @@ void QtUiMessageProcessor::process(QList<Message> &msgs)
     QList<Message>::iterator msgIter = msgs.begin();
     QList<Message>::iterator msgIterEnd = msgs.end();
     while (msgIter != msgIterEnd) {
-        if (!Client::coreFeatures().testFlag(Quassel::Feature::CoreSideHighlights))
+        if (!Client::isCoreFeatureEnabled(Quassel::Feature::CoreSideHighlights))
             checkForHighlight(*msgIter);
         preProcess(*msgIter);
         ++msgIter;

--- a/src/qtui/settingspages/bufferviewsettingspage.cpp
+++ b/src/qtui/settingspages/bufferviewsettingspage.cpp
@@ -40,7 +40,7 @@ BufferViewSettingsPage::BufferViewSettingsPage(QWidget *parent)
 {
     ui.setupUi(this);
     //Hide the hide inactive networks feature on older cores (which won't save the setting)
-    if (!(Client::coreFeatures() & Quassel::HideInactiveNetworks))
+    if (!Client::isCoreFeatureEnabled(Quassel::Feature::HideInactiveNetworks))
         ui.hideInactiveNetworks->hide();
 
     ui.renameBufferView->setIcon(QIcon::fromTheme("edit-rename"));

--- a/src/qtui/settingspages/chatviewsettingspage.cpp
+++ b/src/qtui/settingspages/chatviewsettingspage.cpp
@@ -34,12 +34,12 @@ ChatViewSettingsPage::ChatViewSettingsPage(QWidget *parent)
 #endif
 
     // FIXME remove with protocol v11
-    if (!Client::coreFeatures().testFlag(Quassel::SynchronizedMarkerLine)) {
+    if (!Client::isCoreFeatureEnabled(Quassel::Feature::SynchronizedMarkerLine)) {
         ui.autoMarkerLine->setEnabled(false);
         ui.autoMarkerLine->setChecked(true);
         ui.autoMarkerLine->setToolTip(tr("You need at least version 0.6 of Quassel Core to use this feature"));
     }
-    if (!Client::coreFeatures().testFlag(Quassel::Feature::CoreSideHighlights)) {
+    if (!Client::isCoreFeatureEnabled(Quassel::Feature::CoreSideHighlights)) {
         ui.showSenderPrefixes->setEnabled(false);
         ui.showSenderPrefixes->setToolTip(tr("You need at least version 0.13 of Quassel Core to use this feature"));
     }

--- a/src/qtui/settingspages/identityeditwidget.cpp
+++ b/src/qtui/settingspages/identityeditwidget.cpp
@@ -86,7 +86,7 @@ IdentityEditWidget::IdentityEditWidget(QWidget *parent)
     ui.sslCertGroupBox->installEventFilter(this);
 #endif
 
-    if (Client::coreFeatures() & Quassel::AwayFormatTimestamp) {
+    if (Client::isCoreFeatureEnabled(Quassel::Feature::AwayFormatTimestamp)) {
         // Core allows formatting %%timestamp%% messages in away strings.  Update tooltips.
         QString strFormatTooltip;
         QTextStream formatTooltip( &strFormatTooltip, QIODevice::WriteOnly );

--- a/src/qtui/settingspages/networkssettingspage.cpp
+++ b/src/qtui/settingspages/networkssettingspage.cpp
@@ -46,9 +46,9 @@ NetworksSettingsPage::NetworksSettingsPage(QWidget *parent)
     ui.setupUi(this);
 
     // hide SASL options for older cores
-    if (!(Client::coreFeatures() & Quassel::SaslAuthentication))
+    if (!Client::isCoreFeatureEnabled(Quassel::Feature::SaslAuthentication))
         ui.sasl->hide();
-    if (!(Client::coreFeatures() & Quassel::SaslExternal))
+    if (!Client::isCoreFeatureEnabled(Quassel::Feature::SaslExternal))
         ui.saslExtInfo->hide();
 #ifndef HAVE_SSL
     ui.saslExtInfo->hide();
@@ -176,7 +176,7 @@ void NetworksSettingsPage::load()
     reset();
 
     // Handle UI dependent on core feature flags here
-    if (Client::coreFeatures() & Quassel::CustomRateLimits) {
+    if (Client::isCoreFeatureEnabled(Quassel::Feature::CustomRateLimits)) {
         // Custom rate limiting supported, allow toggling
         ui.useCustomMessageRate->setEnabled(true);
         // Reset tooltip to default.
@@ -358,7 +358,7 @@ void NetworksSettingsPage::setItemState(NetworkId id, QListWidgetItem *item)
 void NetworksSettingsPage::setNetworkCapStates(NetworkId id)
 {
     const Network *net = Client::network(id);
-    if ((Client::coreFeatures() & Quassel::CapNegotiation) && net) {
+    if (Client::isCoreFeatureEnabled(Quassel::Feature::CapNegotiation) && net) {
         // Capability negotiation is supported, network exists.
         // Check if the network is connected.  Don't use net->isConnected() as that won't be true
         // during capability negotiation when capabilities are added and removed.
@@ -575,7 +575,7 @@ void NetworksSettingsPage::displayNetwork(NetworkId id)
 
 #ifdef HAVE_SSL
         // this is only needed when the core supports SASL EXTERNAL
-        if (Client::coreFeatures() & Quassel::SaslExternal) {
+        if (Client::isCoreFeatureEnabled(Quassel::Feature::SaslExternal)) {
             if (_cid) {
                 disconnect(_cid, SIGNAL(sslSettingsUpdated()), this, SLOT(sslUpdated()));
                 delete _cid;
@@ -1021,7 +1021,7 @@ NetworkAddDlg::NetworkAddDlg(const QStringList &exist, QWidget *parent) : QDialo
     // Do NOT call updateSslPort when loading settings, otherwise port settings may be overriden.
     // If useSSL is later changed to be checked by default, change port's default value, too.
 
-    if (Client::coreFeatures() & Quassel::VerifyServerSSL) {
+    if (Client::isCoreFeatureEnabled(Quassel::Feature::VerifyServerSSL)) {
         // Synchronize requiring SSL with the use SSL checkbox
         ui.sslVerify->setEnabled(ui.useSSL->isChecked());
         connect(ui.useSSL, SIGNAL(toggled(bool)), ui.sslVerify, SLOT(setEnabled(bool)));
@@ -1168,7 +1168,7 @@ ServerEditDlg::ServerEditDlg(const Network::Server &server, QWidget *parent) : Q
     // Do NOT call updateSslPort when loading settings, otherwise port settings may be overriden.
     // If useSSL is later changed to be checked by default, change port's default value, too.
 
-    if (Client::coreFeatures() & Quassel::VerifyServerSSL) {
+    if (Client::isCoreFeatureEnabled(Quassel::Feature::VerifyServerSSL)) {
         // Synchronize requiring SSL with the use SSL checkbox
         ui.sslVerify->setEnabled(ui.useSSL->isChecked());
         connect(ui.useSSL, SIGNAL(toggled(bool)), ui.sslVerify, SLOT(setEnabled(bool)));


### PR DESCRIPTION
The previous way of representing all supported features as a bit-wise
combination of flags is reaching its limits, due to the fact that the
old Features enum didn't have a defined width, and thus the compiler
can (and does) choose to represent it as a 16 bit value even though
the serialization in the protocol is defined as a 32 bit value.

In order to solve this problem, and to make feature negotiation more
robust, a new field "FeatureList" is added to both "ClientInit"
and "ClientInitAck" handshake messages that holds a string list with
the supported features.

Clients still send both "Features" and "FeatureList" fields when
registering, in order to support older cores. The core now omits
the legacy "CoreFeatures" field if the client indicates support
for extended features. Support for extended features is indicated
as the legacy feature 0x8000.