### PR TITLE
Coreside Realname/Avatar URL Storage

### DIFF
--- a/src/common/message.cpp
+++ b/src/common/message.cpp
@@ -26,24 +26,31 @@
 
 #include <QDataStream>
 
-Message::Message(const BufferInfo &bufferInfo, Type type, const QString &contents, const QString &sender, const QString &senderPrefixes, Flags flags)
+Message::Message(const BufferInfo &bufferInfo, Type type, const QString &contents, const QString &sender,
+                 const QString &senderPrefixes, const QString &realName, const QString &avatarUrl, Flags flags)
     : _timestamp(QDateTime::currentDateTime().toUTC()),
     _bufferInfo(bufferInfo),
     _contents(contents),
     _sender(sender),
     _senderPrefixes(senderPrefixes),
+    _realName(realName),
+    _avatarUrl(avatarUrl),
     _type(type),
     _flags(flags)
 {
 }
 
 
-Message::Message(const QDateTime &ts, const BufferInfo &bufferInfo, Type type, const QString &contents, const QString &sender, const QString &senderPrefixes, Flags flags)
+Message::Message(const QDateTime &ts, const BufferInfo &bufferInfo, Type type, const QString &contents,
+                 const QString &sender, const QString &senderPrefixes, const QString &realName,
+                 const QString &avatarUrl, Flags flags)
     : _timestamp(ts),
     _bufferInfo(bufferInfo),
     _contents(contents),
     _sender(sender),
     _senderPrefixes(senderPrefixes),
+    _realName(realName),
+    _avatarUrl(avatarUrl),
     _type(type),
     _flags(flags)
 {
@@ -52,7 +59,6 @@ Message::Message(const QDateTime &ts, const BufferInfo &bufferInfo, Type type, c
 
 QDataStream &operator<<(QDataStream &out, const Message &msg)
 {
-    // We do not serialize the sender prefixes until we have a new protocol or client-features implemented
     out << msg.msgId()
         << (quint32) msg.timestamp().toTime_t()
         << (quint32) msg.type()
@@ -62,6 +68,12 @@ QDataStream &operator<<(QDataStream &out, const Message &msg)
 
     if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::SenderPrefixes))
         out << msg.senderPrefixes().toUtf8();
+
+    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::RichMessages))
+        out << msg.realName().toUtf8();
+
+    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::RichMessages))
+        out << msg.avatarUrl().toUtf8();
 
     out << msg.contents().toUtf8();
     return out;
@@ -95,6 +107,16 @@ QDataStream &operator>>(QDataStream &in, Message &msg)
         in >> senderPrefixes;
     msg._senderPrefixes = QString::fromUtf8(senderPrefixes);
 
+    QByteArray realName;
+    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::RichMessages))
+        in >> realName;
+    msg._realName = QString::fromUtf8(realName);
+
+    QByteArray avatarUrl;
+    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::RichMessages))
+        in >> avatarUrl;
+    msg._avatarUrl = QString::fromUtf8(avatarUrl);
+
     QByteArray contents;
     in >> contents;
     msg._contents = QString::fromUtf8(contents);
@@ -108,7 +130,9 @@ QDebug operator<<(QDebug dbg, const Message &msg)
     dbg.nospace() << qPrintable(QString("Message(MsgId:")) << msg.msgId()
     << qPrintable(QString(",")) << msg.timestamp()
     << qPrintable(QString(", Type:")) << msg.type()
+    << qPrintable(QString(", RealName:")) << msg.realName()
+    << qPrintable(QString(", AvatarURL:")) << msg.avatarUrl()
     << qPrintable(QString(", Flags:")) << msg.flags() << qPrintable(QString(")"))
-    << msg.sender() << ":" << msg.contents();
+    << msg.senderPrefixes() << msg.sender() << ":" << msg.contents();
     return dbg;
 }

--- a/src/common/message.cpp
+++ b/src/common/message.cpp
@@ -69,11 +69,10 @@ QDataStream &operator<<(QDataStream &out, const Message &msg)
     if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::SenderPrefixes))
         out << msg.senderPrefixes().toUtf8();
 
-    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::RichMessages))
+    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::RichMessages)) {
         out << msg.realName().toUtf8();
-
-    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::RichMessages))
         out << msg.avatarUrl().toUtf8();
