### PR TITLE
Fixes the Highlight Rule Manager

### DIFF
--- a/src/common/highlightrulemanager.h
+++ b/src/common/highlightrulemanager.h
@@ -129,11 +129,11 @@ public slots:
     virtual void addHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive, bool isEnabled,
                                   bool isInverse, const QString &sender, const QString &chanName);
 
-    virtual inline void requestSetHighlightNick(HighlightNickType highlightNick)
+    virtual inline void requestSetHighlightNick(int highlightNick)
     {
         REQUEST(ARG(highlightNick))
     }
-    inline void setHighlightNick(HighlightNickType highlightNick) { _highlightNick = highlightNick; }
+    inline void setHighlightNick(int highlightNick) { _highlightNick = static_cast<HighlightNickType>(highlightNick); }
 
     virtual inline void requestSetNicksCaseSensitive(bool nicksCaseSensitive)
     {


### PR DESCRIPTION
## In Short
- Previously, sync calls included the new HighlightNickType
- This causes deserialization trouble in older clients
- Now int is used, and the data is static_cast'd back and forth

## Impact
This breaks compatibility with 0.13 clients and cores from the past months, and restores compatibility with 0.12.4 or older clients.