### PR TITLE
Add support for Elliptic Curve keys for CertFP

### DIFF
--- a/src/client/clientidentity.cpp
+++ b/src/client/clientidentity.cpp
@@ -111,6 +111,10 @@ void CertIdentity::markClean()
 void ClientCertManager::setSslKey(const QByteArray &encoded)
 {
     QSslKey key(encoded, QSsl::Rsa);
+#if QT_VERSION >= 0x050500
+    if (key.isNull() && Client::isCoreFeatureEnabled(Quassel::Feature::EcdsaCertfpKeys))
+        key = QSslKey(encoded, QSsl::Ec);
+#endif
     if (key.isNull())
         key = QSslKey(encoded, QSsl::Dsa);
     _certIdentity->setSslKey(key);

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -127,6 +127,9 @@ public:
         SenderPrefixes,           ///< Show prefixes for senders in backlog
         RemoteDisconnect,         ///< Allow this peer to be remotely disconnected
         ExtendedFeatures,         ///< Extended features
+#if QT_VERSION >= 0x050500
+        EcdsaCertfpKeys,          ///< ECDSA keys for CertFP in identities
+#endif
     };
     Q_ENUMS(Feature)
 

--- a/src/core/coreidentity.cpp
+++ b/src/core/coreidentity.cpp
@@ -77,6 +77,10 @@ void CoreIdentity::synchronize(SignalProxy *proxy)
 void CoreIdentity::setSslKey(const QByteArray &encoded)
 {
     QSslKey key(encoded, QSsl::Rsa);
+#if QT_VERSION >= 0x050500
+    if (key.isNull())
+        key = QSslKey(encoded, QSsl::Ec);
+#endif
     if (key.isNull())
         key = QSslKey(encoded, QSsl::Dsa);
     setSslKey(key);


### PR DESCRIPTION
This functionality is controlled by a feature flag so that clients
supporting EC keys won't try to set an EC key on a core that
doesn't.  As with the previous EC patch, this requires Qt 5.5 to
work but uses the QT_VERSION macro to remain compileable with Qt4.

This patch also fixes the QSsl::KeyAlgorithm indices to be correct
for both Qt4 and Qt5.  In Qt4, RSA was 0 and DSA was 1, but in Qt5
0 became Opaque, 1 because RSA, and two became DSA.  EC is 3 and
wasn't added until 5.5.  The new macro handles all three versions
correctly.  (See https://doc.qt.io/qt-5/qssl.html#KeyAlgorithm-enum
and https://doc.qt.io/archives/qt-4.8/qssl.html#KeyAlgorithm-enum.)
Thanks to @justJanne for pointing out this discrepancy.