### PR TITLE
PostgreSqlStorage: Fix apparently-incorrect index in requestAllMsgs

### DIFF
--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1685,7 +1685,7 @@ QList<Message> PostgreSqlStorage::requestAllMsgs(UserId user, MsgId first, MsgId
 
     QDateTime timestamp;
     for (int i = 0; i < limit && query.next(); i++) {
-        timestamp = query.value(1).toDateTime();
+        timestamp = query.value(2).toDateTime();
         timestamp.setTimeSpec(Qt::UTC);
         Message msg(timestamp,
             bufferInfoHash[query.value(1).toInt()],


### PR DESCRIPTION
This function was using 1 for its date index, which is the same
index as was used for bufferid.  The correct index to use is 2.