+    }
 
     out << msg.contents().toUtf8();
     return out;
@@ -108,13 +107,12 @@ QDataStream &operator>>(QDataStream &in, Message &msg)
     msg._senderPrefixes = QString::fromUtf8(senderPrefixes);
 
     QByteArray realName;
-    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::RichMessages))
-        in >> realName;
-    msg._realName = QString::fromUtf8(realName);
-
     QByteArray avatarUrl;
-    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::RichMessages))
+    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::RichMessages)) {
+        in >> realName;
         in >> avatarUrl;
+    }
+    msg._realName = QString::fromUtf8(realName);
     msg._avatarUrl = QString::fromUtf8(avatarUrl);
 
     QByteArray contents;

--- a/src/common/message.h
+++ b/src/common/message.h
@@ -68,10 +68,11 @@ public:
     Q_DECLARE_FLAGS(Flags, Flag)
 
     Message(const BufferInfo &bufferInfo = BufferInfo(), Type type = Plain, const QString &contents = {},
-            const QString &sender = {}, const QString &senderPrefixes = {}, Flags flags = None);
+            const QString &sender = {}, const QString &senderPrefixes = {}, const QString &realName = {},
+            const QString &avatarUrl = {}, Flags flags = None);
     Message(const QDateTime &ts, const BufferInfo &buffer = BufferInfo(), Type type = Plain,
             const QString &contents = {}, const QString &sender = {}, const QString &senderPrefixes = {},
-            Flags flags = None);
+            const QString &realName = {}, const QString &avatarUrl = {}, Flags flags = None);
 
     inline static Message ChangeOfDay(const QDateTime &day) { return Message(day, BufferInfo(), DayChange); }
     inline const MsgId &msgId() const { return _msgId; }
@@ -83,6 +84,8 @@ public:
     inline const QString &contents() const { return _contents; }
     inline const QString &sender() const { return _sender; }
     inline const QString &senderPrefixes() const { return _senderPrefixes; }
+    inline const QString &realName() const { return _realName; }
+    inline const QString &avatarUrl() const { return _avatarUrl; }
     inline Type type() const { return _type; }
     inline Flags flags() const { return _flags; }
     inline void setFlags(Flags flags) { _flags = flags; }
@@ -99,6 +102,8 @@ private:
     QString _contents;
     QString _sender;
     QString _senderPrefixes;
+    QString _realName;
+    QString _avatarUrl;
     Type _type;
     Flags _flags;
 

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -127,6 +127,7 @@ public:
         SenderPrefixes,           ///< Show prefixes for senders in backlog
         RemoteDisconnect,         ///< Allow this peer to be remotely disconnected
         ExtendedFeatures,         ///< Extended features
+        RichMessages,             ///< Real Name and Avatar URL in backlog
     };
     Q_ENUMS(Feature)
 

--- a/src/core/SQL/PostgreSQL/insert_sender.sql
+++ b/src/core/SQL/PostgreSQL/insert_sender.sql
@@ -1,3 +1,3 @@
-INSERT INTO sender (sender)
-VALUES ($1)
+INSERT INTO sender (sender, realname, avatarurl)
+VALUES ($1, $2, $3)
 RETURNING senderid

--- a/src/core/SQL/PostgreSQL/migrate_write_sender.sql
+++ b/src/core/SQL/PostgreSQL/migrate_write_sender.sql
@@ -1,2 +1,2 @@
-INSERT INTO sender (senderid, sender)
-VALUES (?, ?)
+INSERT INTO sender (senderid, sender, realname, avatarurl)
+VALUES (?, ?, ?, ?)

--- a/src/core/SQL/PostgreSQL/select_messagesAll.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesAll.sql
@@ -1,4 +1,4 @@
-SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)

--- a/src/core/SQL/PostgreSQL/select_messagesAllNew.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesAllNew.sql
@@ -1,4 +1,4 @@
-SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)

--- a/src/core/SQL/PostgreSQL/select_messagesNewerThan.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesNewerThan.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= $1

--- a/src/core/SQL/PostgreSQL/select_messagesNewestK.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesNewestK.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE bufferid = $1

--- a/src/core/SQL/PostgreSQL/select_messagesRange.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesRange.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= $1

