### PR TITLE
Add strict-oidentd mode

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -169,6 +169,7 @@ int main(int argc, char **argv)
     cliParser->addOption("change-userpass", 0, "Starts an interactive session to change the password of the user identified by <username>", "username");
     cliParser->addSwitch("oidentd", 0, "Enable oidentd integration");
     cliParser->addOption("oidentd-conffile", 0, "Set path to oidentd configuration file", "file");
+    cliParser->addSwitch("oidentd-strict", 0, "Use users' quasselcore username as ident reply. Ignores each user's configured ident setting. Only meaningful with --oidentd.");
 #ifdef HAVE_SSL
     cliParser->addSwitch("require-ssl", 0, "Require SSL for remote (non-loopback) client connections");
     cliParser->addOption("ssl-cert", 0, "Specify the path to the SSL Certificate", "path", "configdir/quasselCert.pem");

--- a/src/core/SQL/PostgreSQL/select_all_authusernames.sql
+++ b/src/core/SQL/PostgreSQL/select_all_authusernames.sql
@@ -1,0 +1,2 @@
+SELECT userid, username
+FROM quasseluser;

--- a/src/core/SQL/PostgreSQL/select_authusername.sql
+++ b/src/core/SQL/PostgreSQL/select_authusername.sql
@@ -1,0 +1,3 @@
+SELECT username
+FROM quasseluser
+WHERE userid = :userid

--- a/src/core/SQL/SQLite/select_all_authusernames.sql
+++ b/src/core/SQL/SQLite/select_all_authusernames.sql
@@ -1,0 +1,2 @@
+SELECT userid, username
+FROM quasseluser;

--- a/src/core/SQL/SQLite/select_authusername.sql
+++ b/src/core/SQL/SQLite/select_authusername.sql
@@ -1,0 +1,3 @@
+SELECT username
+FROM quasseluser
+WHERE userid = :userid

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -237,7 +237,7 @@ void Core::init()
     if (!startListening()) exit(1);  // TODO make this less brutal
 
     if (Quassel::isOptionSet("oidentd"))
-        _oidentdConfigGenerator = new OidentdConfigGenerator(this);
+        _oidentdConfigGenerator = new OidentdConfigGenerator(Quassel::isOptionSet("oidentd-strict"), this);
 }
 
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -501,6 +501,12 @@ public:
         return instance()->_storage->getAuthusername(user);
     }
 
+    //! Get a usable sysident for the given user in oidentd-strict mode
+    /** \param user    The user to retrieve the sysident for
+     *  \return The authusername
+     */
+    QString strictSysident(UserId user);
+
 
     //! Get a Hash of all last seen message ids
     /** This Method is called when the Quassel Core is started to restore the lastSeenMsgIds
@@ -583,6 +589,8 @@ public:
      * @return True if certificates reloaded successfully, otherwise false.
      */
     static bool reloadCerts();
+
+    static void cacheSysident();
 
     static QVariantList backendInfo();
     static QVariantList authenticatorInfo();
@@ -667,6 +675,7 @@ private:
     DeferredSharedPtr<Storage>       _storage;        ///< Active storage backend
     DeferredSharedPtr<Authenticator> _authenticator;  ///< Active authenticator
     QTimer _storageSyncTimer;
+    QMap<UserId, QString> _authusernames;
 
 #ifdef HAVE_SSL
     SslServer _server, _v6server;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -493,6 +493,14 @@ public:
         return instance()->_storage->setBufferLastSeenMsg(user, bufferId, msgId);
     }
 
+    //! Get the auth username associated with a userId
+    /** \param user  The user to retrieve the username for
+     *  \return      The username for the user
+     */
+    static inline const QString getAuthusername(UserId user) {
+        return instance()->_storage->getAuthusername(user);
+    }
+
 
     //! Get a Hash of all last seen message ids
     /** This Method is called when the Quassel Core is started to restore the lastSeenMsgIds

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -497,15 +497,15 @@ public:
     /** \param user  The user to retrieve the username for
      *  \return      The username for the user
      */
