### PR TITLE
Initial draft of integrated ident daemon

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -169,7 +169,9 @@ int main(int argc, char **argv)
     cliParser->addOption("change-userpass", 0, "Starts an interactive session to change the password of the user identified by <username>", "username");
     cliParser->addSwitch("oidentd", 0, "Enable oidentd integration");
     cliParser->addOption("oidentd-conffile", 0, "Set path to oidentd configuration file", "file");
-    cliParser->addSwitch("oidentd-strict", 0, "Use users' quasselcore username as ident reply. Ignores each user's configured ident setting. Only meaningful with --oidentd.");
+    cliParser->addSwitch("oidentd-strict", 0, "Use users' quasselcore username as ident reply. Ignores each user's configured ident setting. Only meaningful with --oidentd or --ident-daemon.");
+    cliParser->addSwitch("ident-daemon", 0, "Enable internal ident daemon");
+    cliParser->addOption("ident-port", 'p', "The port quasselcore will listen at for ident requests. Only meaningful with --ident-daemon", "port", "10113");
 #ifdef HAVE_SSL
     cliParser->addSwitch("require-ssl", 0, "Require SSL for remote (non-loopback) client connections");
     cliParser->addOption("ssl-cert", 0, "Specify the path to the SSL Certificate", "path", "configdir/quasselCert.pem");

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SOURCES
     coreusersettings.cpp
     ctcpparser.cpp
     eventstringifier.cpp
+    identserver.cpp
     ircparser.cpp
     netsplit.cpp
     oidentdconfiggenerator.cpp
@@ -41,8 +42,7 @@ set(SOURCES
     storage.cpp
 
     # needed for automoc
-    coreeventmanager.h
-)
+    coreeventmanager.h)
 
 set(LIBS )
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -44,6 +44,7 @@
 #include "sessionthread.h"
 #include "storage.h"
 #include "types.h"
+#include "identserver.h"
 
 class CoreAuthHandler;
 class CoreSession;
@@ -600,6 +601,7 @@ public:
     static inline QTimer &syncTimer() { return instance()->_storageSyncTimer; }
 
     inline OidentdConfigGenerator *oidentdConfigGenerator() const { return _oidentdConfigGenerator; }
+    inline IdentServer *identServer() const { return _identServer; }
 
     static const int AddClientEventId;
 
@@ -689,6 +691,8 @@ private:
     std::vector<DeferredSharedPtr<Authenticator>> _registeredAuthenticators;
 
     QDateTime _startTime;
