### PR TITLE
Fixes support for extended features on Qt4

### DIFF
--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -111,7 +111,11 @@ public:
      *
      * This list should be cleaned up after every protocol break, as we can assume them to be present then.
      */
-    enum class Feature : quint32 {
+    #if QT_VERSION >= 0x050000
+    enum class Feature : uint32_t {
+    #else
+    enum Feature {
+    #endif
         SynchronizedMarkerLine,
         SaslAuthentication,
         SaslExternal,


### PR DESCRIPTION
## In short
- On Qt4, Q_ENUMS can *not* handle enum class, but only enum
- This patch adds an #ifdef to only use enum class on Qt5