-    static inline const QString getAuthusername(UserId user) {
-        return instance()->_storage->getAuthusername(user);
+    static inline QString getAuthUserName(UserId user) {
+        return instance()->_storage->getAuthUserName(user);
     }
 
     //! Get a usable sysident for the given user in oidentd-strict mode
     /** \param user    The user to retrieve the sysident for
      *  \return The authusername
      */
-    QString strictSysident(UserId user);
+    QString strictSysIdent(UserId user) const;
 
 
     //! Get a Hash of all last seen message ids
@@ -590,7 +590,7 @@ public:
      */
     static bool reloadCerts();
 
-    static void cacheSysident();
+    static void cacheSysIdent();
 
     static QVariantList backendInfo();
     static QVariantList authenticatorInfo();
@@ -675,7 +675,7 @@ private:
     DeferredSharedPtr<Storage>       _storage;        ///< Active storage backend
     DeferredSharedPtr<Authenticator> _authenticator;  ///< Active authenticator
     QTimer _storageSyncTimer;
-    QMap<UserId, QString> _authusernames;
+    QMap<UserId, QString> _authUserNames;
 
 #ifdef HAVE_SSL
     SslServer _server, _v6server;

--- a/src/core/coreapplication.cpp
+++ b/src/core/coreapplication.cpp
@@ -56,7 +56,8 @@ bool CoreApplicationInternal::init()
     _coreCreated = true;
 
     Quassel::registerReloadHandler([]() {
-        // Currently, only reloading SSL certificates is supported
+        // Currently, only reloading SSL certificates and the sysident cache is supported
+        Core::cacheSysident();
         return Core::reloadCerts();
     });
 

--- a/src/core/coreapplication.cpp
+++ b/src/core/coreapplication.cpp
@@ -57,7 +57,7 @@ bool CoreApplicationInternal::init()
 
     Quassel::registerReloadHandler([]() {
         // Currently, only reloading SSL certificates and the sysident cache is supported
-        Core::cacheSysident();
+        Core::cacheSysIdent();
         return Core::reloadCerts();
     });
 

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -509,7 +509,7 @@ void CoreSession::createIdentity(const Identity &identity, const QVariantMap &ad
 }
 
 const QString CoreSession::strictSysident() {
-    return Core::instance()->strictSysident(_user);
+    return Core::instance()->strictSysIdent(_user);
 }
 
 void CoreSession::createIdentity(const CoreIdentity &identity)

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -509,8 +509,7 @@ void CoreSession::createIdentity(const Identity &identity, const QVariantMap &ad
 }
 
 const QString CoreSession::strictSysident() {
-    const QString authusername = Core::getAuthusername(_user);
-    return authusername;
+    return Core::instance()->strictSysident(_user);
 }
 
 void CoreSession::createIdentity(const CoreIdentity &identity)

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -508,6 +508,10 @@ void CoreSession::createIdentity(const Identity &identity, const QVariantMap &ad
         createIdentity(coreIdentity);
 }
 
+const QString CoreSession::strictSysident() {
+    const QString authusername = Core::getAuthusername(_user);
+    return authusername;
+}
 
 void CoreSession::createIdentity(const CoreIdentity &identity)
 {

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -69,6 +69,7 @@ public:
     inline UserId user() const { return _user; }
     CoreNetwork *network(NetworkId) const;
     CoreIdentity *identity(IdentityId) const;
+    const QString strictSysident();
     inline CoreNetworkConfig *networkConfig() const { return _networkConfig; }
     NetworkConnection *networkConnection(NetworkId) const;
 

--- a/src/core/oidentdconfiggenerator.cpp
+++ b/src/core/oidentdconfiggenerator.cpp
@@ -18,10 +18,10 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#include "oidentdconfiggenerator.h"
-#include "corenetwork.h"
-
 #include <QString>
+
+#include "corenetwork.h"
+#include "oidentdconfiggenerator.h"
 
 OidentdConfigGenerator::OidentdConfigGenerator(bool strict, QObject *parent) :
     QObject(parent),
@@ -69,7 +69,8 @@ bool OidentdConfigGenerator::init()
     return _initialized;
 }
 
-const QString OidentdConfigGenerator::sysidentForIdentity(const CoreIdentity *identity) {
+
+QString OidentdConfigGenerator::sysIdentForIdentity(const CoreIdentity *identity) const {
     if (!_strict) {
         return identity->ident();
     }
@@ -77,10 +78,11 @@ const QString OidentdConfigGenerator::sysidentForIdentity(const CoreIdentity *id
     return network->coreSession()->strictSysident();
 }
 
+
 bool OidentdConfigGenerator::addSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort)
 {
     Q_UNUSED(localAddress) Q_UNUSED(peerAddress) Q_UNUSED(peerPort)
-    const QString ident = sysidentForIdentity(identity);
+    const QString ident = sysIdentForIdentity(identity);
 
     _quasselConfig.append(_quasselStanzaTemplate.arg(localPort).arg(ident).arg(_configTag).toLatin1());
 

--- a/src/core/oidentdconfiggenerator.cpp
+++ b/src/core/oidentdconfiggenerator.cpp
@@ -19,10 +19,14 @@
  ***************************************************************************/
 
 #include "oidentdconfiggenerator.h"
+#include "corenetwork.h"
 
-OidentdConfigGenerator::OidentdConfigGenerator(QObject *parent) :
+#include <QString>
+
+OidentdConfigGenerator::OidentdConfigGenerator(bool strict, QObject *parent) :
     QObject(parent),
-    _initialized(false)
+    _initialized(false),
+    _strict(strict)
 {
     if (!_initialized)
         init();
@@ -65,11 +69,18 @@ bool OidentdConfigGenerator::init()
     return _initialized;
 }
 
+const QString OidentdConfigGenerator::sysidentForIdentity(const CoreIdentity *identity) {
+    if (!_strict) {
+        return identity->ident();
+    }
+    const CoreNetwork *network = qobject_cast<CoreNetwork *>(sender());
+    return network->coreSession()->strictSysident();
+}
 
 bool OidentdConfigGenerator::addSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort)
 {
     Q_UNUSED(localAddress) Q_UNUSED(peerAddress) Q_UNUSED(peerPort)
-    QString ident = identity->ident();
+    const QString ident = sysidentForIdentity(identity);
 
     _quasselConfig.append(_quasselStanzaTemplate.arg(localPort).arg(ident).arg(_configTag).toLatin1());
 

--- a/src/core/oidentdconfiggenerator.h
+++ b/src/core/oidentdconfiggenerator.h
@@ -22,6 +22,7 @@
 #define OIDENTDCONFIGGENERATOR_H
 
 #include <QObject>
+#include <QString>
 #include <QDir>
 #include <QFile>
 #include <QDateTime>
@@ -58,7 +59,11 @@ class OidentdConfigGenerator : public QObject
 {
     Q_OBJECT
 public:
-    explicit OidentdConfigGenerator(QObject *parent = 0);
+    /**
+     * @param strict If false, any identity a user chooses is reported to servers as authoritative.
+     *               If true, the user's quassel username is always reported.
+     */
+    explicit OidentdConfigGenerator(bool strict = false, QObject *parent = 0);
     ~OidentdConfigGenerator();
 
 public slots:
@@ -66,12 +71,14 @@ public slots:
     bool removeSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
 
 private:
+    const QString sysidentForIdentity(const CoreIdentity *identity);
     bool init();
     bool writeConfig();
     bool parseConfig(bool readQuasselStanzas = false);
     bool lineByUs(const QByteArray &line);
 
     bool _initialized;
+    bool _strict;
     QDateTime _lastSync;
     QFile *_configFile;
     QByteArray _parsedConfig;

--- a/src/core/oidentdconfiggenerator.h
+++ b/src/core/oidentdconfiggenerator.h
@@ -71,7 +71,7 @@ public slots:
     bool removeSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
 
 private:
-    const QString sysidentForIdentity(const CoreIdentity *identity);
+    QString sysIdentForIdentity(const CoreIdentity *identity) const;
     bool init();
     bool writeConfig();
     bool parseConfig(bool readQuasselStanzas = false);

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1702,6 +1702,19 @@ QList<Message> PostgreSqlStorage::requestAllMsgs(UserId user, MsgId first, MsgId
     return messagelist;
 }
 
+QMap<UserId, QString> PostgreSqlStorage::getAllAuthusernames() {
+    QMap<UserId, QString> authusernames;
+    QSqlQuery query(logDb());
+    query.prepare(queryString("select_all_authusernames"));
+    safeExec(query);
+    watchQuery(query);
+
+    while (query.next()) {
+        authusernames[query.value(0).toInt()] = query.value(1).toString();
+    }
+    return authusernames;
+}
+
 const QString PostgreSqlStorage::getAuthusername(UserId user) {
     QString authusername;
     QSqlQuery query(logDb());

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1702,7 +1702,9 @@ QList<Message> PostgreSqlStorage::requestAllMsgs(UserId user, MsgId first, MsgId
     return messagelist;
 }
 
-QMap<UserId, QString> PostgreSqlStorage::getAllAuthusernames() {
+
+QMap<UserId, QString> PostgreSqlStorage::getAllAuthUserNames()
+{
     QMap<UserId, QString> authusernames;
     QSqlQuery query(logDb());
     query.prepare(queryString("select_all_authusernames"));
@@ -1715,7 +1717,9 @@ QMap<UserId, QString> PostgreSqlStorage::getAllAuthusernames() {
     return authusernames;
 }
 
-const QString PostgreSqlStorage::getAuthusername(UserId user) {
+
+QString PostgreSqlStorage::getAuthUserName(UserId user)
+{
     QString authusername;
     QSqlQuery query(logDb());
     query.prepare(queryString("select_authusername"));

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1702,6 +1702,19 @@ QList<Message> PostgreSqlStorage::requestAllMsgs(UserId user, MsgId first, MsgId
     return messagelist;
 }
 
+const QString PostgreSqlStorage::getAuthusername(UserId user) {
+    QString authusername;
+    QSqlQuery query(logDb());
+    query.prepare(queryString("select_authusername"));
+    query.bindValue(":userid", user.toInt());
+    safeExec(query);
+    watchQuery(query);
+
+    if (query.first()) {
+         authusername = query.value(0).toString();
+    }
+    return authusername;
+}
 
 // void PostgreSqlStorage::safeExec(QSqlQuery &query) {
 //   qDebug() << "PostgreSqlStorage::safeExec";

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -106,6 +106,7 @@ public slots:
     QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
 
     /* Sysident handling */
+    virtual QMap<UserId, QString> getAllAuthusernames();
     virtual const QString getAuthusername(UserId user);
 
 protected:

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -106,8 +106,8 @@ public slots:
     QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
 
     /* Sysident handling */
-    virtual QMap<UserId, QString> getAllAuthusernames();
-    virtual const QString getAuthusername(UserId user);
+    QMap<UserId, QString> getAllAuthUserNames() override;
+    QString getAuthUserName(UserId user) override;
 
 protected:
     bool initDbSession(QSqlDatabase &db) override;

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -105,6 +105,9 @@ public slots:
     QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) override;
     QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
 
+    /* Sysident handling */
+    virtual const QString getAuthusername(UserId user);
+
 protected:
     bool initDbSession(QSqlDatabase &db) override;
     void setConnectionProperties(const QVariantMap &properties) override;

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -30,6 +30,7 @@
     <file>./SQL/PostgreSQL/migrate_write_quasseluser.sql</file>
     <file>./SQL/PostgreSQL/migrate_write_sender.sql</file>
     <file>./SQL/PostgreSQL/migrate_write_usersetting.sql</file>
+    <file>./SQL/PostgreSQL/select_all_authusernames.sql</file>
     <file>./SQL/PostgreSQL/select_authenticator.sql</file>
     <file>./SQL/PostgreSQL/select_authuser.sql</file>
     <file>./SQL/PostgreSQL/select_authusername.sql</file>
@@ -140,6 +141,7 @@
     <file>./SQL/SQLite/migrate_read_quasseluser.sql</file>
     <file>./SQL/SQLite/migrate_read_sender.sql</file>
     <file>./SQL/SQLite/migrate_read_usersetting.sql</file>
+    <file>./SQL/SQLite/select_all_authusernames.sql</file>
     <file>./SQL/SQLite/select_authenticator.sql</file>
     <file>./SQL/SQLite/select_authuser.sql</file>
     <file>./SQL/SQLite/select_authusername.sql</file>

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -32,6 +32,7 @@
     <file>./SQL/PostgreSQL/migrate_write_usersetting.sql</file>
     <file>./SQL/PostgreSQL/select_authenticator.sql</file>
     <file>./SQL/PostgreSQL/select_authuser.sql</file>
+    <file>./SQL/PostgreSQL/select_authusername.sql</file>
     <file>./SQL/PostgreSQL/select_bufferByName.sql</file>
     <file>./SQL/PostgreSQL/select_bufferExists.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_bufferactivities.sql</file>
@@ -141,6 +142,7 @@
     <file>./SQL/SQLite/migrate_read_usersetting.sql</file>
     <file>./SQL/SQLite/select_authenticator.sql</file>
     <file>./SQL/SQLite/select_authuser.sql</file>
+    <file>./SQL/SQLite/select_authusername.sql</file>
     <file>./SQL/SQLite/select_bufferByName.sql</file>
     <file>./SQL/SQLite/select_bufferExists.sql</file>
     <file>./SQL/SQLite/select_buffer_bufferactivities.sql</file>

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1820,7 +1820,8 @@ QList<Message> SqliteStorage::requestAllMsgs(UserId user, MsgId first, MsgId las
     return messagelist;
 }
 
-QMap<UserId, QString> SqliteStorage::getAllAuthusernames()
+
+QMap<UserId, QString> SqliteStorage::getAllAuthUserNames()
 {
     QMap<UserId, QString> authusernames;
 
@@ -1842,7 +1843,8 @@ QMap<UserId, QString> SqliteStorage::getAllAuthusernames()
     return authusernames;
 }
 
-const QString SqliteStorage::getAuthusername(UserId user) {
+
+QString SqliteStorage::getAuthUserName(UserId user) {
     QString authusername;
     QSqlQuery query(logDb());
     query.prepare(queryString("select_authusername"));
@@ -1859,6 +1861,7 @@ const QString SqliteStorage::getAuthusername(UserId user) {
 
     return authusername;
 }
+
 
 QString SqliteStorage::backlogFile()
 {

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1820,6 +1820,23 @@ QList<Message> SqliteStorage::requestAllMsgs(UserId user, MsgId first, MsgId las
     return messagelist;
 }
 
+const QString SqliteStorage::getAuthusername(UserId user) {
+    QString authusername;
+    QSqlQuery query(logDb());
+    query.prepare(queryString("select_authusername"));
+    query.bindValue(":userid", user.toInt());
+
+    lockForRead();
+    safeExec(query);
+    watchQuery(query);
+    unlock();
+
+    if (query.first()) {
+        authusername = query.value(0).toString();
+    }
+
+    return authusername;
+}
 
 QString SqliteStorage::backlogFile()
 {

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1820,6 +1820,28 @@ QList<Message> SqliteStorage::requestAllMsgs(UserId user, MsgId first, MsgId las
     return messagelist;
 }
 
+QMap<UserId, QString> SqliteStorage::getAllAuthusernames()
+{
+    QMap<UserId, QString> authusernames;
+
+    QSqlDatabase db = logDb();
+    db.transaction();
+    {
+        QSqlQuery query(db);
+        query.prepare(queryString("select_all_authusernames"));
+
+        lockForRead();
+        safeExec(query);
+        watchQuery(query);
+        while (query.next()) {
+            authusernames[query.value(0).toInt()] = query.value(1).toString();
+        }
+    }
+    db.commit();
+    unlock();
+    return authusernames;
+}
+
 const QString SqliteStorage::getAuthusername(UserId user) {
     QString authusername;
     QSqlQuery query(logDb());

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -107,8 +107,8 @@ public slots:
     QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
 
     /* Sysident handling */
-    virtual QMap<UserId, QString> getAllAuthusernames();
-    virtual const QString getAuthusername(UserId user);
+    QMap<UserId, QString> getAllAuthUserNames() override;
+    QString getAuthUserName(UserId user) override;
 
 protected:
     void setConnectionProperties(const QVariantMap & /* properties */)  override {}

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -106,6 +106,9 @@ public slots:
     QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) override;
     QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
 
+    /* Sysident handling */
+    virtual const QString getAuthusername(UserId user);
+
 protected:
     void setConnectionProperties(const QVariantMap & /* properties */)  override {}
     QString driverName()  override { return "QSQLITE"; }

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -107,6 +107,7 @@ public slots:
     QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
 
     /* Sysident handling */
+    virtual QMap<UserId, QString> getAllAuthusernames();
     virtual const QString getAuthusername(UserId user);
 
 protected:

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -442,6 +442,12 @@ public slots:
      */
     virtual QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) = 0;
 
+    //! Get the auth username associated with a userId
+    /** \param user  The user to retrieve the username for
+     *  \return      The username for the user
+     */
+    virtual const QString getAuthusername(UserId user) = 0;
+
 signals:
     //! Sent when a new BufferInfo is created, or an existing one changed somehow.
     void bufferInfoUpdated(UserId user, const BufferInfo &);

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -445,13 +445,13 @@ public slots:
     //! Fetch all authusernames
     /** \return      Map of all current UserIds to permitted idents
      */
-    virtual QMap<UserId, QString> getAllAuthusernames() = 0;
+    virtual QMap<UserId, QString> getAllAuthUserNames() = 0;
 
     //! Get the auth username associated with a userId
     /** \param user  The user to retrieve the username for
      *  \return      The username for the user
      */
-    virtual const QString getAuthusername(UserId user) = 0;
+    virtual QString getAuthUserName(UserId user) = 0;
 
 signals:
     //! Sent when a new BufferInfo is created, or an existing one changed somehow.

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -442,6 +442,11 @@ public slots:
      */
     virtual QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) = 0;
 
+    //! Fetch all authusernames
+    /** \return      Map of all current UserIds to permitted idents
+     */
+    virtual QMap<UserId, QString> getAllAuthusernames() = 0;
+
     //! Get the auth username associated with a userId
     /** \param user  The user to retrieve the username for
      *  \return      The username for the user


### PR DESCRIPTION
This mode is disabled by default.  When specified, this restricts
authoratative ident responses to be the authuser account name.

This is a cut-down version of,
https://github.com/quassel/quassel/pull/164 which was originally
authored by @esainane.  @AlD requested that the database schema
change be removed, but the request fell dormant and was eventually
closed.  This version removes the schema change as requested,
always using the user's core username as the ident when enabled.

Co-authored-by: Sai Nane <esainane+github@gmail.com>
Co-authored-by: Michael Marley <michael@michaelmarley.com>