--- a/src/core/SQL/PostgreSQL/select_senderid.sql
+++ b/src/core/SQL/PostgreSQL/select_senderid.sql
@@ -1,3 +1,3 @@
 SELECT senderid
 FROM sender
-WHERE sender = $1
+WHERE sender = $1 AND realname = $2 AND avatarurl = $3

--- a/src/core/SQL/PostgreSQL/setup_010_sender.sql
+++ b/src/core/SQL/PostgreSQL/setup_010_sender.sql
@@ -1,4 +1,6 @@
 CREATE TABLE sender ( -- THE SENDER OF IRC MESSAGES
        senderid serial NOT NULL PRIMARY KEY,
-       sender varchar(128) UNIQUE NOT NULL
-)
+       sender varchar(128) NOT NULL
+	   realname TEXT,
+	   avatarurl TEXT
+);

--- a/src/core/SQL/PostgreSQL/setup_010_sender.sql
+++ b/src/core/SQL/PostgreSQL/setup_010_sender.sql
@@ -1,6 +1,6 @@
 CREATE TABLE sender ( -- THE SENDER OF IRC MESSAGES
        senderid serial NOT NULL PRIMARY KEY,
-       sender varchar(128) NOT NULL
+       sender varchar(128) NOT NULL,
 	   realname TEXT,
 	   avatarurl TEXT
 );

--- a/src/core/SQL/PostgreSQL/setup_140_sender_idx.sql
+++ b/src/core/SQL/PostgreSQL/setup_140_sender_idx.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX sender_sender_realname_avatarurl_uindex ON sender(sender, realname, avatarurl);

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_000_update_sender_add_realname.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_000_update_sender_add_realname.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sender ADD realname TEXT NULL;

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_010_update_sender_add_avatarurl.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_010_update_sender_add_avatarurl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sender ADD avatarurl TEXT NULL;

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_020_update_sender_add_new_constraint.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_020_update_sender_add_new_constraint.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX sender_sender_realname_avatarurl_uindex ON sender(sender, realname, avatarurl);

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_030_upgrade_sender_drop_old_constraint.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_030_upgrade_sender_drop_old_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sender DROP CONSTRAINT sender_sender_key;

--- a/src/core/SQL/SQLite/insert_sender.sql
+++ b/src/core/SQL/SQLite/insert_sender.sql
@@ -1,2 +1,2 @@
-INSERT INTO sender (sender)
-VALUES (:sender)
+INSERT INTO sender (sender, realname, avatarurl)
+VALUES (:sender, :realname, :avatarurl)

--- a/src/core/SQL/SQLite/migrate_read_sender.sql
+++ b/src/core/SQL/SQLite/migrate_read_sender.sql
@@ -1,5 +1,4 @@
-SELECT senderid, sender
+SELECT senderid, sender, realname, avatarurl
 FROM sender
 WHERE senderid > ? AND senderid <= ?
 ORDER BY senderid ASC
-

--- a/src/core/SQL/SQLite/select_messagesAll.sql
+++ b/src/core/SQL/SQLite/select_messagesAll.sql
@@ -1,4 +1,4 @@
-SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)

--- a/src/core/SQL/SQLite/select_messagesAllNew.sql
+++ b/src/core/SQL/SQLite/select_messagesAllNew.sql
@@ -1,4 +1,4 @@
-SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)

--- a/src/core/SQL/SQLite/select_messagesNewerThan.sql
+++ b/src/core/SQL/SQLite/select_messagesNewerThan.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= :firstmsg

--- a/src/core/SQL/SQLite/select_messagesNewestK.sql
+++ b/src/core/SQL/SQLite/select_messagesNewestK.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE bufferid = :bufferid

--- a/src/core/SQL/SQLite/select_messagesRange.sql
+++ b/src/core/SQL/SQLite/select_messagesRange.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE bufferid = :bufferid

--- a/src/core/SQL/SQLite/setup_010_sender.sql
+++ b/src/core/SQL/SQLite/setup_010_sender.sql
@@ -1,6 +1,6 @@
 CREATE TABLE sender ( -- THE SENDER OF IRC MESSAGES
        senderid INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-       sender TEXT UNIQUE NOT NULL
-)
-
-	  
+       sender TEXT NOT NULL,
+       realname TEXT,
+       avatarurl TEXT
+);

