### PR TITLE
cmake: Fix build with Qt 5.11

### DIFF
--- a/cmake/QuasselMacros.cmake
+++ b/cmake/QuasselMacros.cmake
@@ -5,6 +5,9 @@
 # The qt4_use_modules function was taken from CMake's Qt4Macros.cmake:
 # (C) 2005-2009 Kitware, Inc.
 #
+# The qt5_use_modules function was taken from Qt 5.10.1 (and modified):
+# (C) 2005-2011 Kitware, Inc.
+#
 # Redistribution and use is allowed according to the terms of the BSD license.
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
@@ -40,6 +43,41 @@ function(qt4_use_modules _target _link_type)
         target_link_libraries(${_target} ${link_type} ${${_targetPrefix}_LIBRARIES})
         set_property(TARGET ${_target} APPEND PROPERTY INCLUDE_DIRECTORIES ${${_targetPrefix}_INCLUDE_DIR} ${QT_HEADERS_DIR} ${QT_MKSPECS_DIR}/default)
         set_property(TARGET ${_target} APPEND PROPERTY COMPILE_DEFINITIONS ${${_targetPrefix}_COMPILE_DEFINITIONS})
+    endforeach()
+endfunction()
+
+# Qt 5.11 removed the qt5_use_modules function, so we need to provide it until we can switch to a modern CMake version.
+# If present, the Qt-provided version will be used automatically instead.
+function(qt5_use_modules _target _link_type)
+    if (NOT TARGET ${_target})
+        message(FATAL_ERROR "The first argument to qt5_use_modules must be an existing target.")
+    endif()
+    if ("${_link_type}" STREQUAL "LINK_PUBLIC" OR "${_link_type}" STREQUAL "LINK_PRIVATE" )
+        set(_qt5_modules ${ARGN})
+        set(_qt5_link_type ${_link_type})
+    else()
+        set(_qt5_modules ${_link_type} ${ARGN})
+    endif()
+
+    if ("${_qt5_modules}" STREQUAL "")
+        message(FATAL_ERROR "qt5_use_modules requires at least one Qt module to use.")
+    endif()
+    foreach(_module ${_qt5_modules})
+        if (NOT Qt5${_module}_FOUND)
+            find_package(Qt5${_module} PATHS "${_Qt5_COMPONENT_PATH}" NO_DEFAULT_PATH)
+            if (NOT Qt5${_module}_FOUND)
+                message(FATAL_ERROR "Can not use \"${_module}\" module which has not yet been found.")
+            endif()
+        endif()
+        target_link_libraries(${_target} ${_qt5_link_type} ${Qt5${_module}_LIBRARIES})
+        set_property(TARGET ${_target} APPEND PROPERTY INCLUDE_DIRECTORIES ${Qt5${_module}_INCLUDE_DIRS})
+        set_property(TARGET ${_target} APPEND PROPERTY COMPILE_DEFINITIONS ${Qt5${_module}_COMPILE_DEFINITIONS})
+        if (Qt5_POSITION_INDEPENDENT_CODE
+                AND (CMAKE_VERSION VERSION_LESS 2.8.12
+                    AND (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+                    OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)))
+            set_property(TARGET ${_target} PROPERTY POSITION_INDEPENDENT_CODE ${Qt5_POSITION_INDEPENDENT_CODE})
+        endif()
     endforeach()
 endfunction()
 


### PR DESCRIPTION
Qt 5.11 removes the qt5_use_modules function, so add a copy. If
present, the Qt-provided function will be used instead.