### PR TITLE
cmake: Add exception handling support to MSVC compile flags

### DIFF
--- a/cmake/QuasselCompileSettings.cmake
+++ b/cmake/QuasselCompileSettings.cmake
@@ -66,11 +66,14 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-function -Wno-undef -fno-strict-aliasing")
 
-# For MSVC, at least do a version sanity check
+# For MSVC, at least do a version sanity check...
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.0")
         message(FATAL_ERROR "Your compiler is too old; you need at least Visual Studio 2015 (MSVC 19.0+), GCC 4.8+, Clang 3.3+, or any other compiler with full C++11 support.")
     endif()
+
+    # ... and enable exception handling (required for STL types)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
 
 # Unknown/unsupported compiler
 else()


### PR DESCRIPTION
Since STL types may throw, MSVC needs to get told to support
exceptions by specifying the /EHsc flag. Otherwise, it warns about
the lack thereof, even though Quassel itself does not use nor handle
exceptions.