--- a/src/core/SQL/SQLite/setup_150_sender_idx.sql
+++ b/src/core/SQL/SQLite/setup_150_sender_idx.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX sender_index ON sender(sender, realname, avatarurl);

--- a/src/core/SQL/SQLite/version/27/upgrade_000_create_sender_tmp.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_000_create_sender_tmp.sql
@@ -1,0 +1,1 @@
+CREATE TABLE sender_tmp (senderid INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, sender TEXT NOT NULL, realname TEXT, avatarurl TEXT);

--- a/src/core/SQL/SQLite/version/27/upgrade_010_copy_sender_sender_tmp.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_010_copy_sender_sender_tmp.sql
@@ -1,0 +1,1 @@
+INSERT INTO sender_tmp SELECT senderid, sender, NULL as realname, NULL as avatarurl FROM sender;

--- a/src/core/SQL/SQLite/version/27/upgrade_020_drop_sender.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_020_drop_sender.sql
@@ -1,0 +1,1 @@
+DROP TABLE sender;

--- a/src/core/SQL/SQLite/version/27/upgrade_030_rename_sender_tmp_sender.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_030_rename_sender_tmp_sender.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sender_tmp RENAME TO sender;

--- a/src/core/SQL/SQLite/version/27/upgrade_040_update_sender_add_realname_avatarurl.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_040_update_sender_add_realname_avatarurl.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX sender_index ON sender(sender, realname, avatarurl);

--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -584,3 +584,13 @@ bool AbstractSqlMigrationReader::transferMo(MigrationObject moType, T &mo)
     qDebug() << "Done.";
     return true;
 }
+
+uint qHash(const SenderData &key) {
+    return qHash(QString(key.sender + "\n" + key.realname + "\n" + key.avatarurl));
+}
+
+bool operator==(const SenderData &a, const SenderData &b) {
+    return a.sender == b.sender &&
+        a.realname == b.realname &&
+        a.avatarurl == b.avatarurl;
+}

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -118,6 +118,14 @@ private:
     QHash<QThread *, Connection *> _connectionPool;
 };
 
+struct SenderData {
+    QString sender;
+    QString realname;
+    QString avatarurl;
+
+    friend uint qHash(const SenderData &key);
+    friend bool operator==(const SenderData &a, const SenderData &b);
+};
 
 // ========================================
 //  AbstractSqlStorage::Connection
@@ -155,6 +163,8 @@ public:
     struct SenderMO {
         int senderId;
         QString sender;
+        QString realname;
+        QString avatarurl;
         SenderMO() : senderId(0) {}
     };
 

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -374,8 +374,9 @@ void CoreSession::processMessages()
             Q_ASSERT(!createBuffer);
             bufferInfo = Core::bufferInfo(user(), rawMsg.networkId, BufferInfo::StatusBuffer, "");
         }
-        Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender,
-                    senderPrefixes(rawMsg.sender, bufferInfo), rawMsg.flags);
+        Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender, senderPrefixes(rawMsg.sender, bufferInfo),
+                    realName(rawMsg.sender, rawMsg.networkId),  avatarUrl(rawMsg.sender, rawMsg.networkId),
+                    rawMsg.flags);
         if(Core::storeMessage(msg))
             emit displayMsg(msg);
     }
@@ -399,8 +400,9 @@ void CoreSession::processMessages()
                 }
                 bufferInfoCache[rawMsg.networkId][rawMsg.target] = bufferInfo;
             }
-            Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender,
-                        senderPrefixes(rawMsg.sender, bufferInfo), rawMsg.flags);
+            Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender, senderPrefixes(rawMsg.sender, bufferInfo),
+                        realName(rawMsg.sender, rawMsg.networkId),  avatarUrl(rawMsg.sender, rawMsg.networkId),
+                        rawMsg.flags);
             messages << msg;
         }
 
@@ -416,8 +418,9 @@ void CoreSession::processMessages()
                 // add the StatusBuffer to the Cache in case there are more Messages for the original target
                 bufferInfoCache[rawMsg.networkId][rawMsg.target] = bufferInfo;
             }
-            Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender,
-                        senderPrefixes(rawMsg.sender, bufferInfo), rawMsg.flags);
+            Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender, senderPrefixes(rawMsg.sender, bufferInfo),
+                        realName(rawMsg.sender, rawMsg.networkId),  avatarUrl(rawMsg.sender, rawMsg.networkId),
+                        rawMsg.flags);
             messages << msg;
         }
 