+
+    IdentServer *_identServer {nullptr};
 
     bool _configured;
 

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -101,6 +101,11 @@ CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
         connect(this, SIGNAL(socketInitialized(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(addSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Qt::BlockingQueuedConnection);
         connect(this, SIGNAL(socketDisconnected(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(removeSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)));
     }
+
+    if (Quassel::isOptionSet("ident-daemon")) {
+        connect(this, SIGNAL(socketInitialized(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->identServer(), SLOT(addSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Qt::BlockingQueuedConnection);
+        connect(this, SIGNAL(socketDisconnected(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->identServer(), SLOT(removeSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)));
+    }
 }
 
 

--- a/src/core/identserver.cpp
+++ b/src/core/identserver.cpp
@@ -1,0 +1,146 @@
+#include <logger.h>
+
+#include "corenetwork.h"
+#include "identserver.h"
+
+IdentServer::IdentServer(bool strict, QObject *parent) : QObject(parent), _strict(strict) {
+    connect(&_server, SIGNAL(newConnection()), this, SLOT(incomingConnection()));
+    connect(&_v6server, SIGNAL(newConnection()), this, SLOT(incomingConnection()));
+}
+
+IdentServer::~IdentServer() = default;
+
+bool IdentServer::startListening() {
+    uint16_t port = 10113;
+
+    bool success = false;
+    if (_v6server.listen(QHostAddress("::1"), port)) {
+        quInfo() << qPrintable(
+                tr("Listening for identd clients on IPv6 %1 port %2")
+                        .arg("::1")
+                        .arg(_v6server.serverPort())
+        );
+
+        success = true;
+    }
+
+    if (_server.listen(QHostAddress("127.0.0.1"), port)) {
+        success = true;
+
+        quInfo() << qPrintable(
+                tr("Listening for identd clients on IPv4 %1 port %2")
+                        .arg("127.0.0.1")
+                        .arg(_server.serverPort())
+        );
+    }
+
+    if (!success) {
+        quError() << qPrintable(
+                tr("Identd could not open any network interfaces to listen on! No identd functionality will be available"));
+    }
+
+    return success;
+}
+
+void IdentServer::stopListening(const QString &msg) {
+    bool wasListening = false;
+    if (_server.isListening()) {
+        wasListening = true;
+        _server.close();
+    }
+    if (_v6server.isListening()) {
+        wasListening = true;
+        _v6server.close();
+    }
+    if (wasListening) {
+        if (msg.isEmpty())
+            quInfo() << "No longer listening for identd clients.";
+        else
+            quInfo() << qPrintable(msg);
+    }
+}
+
+void IdentServer::incomingConnection() {
+    auto *server = qobject_cast<QTcpServer *>(sender());
+    Q_ASSERT(server);
+    while (server->hasPendingConnections()) {
+        QTcpSocket *socket = server->nextPendingConnection();
+        connect(socket, SIGNAL(readyRead()), this, SLOT(respond()));
+    }
+}
+
+void IdentServer::respond() {
+    auto *socket = qobject_cast<QTcpSocket *>(sender());
+    Q_ASSERT(socket);
+
+    if (socket->canReadLine()) {
+        QByteArray s = socket->readLine();
+        if (s.endsWith("\r\n"))
+            s.chop(2);
+        else if (s.endsWith("\n"))
+            s.chop(1);
+
+        QList<QByteArray> split = s.split(',');
+
+        bool success = false;
+
+        uint16_t localPort;
+        if (!split.empty()) {
+            localPort = split[0].toUShort(&success, 10);
+        }
+
+        QString user;
+        if (success) {
+            if (_connections.contains(localPort)) {
+                user = _connections[localPort];
+            } else {
+                success = false;
+            }
+        }
+
+        QString data;
+        if (success) {
+            data += s + " : USERID : Quassel : " + user + "\r\n";
+        } else {
+            data += s + " : ERROR : NO-USER\r\n";
+        }
+
+        socket->write(data.toUtf8());
+        socket->flush();
+        socket->close();
+        socket->deleteLater();
+    }
+}
+
+QString IdentServer::sysIdentForIdentity(const CoreIdentity *identity) const {
+    if (!_strict) {
+        return identity->ident();
+    }
+    const CoreNetwork *network = qobject_cast<CoreNetwork *>(sender());
+    return network->coreSession()->strictSysident();
+}
+
+
+bool IdentServer::addSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort,
+                            const QHostAddress &peerAddress, quint16 peerPort) {
+    Q_UNUSED(localAddress)
+    Q_UNUSED(peerAddress)
+    Q_UNUSED(peerPort)
+
+    const QString ident = sysIdentForIdentity(identity);
+    _connections[localPort] = ident;
+    return true;
+}
+
+
+//! not yet implemented
+bool IdentServer::removeSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort,
+                               const QHostAddress &peerAddress, quint16 peerPort) {
+    Q_UNUSED(identity)
+    Q_UNUSED(localAddress)
+    Q_UNUSED(peerAddress)
+    Q_UNUSED(peerPort)
+
+    _connections.remove(localPort);
+    return true;
+}

--- a/src/core/identserver.h
+++ b/src/core/identserver.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <QTcpServer>
+#include <QTcpSocket>
+
+#include "coreidentity.h"
+
+class IdentServer : public QObject {
+Q_OBJECT
+public:
+    IdentServer(bool strict, QObject *parent);
+    ~IdentServer();
+
+    bool startListening();
+    void stopListening(const QString &msg);
+public slots:
+    bool addSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
+    bool removeSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
+
+private slots:
+    void incomingConnection();
+
+    void respond();
+
+private:
+    QString sysIdentForIdentity(const CoreIdentity *identity) const;
+
+    QTcpServer _server, _v6server;
+
+    bool _strict;
+
+    QHash<uint16_t, QString> _connections;
+};


### PR DESCRIPTION
## In Short
* Implements an integrated daemon for identd which listens on localhost on a configurable port
* Adds --ident-daemon and --ident-port config flags

## Rationale
The current oidentd integration is prone to race conditions, especially with many users. This solution should work much more reliable in the long term.