@@ -450,6 +453,27 @@ QString CoreSession::senderPrefixes(const QString &sender, const BufferInfo &buf
 
     const QString modes = currentChannel->userModes(nickFromMask(sender).toLower());
     return currentNetwork->modesToPrefixes(modes);
+}
+
+QString CoreSession::realName(const QString &sender, NetworkId networkId) const
+{
+    CoreNetwork *currentNetwork = network(networkId);
+    if (!currentNetwork) {
+        return {};
+    }
+
+    IrcUser *currentUser = currentNetwork->ircUser(nickFromMask(sender));
+    if (!currentUser) {
+        return {};
+    }
+
+    return currentUser->realName();
+}
+
+QString CoreSession::avatarUrl(const QString &sender, NetworkId networkId) const
+{
+    // Currently we do not have a way to retrieve this value yet.
+    return "";
 }
 
 Protocol::SessionState CoreSession::sessionState() const

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -237,6 +237,20 @@ private:
      * @param bufferInfo The BufferInfo object of the buffer
      */
     QString senderPrefixes(const QString &sender, const BufferInfo &bufferInfo) const;
+
+    /**
+     * This method obtains the realname of the message's sender.
+     * @param sender The hostmask of the sender
+     * @param networkId The network the user is on
+     */
+    QString realName(const QString &sender, NetworkId networkId) const;
+
+    /**
+     * This method obtains the avatar of the message's sender.
+     * @param sender The hostmask of the sender
+     * @param networkId The network the user is on
+     */
+    QString avatarUrl(const QString &sender, NetworkId networkId) const;
     QList<RawMessage> _messageQueue;
     bool _processMessages;
     CoreIgnoreListManager _ignoreListManager;

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1449,7 +1449,11 @@ bool PostgreSqlStorage::logMessage(Message &msg)
         return false;
     }
 
-    QSqlQuery getSenderIdQuery = executePreparedQuery("select_senderid", msg.sender(), db);
+    QVariantList senderParams;
+    senderParams << msg.sender()
+                 << msg.realName()
+                 << msg.avatarUrl();
+    QSqlQuery getSenderIdQuery = executePreparedQuery("select_senderid", senderParams, db);
     int senderId;
     if (getSenderIdQuery.first()) {
         senderId = getSenderIdQuery.value(0).toInt();
@@ -1458,11 +1462,11 @@ bool PostgreSqlStorage::logMessage(Message &msg)
         // it's possible that the sender was already added by another thread
         // since the insert might fail we're setting a savepoint
         savePoint("sender_sp1", db);
-        QSqlQuery addSenderQuery = executePreparedQuery("insert_sender", msg.sender(), db);
+        QSqlQuery addSenderQuery = executePreparedQuery("insert_sender", senderParams, db);
 
         if (addSenderQuery.lastError().isValid()) {
             rollbackSavePoint("sender_sp1", db);
-            getSenderIdQuery = executePreparedQuery("select_senderid", msg.sender(), db);
+            getSenderIdQuery = executePreparedQuery("select_senderid", senderParams, db);
             watchQuery(getSenderIdQuery);
             getSenderIdQuery.first();
             senderId = getSenderIdQuery.value(0).toInt();
@@ -1512,28 +1516,34 @@ bool PostgreSqlStorage::logMessages(MessageList &msgs)
     }
 
     QList<int> senderIdList;
-    QHash<QString, int> senderIds;
+    QHash<SenderData, int> senderIds;
     QSqlQuery addSenderQuery;
     QSqlQuery selectSenderQuery;;
     for (int i = 0; i < msgs.count(); i++) {
-        const QString &sender = msgs.at(i).sender();
+        auto &msg = msgs.at(i);
+        SenderData sender = { msg.sender(), msg.realName(), msg.avatarUrl() };
         if (senderIds.contains(sender)) {
             senderIdList << senderIds[sender];
             continue;
         }
 
-        selectSenderQuery = executePreparedQuery("select_senderid", sender, db);
+        QVariantList senderParams;
+        senderParams << sender.sender
+                     << sender.realname
+                     << sender.avatarurl;
+
+        selectSenderQuery = executePreparedQuery("select_senderid", senderParams, db);
         if (selectSenderQuery.first()) {
             senderIdList << selectSenderQuery.value(0).toInt();
             senderIds[sender] = selectSenderQuery.value(0).toInt();
         }
         else {
             savePoint("sender_sp", db);
-            addSenderQuery = executePreparedQuery("insert_sender", sender, db);
+            addSenderQuery = executePreparedQuery("insert_sender", senderParams, db);
             if (addSenderQuery.lastError().isValid()) {
                 // seems it was inserted meanwhile... by a different thread
                 rollbackSavePoint("sender_sp", db);
-                selectSenderQuery = executePreparedQuery("select_senderid", sender, db);
+                selectSenderQuery = executePreparedQuery("select_senderid", senderParams, db);
                 watchQuery(selectSenderQuery);
                 selectSenderQuery.first();
                 senderIdList << selectSenderQuery.value(0).toInt();
@@ -1637,9 +1647,11 @@ QList<Message> PostgreSqlStorage::requestMsgs(UserId user, BufferId bufferId, Ms
         Message msg(timestamp,
             bufferInfo,
             (Message::Type)query.value(2).toUInt(),
-            query.value(6).toString(),
+            query.value(8).toString(),
             query.value(4).toString(),
             query.value(5).toString(),
+            query.value(6).toString(),
+            query.value(7).toString(),
             (Message::Flags)query.value(3).toUInt());
         msg.setMsgId(query.value(0).toInt());
         messagelist << msg;
@@ -1690,9 +1702,11 @@ QList<Message> PostgreSqlStorage::requestAllMsgs(UserId user, MsgId first, MsgId
         Message msg(timestamp,
             bufferInfoHash[query.value(1).toInt()],
             (Message::Type)query.value(3).toUInt(),
-            query.value(7).toString(),
+            query.value(9).toString(),
             query.value(5).toString(),
             query.value(6).toString(),
+            query.value(7).toString(),
+            query.value(8).toString(),
             (Message::Flags)query.value(4).toUInt());
         msg.setMsgId(query.value(0).toInt());
         messagelist << msg;
@@ -1937,6 +1951,8 @@ bool PostgreSqlMigrationWriter::writeMo(const SenderMO &sender)
 {
     bindValue(0, sender.senderId);
     bindValue(1, sender.sender);
+    bindValue(2, sender.realname);
+    bindValue(3, sender.avatarurl);
     return exec();
 }
 

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -76,6 +76,7 @@
     <file>./SQL/PostgreSQL/setup_110_alter_sender_seq.sql</file>
     <file>./SQL/PostgreSQL/setup_120_alter_messageid_seq.sql</file>
     <file>./SQL/PostgreSQL/setup_130_function_lastmsgid.sql</file>
+    <file>./SQL/PostgreSQL/setup_140_sender_idx.sql</file>
     <file>./SQL/PostgreSQL/update_backlog_bufferid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_bufferactivity.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_lastseen.sql</file>
@@ -109,6 +110,10 @@
     <file>./SQL/PostgreSQL/version/22/upgrade_000_alter_quasseluser_add_authenticator.sql</file>
     <file>./SQL/PostgreSQL/version/23/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/PostgreSQL/version/24/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_000_update_sender_add_realname.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_010_update_sender_add_avatarurl.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_020_update_sender_add_new_constraint.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_030_upgrade_sender_drop_old_constraint.sql</file>
     <file>./SQL/SQLite/delete_backlog_by_uid.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_buffer.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_network.sql</file>
@@ -187,6 +192,7 @@
     <file>./SQL/SQLite/setup_120_user_setting.sql</file>
     <file>./SQL/SQLite/setup_130_identity.sql</file>
     <file>./SQL/SQLite/setup_140_identity_nick.sql</file>
+    <file>./SQL/SQLite/setup_150_sender_idx.sql</file>
     <file>./SQL/SQLite/update_backlog_bufferid.sql</file>
     <file>./SQL/SQLite/update_buffer_bufferactivity.sql</file>
     <file>./SQL/SQLite/update_buffer_lastseen.sql</file>
@@ -293,5 +299,10 @@
     <file>./SQL/SQLite/version/24/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/SQLite/version/25/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
     <file>./SQL/SQLite/version/26/upgrade_000_create_buffer_idx.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_000_create_sender_tmp.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_010_copy_sender_sender_tmp.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_020_drop_sender.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_030_rename_sender_tmp_sender.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_040_update_sender_add_realname_avatarurl.sql</file>
 </qresource>
 </RCC>

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1603,6 +1603,8 @@ bool SqliteStorage::logMessage(Message &msg)
                 QSqlQuery addSenderQuery(db);
                 addSenderQuery.prepare(queryString("insert_sender"));
                 addSenderQuery.bindValue(":sender", msg.sender());
+                addSenderQuery.bindValue(":realname", msg.realName());
+                addSenderQuery.bindValue(":avatarurl", msg.avatarUrl());
                 safeExec(addSenderQuery);
                 safeExec(logMessageQuery);
                 error = !watchQuery(logMessageQuery);
@@ -1640,17 +1642,20 @@ bool SqliteStorage::logMessages(MessageList &msgs)
     db.transaction();
 
     {
-        QSet<QString> senders;
+        QSet<SenderData> senders;
         QSqlQuery addSenderQuery(db);
         addSenderQuery.prepare(queryString("insert_sender"));
         lockForWrite();
         for (int i = 0; i < msgs.count(); i++) {
-            const QString &sender = msgs.at(i).sender();
+            auto &msg = msgs.at(i);
+            SenderData sender = { msg.sender(), msg.realName(), msg.avatarUrl() };
             if (senders.contains(sender))
                 continue;
             senders << sender;
 
-            addSenderQuery.bindValue(":sender", sender);
+            addSenderQuery.bindValue(":sender", sender.sender);
+            addSenderQuery.bindValue(":realname", sender.realname);
+            addSenderQuery.bindValue(":avatarurl", sender.avatarurl);
             safeExec(addSenderQuery);
         }
     }
@@ -1752,9 +1757,11 @@ QList<Message> SqliteStorage::requestMsgs(UserId user, BufferId bufferId, MsgId 
             Message msg(QDateTime::fromTime_t(query.value(1).toInt()),
                 bufferInfo,
                 (Message::Type)query.value(2).toUInt(),
-                query.value(6).toString(),
+                query.value(8).toString(),
                 query.value(4).toString(),
                 query.value(5).toString(),
+                query.value(6).toString(),
+                query.value(7).toString(),
                 (Message::Flags)query.value(3).toUInt());
             msg.setMsgId(query.value(0).toInt());
             messagelist << msg;
@@ -1807,9 +1814,11 @@ QList<Message> SqliteStorage::requestAllMsgs(UserId user, MsgId first, MsgId las
             Message msg(QDateTime::fromTime_t(query.value(2).toInt()),
                 bufferInfoHash[query.value(1).toInt()],
                 (Message::Type)query.value(3).toUInt(),
-                query.value(7).toString(),
+                query.value(9).toString(),
                 query.value(5).toString(),
                 query.value(6).toString(),
+                query.value(7).toString(),
+                query.value(8).toString(),
                 (Message::Flags)query.value(4).toUInt());
             msg.setMsgId(query.value(0).toInt());
             messagelist << msg;


### PR DESCRIPTION
## In short
- Store avatar URL (currently just "", as we don’t implement METADATA yet) for each sender in database
- Store realname for each sender in database
- Add feature RichMessages to control serialization of these
- Transmit them over the network to clients in messages

### Impact
| Criteria | Rank | Reason |
| - | - | - |
| Impact | *★☆☆&nbsp;1/3* | No user-facing changes, only visible to users in third-party clients |
| Risk | *★★★&nbsp;2/3* | Has to recreate, migrate, and drop the entire senders table |
| Intrusiveness | *★☆☆&nbsp;1/3* | No breaking core changes, interference with other PRs limited to Quassel::Features allocation and sql.qrc |

## Rationale
To show the realname on clients, as well as the user avatar, we need to store these with messages. These features are available in Slack, Discord and IRCCloud, and we’d like to provide them as well.

## Examples
[![Screenshot showing realnames and avatars in action](https://i.k8r.eu/cxqY2Q)](https://i.k8r.eu/cxqY2Q)  
In this screenshot, Quasseldroid-NNG uses the e-mail in the realname to show a fallback avatar (through Gravatar, this feature is optional).

**To be done in the future:**
* Add quasselclient UI to use these features
* Add actual avatar URL functionality with IRCv3 METADATA