### PR TITLE
[Rollup] common: Master of database/protocol PRs

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -394,6 +394,7 @@ void Client::setSyncedToCore()
     connect(bufferSyncer(), SIGNAL(buffersPermanentlyMerged(BufferId, BufferId)), _messageModel, SLOT(buffersPermanentlyMerged(BufferId, BufferId)));
     connect(bufferSyncer(), SIGNAL(bufferMarkedAsRead(BufferId)), SIGNAL(bufferMarkedAsRead(BufferId)));
     connect(bufferSyncer(), SIGNAL(bufferActivityChanged(BufferId, const Message::Types)), _networkModel, SLOT(bufferActivityChanged(BufferId, const Message::Types)));
+    connect(bufferSyncer(), SIGNAL(highlightCountChanged(BufferId, int)), _networkModel, SLOT(highlightCountChanged(BufferId, int)));
     connect(networkModel(), SIGNAL(requestSetLastSeenMsg(BufferId, MsgId)), bufferSyncer(), SLOT(requestSetLastSeenMsg(BufferId, const MsgId &)));
 
     SignalProxy *p = signalProxy();
@@ -460,8 +461,10 @@ void Client::finishConnectionInitialization()
     disconnect(bufferSyncer(), SIGNAL(initDone()), this, SLOT(finishConnectionInitialization()));
 
     requestInitialBacklog();
-    if (isCoreFeatureEnabled(Quassel::Feature::BufferActivitySync))
+    if (isCoreFeatureEnabled(Quassel::Feature::BufferActivitySync)) {
         bufferSyncer()->markActivitiesChanged();
+        bufferSyncer()->markHighlightCountsChanged();
+    }
 }
 
 

--- a/src/client/messagefilter.cpp
+++ b/src/client/messagefilter.cpp
@@ -221,7 +221,8 @@ bool MessageFilter::filterAcceptsRow(int sourceRow, const QModelIndex &sourcePar
         if (myNetworkId != msgNetworkId)
             return false;
 
-        uint messageTimestamp = sourceModel()->data(sourceIdx, MessageModel::TimestampRole).value<QDateTime>().toTime_t();
+        qint64 messageTimestamp = sourceModel()->data(sourceIdx, MessageModel::TimestampRole)
+                .value<QDateTime>().toMSecsSinceEpoch();
         QString quiter = sourceModel()->data(sourceIdx, Qt::DisplayRole).toString().section(' ', 0, 0, QString::SectionSkipEmpty).toLower();
         if (quiter != bufferName().toLower())
             return false;

--- a/src/client/messagefilter.h
+++ b/src/client/messagefilter.h
@@ -62,7 +62,7 @@ private:
     void init();
 
     QSet<BufferId> _validBuffers;
-    QMultiHash<QString, uint> _filteredQuitMsgs;
+    QMultiHash<QString, qint64> _filteredQuitMsgs;
     int _messageTypeFilter;
 
     int _userNoticesTarget;

--- a/src/client/messagemodel.cpp
+++ b/src/client/messagemodel.cpp
@@ -41,7 +41,8 @@ MessageModel::MessageModel(QObject *parent)
     QDateTime now = QDateTime::currentDateTime();
     now.setTimeSpec(Qt::UTC);
     _nextDayChange.setTimeSpec(Qt::UTC);
-    _nextDayChange.setTime_t(((now.toTime_t() / 86400) + 1) * 86400);
+    _nextDayChange.setMSecsSinceEpoch(
+                ((now.toMSecsSinceEpoch() / DAY_IN_MSECS) + 1) * DAY_IN_MSECS);
     _nextDayChange.setTimeSpec(Qt::LocalTime);
     _dayChangeTimer.setInterval(QDateTime::currentDateTime().secsTo(_nextDayChange) * 1000);
     _dayChangeTimer.start();
@@ -158,10 +159,10 @@ void MessageModel::insertMessageGroup(const QList<Message> &msglist)
         QDateTime prevTs = msglist.last().timestamp();
         nextTs.setTimeSpec(Qt::UTC);
         prevTs.setTimeSpec(Qt::UTC);
-        uint nextDay = nextTs.toTime_t() / 86400;
-        uint prevDay = prevTs.toTime_t() / 86400;
+        qint64 nextDay = nextTs.toMSecsSinceEpoch() / DAY_IN_MSECS;
+        qint64 prevDay = prevTs.toMSecsSinceEpoch() / DAY_IN_MSECS;
         if (nextDay != prevDay) {
-            nextTs.setTime_t(nextDay * 86400);
+            nextTs.setMSecsSinceEpoch(nextDay * DAY_IN_MSECS);
             nextTs.setTimeSpec(Qt::LocalTime);
             dayChangeMsg = Message::ChangeOfDay(nextTs);
             dayChangeMsg.setMsgId(msglist.last().msgId());
@@ -250,10 +251,10 @@ int MessageModel::insertMessagesGracefully(const QList<Message> &msglist)
                     QDateTime prevTs = (*iter).timestamp();
                     nextTs.setTimeSpec(Qt::UTC);
                     prevTs.setTimeSpec(Qt::UTC);
-                    uint nextDay = nextTs.toTime_t() / 86400;
-                    uint prevDay = prevTs.toTime_t() / 86400;
+                    qint64 nextDay = nextTs.toMSecsSinceEpoch() / DAY_IN_MSECS;
+                    qint64 prevDay = prevTs.toMSecsSinceEpoch() / DAY_IN_MSECS;
                     if (nextDay != prevDay) {
-                        nextTs.setTime_t(nextDay * 86400);
+                        nextTs.setMSecsSinceEpoch(nextDay * DAY_IN_MSECS);
                         nextTs.setTimeSpec(Qt::LocalTime);
                         Message dayChangeMsg = Message::ChangeOfDay(nextTs);
                         dayChangeMsg.setMsgId((*iter).msgId());
@@ -282,10 +283,10 @@ int MessageModel::insertMessagesGracefully(const QList<Message> &msglist)
                     QDateTime prevTs = (*iter).timestamp();
                     nextTs.setTimeSpec(Qt::UTC);
                     prevTs.setTimeSpec(Qt::UTC);
-                    uint nextDay = nextTs.toTime_t() / 86400;
-                    uint prevDay = prevTs.toTime_t() / 86400;
+                    qint64 nextDay = nextTs.toMSecsSinceEpoch() / DAY_IN_MSECS;
+                    qint64 prevDay = prevTs.toMSecsSinceEpoch() / DAY_IN_MSECS;
                     if (nextDay != prevDay) {
-                        nextTs.setTime_t(nextDay * 86400);
+                        nextTs.setMSecsSinceEpoch(nextDay * DAY_IN_MSECS);
                         nextTs.setTimeSpec(Qt::LocalTime);
                         Message dayChangeMsg = Message::ChangeOfDay(nextTs);
                         dayChangeMsg.setMsgId((*iter).msgId());
@@ -360,7 +361,7 @@ int MessageModel::indexForId(MsgId id)
 
 void MessageModel::changeOfDay()
 {
-    _dayChangeTimer.setInterval(86400000);
+    _dayChangeTimer.setInterval(DAY_IN_MSECS);
     if (!messagesIsEmpty()) {
         int idx = messageCount();
         while (idx > 0 && messageItemAt(idx - 1)->timestamp() > _nextDayChange) {
@@ -372,7 +373,7 @@ void MessageModel::changeOfDay()
         insertMessage__(idx, dayChangeMsg);
         endInsertRows();
     }
-    _nextDayChange = _nextDayChange.addSecs(86400);
+    _nextDayChange = _nextDayChange.addMSecs(DAY_IN_MSECS);
 }
 
 

--- a/src/client/messagemodel.h
+++ b/src/client/messagemodel.h
@@ -114,6 +114,10 @@ private:
     QTimer _dayChangeTimer;
     QDateTime _nextDayChange;
     QHash<BufferId, int> _messagesWaiting;
+
+    /// Period of time for one day in milliseconds
+    /// 24 hours * 60 minutes * 60 seconds * 1000 milliseconds
+    const qint64 DAY_IN_MSECS = 24 * 60 * 60 * 1000;
 };
 
 

--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -147,8 +147,12 @@ BufferItem *NetworkItem::bufferItem(const BufferInfo &bufferInfo)
     }
 
     BufferSyncer *bufferSyncer = Client::bufferSyncer();
-    if (bufferSyncer)
-        bufferItem->addActivity(bufferSyncer->activity(bufferItem->bufferId()), false);
+    if (bufferSyncer) {
+        bufferItem->addActivity(
+                bufferSyncer->activity(bufferItem->bufferId()),
+                bufferSyncer->highlightCount(bufferItem->bufferId()) > 0
+        );
+    }
 
     return bufferItem;
 }
@@ -1756,4 +1760,13 @@ void NetworkModel::bufferActivityChanged(BufferId bufferId, const Message::Types
     auto visibleTypes = ~hiddenTypes;
     auto activityVisibleTypesIntersection = activity & visibleTypes;
     _bufferItem->setActivity(activityVisibleTypesIntersection, false);
+}
+
+void NetworkModel::highlightCountChanged(BufferId bufferId, int count) {
+    auto _bufferItem = findBufferItem(bufferId);
+    if (!_bufferItem) {
+        qDebug() << "NetworkModel::highlightCountChanged(): buffer is unknown:" << bufferId;
+        return;
+    }
+    _bufferItem->addActivity(Message::Types{}, count > 0);
 }

--- a/src/client/networkmodel.h
+++ b/src/client/networkmodel.h
@@ -386,6 +386,7 @@ public slots:
     void updateBufferActivity(Message &msg);
     void networkRemoved(const NetworkId &networkId);
     void bufferActivityChanged(BufferId, Message::Types);
+    void highlightCountChanged(BufferId, int);
 
 signals:
     void requestSetLastSeenMsg(BufferId buffer, MsgId msg);

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
     syncableobject.cpp
     transfer.cpp
     transfermanager.cpp
+    types.cpp
     util.cpp
 
     serializers/serializers.cpp

--- a/src/common/backlogmanager.cpp
+++ b/src/common/backlogmanager.cpp
@@ -27,9 +27,20 @@ QVariantList BacklogManager::requestBacklog(BufferId bufferId, MsgId first, MsgI
     return QVariantList();
 }
 
+QVariantList BacklogManager::requestBacklogFiltered(BufferId bufferId, MsgId first, MsgId last, int limit, int additional, int type, int flags)
+{
+    REQUEST(ARG(bufferId), ARG(first), ARG(last), ARG(limit), ARG(additional), ARG(type), ARG(flags))
+    return QVariantList();
+}
 
 QVariantList BacklogManager::requestBacklogAll(MsgId first, MsgId last, int limit, int additional)
 {
     REQUEST(ARG(first), ARG(last), ARG(limit), ARG(additional))
+    return QVariantList();
+}
+
+QVariantList BacklogManager::requestBacklogAllFiltered(MsgId first, MsgId last, int limit, int additional, int type, int flags)
+{
+    REQUEST(ARG(first), ARG(last), ARG(limit), ARG(additional), ARG(type), ARG(flags))
     return QVariantList();
 }

--- a/src/common/backlogmanager.h
+++ b/src/common/backlogmanager.h
@@ -35,10 +35,14 @@ public:
 
 public slots:
     virtual QVariantList requestBacklog(BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0);
+    virtual QVariantList requestBacklogFiltered(BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0, int type = -1, int flags = -1);
     inline virtual void receiveBacklog(BufferId, MsgId, MsgId, int, int, QVariantList) {};
+    inline virtual void receiveBacklogFiltered(BufferId, MsgId, MsgId, int, int, int, int, QVariantList) {};
 
     virtual QVariantList requestBacklogAll(MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0);
+    virtual QVariantList requestBacklogAllFiltered(MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0, int type = -1, int flags = -1);
     inline virtual void receiveBacklogAll(MsgId, MsgId, int, int, QVariantList) {};
+    inline virtual void receiveBacklogAllFiltered(MsgId, MsgId, int, int, int, int, QVariantList) {};
 
 signals:
     void backlogRequested(BufferId, MsgId, MsgId, int, int);

--- a/src/common/ircuser.cpp
+++ b/src/common/ircuser.cpp
@@ -40,7 +40,7 @@ IrcUser::IrcUser(const QString &hostmask, Network *network) : SyncableObject(net
     _server(),
     // _idleTime(QDateTime::currentDateTime()),
     _ircOperator(),
-    _lastAwayMessage(0),
+    _lastAwayMessage(),
     _whoisServiceReply(),
     _encrypted(false),
     _network(network),
@@ -48,6 +48,8 @@ IrcUser::IrcUser(const QString &hostmask, Network *network) : SyncableObject(net
     _codecForDecoding(0)
 {
     updateObjectName();
+    _lastAwayMessage.setTimeSpec(Qt::UTC);
+    _lastAwayMessage.setMSecsSinceEpoch(0);
 }
 
 
@@ -215,7 +217,7 @@ void IrcUser::setIrcOperator(const QString &ircOperator)
 }
 
 
-void IrcUser::setLastAwayMessage(const int &lastAwayMessage)
+void IrcUser::setLastAwayMessage(const QDateTime &lastAwayMessage)
 {
     if (lastAwayMessage > _lastAwayMessage) {
         _lastAwayMessage = lastAwayMessage;

--- a/src/common/ircuser.cpp
+++ b/src/common/ircuser.cpp
@@ -68,8 +68,12 @@ QString IrcUser::hostmask() const
 
 QDateTime IrcUser::idleTime()
 {
-    if (QDateTime::currentDateTime().toTime_t() - _idleTimeSet.toTime_t() > 1200)
+    if ((QDateTime::currentDateTime().toMSecsSinceEpoch() - _idleTimeSet.toMSecsSinceEpoch())
+            > 1200000) {
+        // 20 * 60 * 1000 = 1200000
+        // 20 minutes have elapsed, clear the known idle time as it's likely inaccurate by now
         _idleTime = QDateTime();
+    }
     return _idleTime;
 }
 

--- a/src/common/ircuser.h
+++ b/src/common/ircuser.h
@@ -50,7 +50,7 @@ class IrcUser : public SyncableObject
     Q_PROPERTY(QDateTime loginTime READ loginTime WRITE setLoginTime)
     Q_PROPERTY(QString server READ server WRITE setServer)
     Q_PROPERTY(QString ircOperator READ ircOperator WRITE setIrcOperator)
-    Q_PROPERTY(int lastAwayMessage READ lastAwayMessage WRITE setLastAwayMessage)
+    Q_PROPERTY(QDateTime lastAwayMessage READ lastAwayMessage WRITE setLastAwayMessage)
     Q_PROPERTY(QString whoisServiceReply READ whoisServiceReply WRITE setWhoisServiceReply)
     Q_PROPERTY(QString suserHost READ suserHost WRITE setSuserHost)
     Q_PROPERTY(bool encrypted READ encrypted WRITE setEncrypted)
@@ -79,7 +79,7 @@ public :
     inline QDateTime loginTime() const { return _loginTime; }
     inline QString server() const { return _server; }
     inline QString ircOperator() const { return _ircOperator; }
-    inline int lastAwayMessage() const { return _lastAwayMessage; }
+    inline QDateTime lastAwayMessage() const { return _lastAwayMessage; }
     inline QString whoisServiceReply() const { return _whoisServiceReply; }
     inline QString suserHost() const { return _suserHost; }
     inline bool encrypted() const { return _encrypted; }
@@ -123,7 +123,7 @@ public slots:
     void setLoginTime(const QDateTime &loginTime);
     void setServer(const QString &server);
     void setIrcOperator(const QString &ircOperator);
-    void setLastAwayMessage(const int &lastAwayMessage);
+    void setLastAwayMessage(const QDateTime &lastAwayMessage);
     void setWhoisServiceReply(const QString &whoisServiceReply);
     void setSuserHost(const QString &suserHost);
     void setEncrypted(bool encrypted);
@@ -156,7 +156,7 @@ signals:
 //   void loginTimeSet(QDateTime loginTime);
 //   void serverSet(QString server);
 //   void ircOperatorSet(QString ircOperator);
-//   void lastAwayMessageSet(int lastAwayMessage);
+//   void lastAwayMessageSet(QDateTime lastAwayMessage);
 //   void whoisServiceReplySet(QString whoisServiceReply);
 //   void suserHostSet(QString suserHost);
     void encryptedSet(bool encrypted);
@@ -203,7 +203,7 @@ private:
     QDateTime _idleTimeSet;
     QDateTime _loginTime;
     QString _ircOperator;
-    int _lastAwayMessage;
+    QDateTime _lastAwayMessage;
     QString _whoisServiceReply;
     QString _suserHost;
     bool _encrypted;

--- a/src/common/ircuser.h
+++ b/src/common/ircuser.h
@@ -50,7 +50,10 @@ class IrcUser : public SyncableObject
     Q_PROPERTY(QDateTime loginTime READ loginTime WRITE setLoginTime)
     Q_PROPERTY(QString server READ server WRITE setServer)
     Q_PROPERTY(QString ircOperator READ ircOperator WRITE setIrcOperator)
-    Q_PROPERTY(QDateTime lastAwayMessage READ lastAwayMessage WRITE setLastAwayMessage)
+    // lastAwayMessage is only set by legacy (pre-0.13) cores, which automatically gets converted to
+    // the appropriate lastAwayMessageTime.  Do not use this in new code.
+    Q_PROPERTY(int lastAwayMessage WRITE setLastAwayMessage)
+    Q_PROPERTY(QDateTime lastAwayMessageTime READ lastAwayMessageTime WRITE setLastAwayMessageTime)
     Q_PROPERTY(QString whoisServiceReply READ whoisServiceReply WRITE setWhoisServiceReply)
     Q_PROPERTY(QString suserHost READ suserHost WRITE setSuserHost)
     Q_PROPERTY(bool encrypted READ encrypted WRITE setEncrypted)
@@ -79,7 +82,7 @@ public :
     inline QDateTime loginTime() const { return _loginTime; }
     inline QString server() const { return _server; }
     inline QString ircOperator() const { return _ircOperator; }
-    inline QDateTime lastAwayMessage() const { return _lastAwayMessage; }
+    inline QDateTime lastAwayMessageTime() const { return _lastAwayMessageTime; }
     inline QString whoisServiceReply() const { return _whoisServiceReply; }
     inline QString suserHost() const { return _suserHost; }
     inline bool encrypted() const { return _encrypted; }
@@ -123,7 +126,10 @@ public slots:
     void setLoginTime(const QDateTime &loginTime);
     void setServer(const QString &server);
     void setIrcOperator(const QString &ircOperator);
-    void setLastAwayMessage(const QDateTime &lastAwayMessage);
+    // setLastAwayMessage is only called by legacy (pre-0.13) cores, which automatically gets
+    // converted to setting the appropriate lastAwayMessageTime.  Do not use this in new code.
+    void setLastAwayMessage(const int &lastAwayMessage);
+    void setLastAwayMessageTime(const QDateTime &lastAwayMessageTime);
     void setWhoisServiceReply(const QString &whoisServiceReply);
     void setSuserHost(const QString &suserHost);
     void setEncrypted(bool encrypted);
@@ -156,7 +162,7 @@ signals:
 //   void loginTimeSet(QDateTime loginTime);
 //   void serverSet(QString server);
 //   void ircOperatorSet(QString ircOperator);
-//   void lastAwayMessageSet(QDateTime lastAwayMessage);
+//   void lastAwayMessageTimeSet(QDateTime lastAwayMessageTime);
 //   void whoisServiceReplySet(QString whoisServiceReply);
 //   void suserHostSet(QString suserHost);
     void encryptedSet(bool encrypted);
@@ -203,7 +209,7 @@ private:
     QDateTime _idleTimeSet;
     QDateTime _loginTime;
     QString _ircOperator;
-    QDateTime _lastAwayMessage;
+    QDateTime _lastAwayMessageTime;
     QString _whoisServiceReply;
     QString _suserHost;
     bool _encrypted;

--- a/src/common/ircuser.h
+++ b/src/common/ircuser.h
@@ -50,9 +50,6 @@ class IrcUser : public SyncableObject
     Q_PROPERTY(QDateTime loginTime READ loginTime WRITE setLoginTime)
     Q_PROPERTY(QString server READ server WRITE setServer)
     Q_PROPERTY(QString ircOperator READ ircOperator WRITE setIrcOperator)
-    // lastAwayMessage is only set by legacy (pre-0.13) cores, which automatically gets converted to
-    // the appropriate lastAwayMessageTime.  Do not use this in new code.
-    Q_PROPERTY(int lastAwayMessage WRITE setLastAwayMessage)
     Q_PROPERTY(QDateTime lastAwayMessageTime READ lastAwayMessageTime WRITE setLastAwayMessageTime)
     Q_PROPERTY(QString whoisServiceReply READ whoisServiceReply WRITE setWhoisServiceReply)
     Q_PROPERTY(QString suserHost READ suserHost WRITE setSuserHost)

--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -163,6 +163,7 @@ int main(int argc, char **argv)
     cliParser->addSwitch("syslog", 0, "Log to syslog");
 #endif
     cliParser->addOption("logfile", 'l', "Log to a file", "path");
+    cliParser->addSwitch("config-from-environment", 0, "Load configuration from environment variables");
     cliParser->addOption("select-backend", 0, "Switch storage backend (migrating data if possible)", "backendidentifier");
     cliParser->addOption("select-authenticator", 0, "Select authentication backend", "authidentifier");
     cliParser->addSwitch("add-user", 0, "Starts an interactive session to add a new core user");

--- a/src/common/message.cpp
+++ b/src/common/message.cpp
@@ -65,8 +65,9 @@ QDataStream &operator<<(QDataStream &out, const Message &msg)
     // We do not serialize the sender prefixes until we have a new protocol or client-features implemented
     out << msg.msgId();
 
-    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::LongMessageTime)) {
-        out << (quint64) msg.timestamp().toMSecsSinceEpoch();
+    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::LongTime)) {
+        // toMSecs returns a qint64, signed rather than unsigned
+        out << (qint64) msg.timestamp().toMSecsSinceEpoch();
     } else {
         out << (quint32) msg.timestamp().toTime_t();
     }
@@ -96,8 +97,9 @@ QDataStream &operator>>(QDataStream &in, Message &msg)
 
     in >> msg._msgId;
 
-    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::LongMessageTime)) {
-        quint64 timeStamp;
+    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::LongTime)) {
+        // timestamp is a qint64, signed rather than unsigned
+        qint64 timeStamp;
         in >> timeStamp;
         msg._timestamp = QDateTime::fromMSecsSinceEpoch(timeStamp);
     } else {

--- a/src/common/message.cpp
+++ b/src/common/message.cpp
@@ -52,10 +52,19 @@ Message::Message(const QDateTime &ts, const BufferInfo &bufferInfo, Type type, c
 
 QDataStream &operator<<(QDataStream &out, const Message &msg)
 {
+    Q_ASSERT(SignalProxy::current());
+    Q_ASSERT(SignalProxy::current()->targetPeer());
+
     // We do not serialize the sender prefixes until we have a new protocol or client-features implemented
-    out << msg.msgId()
-        << (quint32) msg.timestamp().toTime_t()
-        << (quint32) msg.type()
+    out << msg.msgId();
+
+    if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::LongMessageTime)) {
+        out << (quint64) msg.timestamp().toMSecsSinceEpoch();
+    } else {
+        out << (quint32) msg.timestamp().toTime_t();
+    }
+
+    out << (quint32) msg.type()
         << (quint8) msg.flags()
         << msg.bufferInfo()
         << msg.sender().toUtf8();
@@ -70,11 +79,20 @@ QDataStream &operator<<(QDataStream &out, const Message &msg)
 
 QDataStream &operator>>(QDataStream &in, Message &msg)
 {
+    Q_ASSERT(SignalProxy::current());
+    Q_ASSERT(SignalProxy::current()->sourcePeer());
+
     in >> msg._msgId;
 
-    quint32 timeStamp;
-    in >> timeStamp;
-    msg._timestamp = QDateTime::fromTime_t(timeStamp);
+    if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::LongMessageTime)) {
+        quint64 timeStamp;
+        in >> timeStamp;
+        msg._timestamp = QDateTime::fromMSecsSinceEpoch(timeStamp);
+    } else {
+        quint32 timeStamp;
+        in >> timeStamp;
+        msg._timestamp = QDateTime::fromTime_t(timeStamp);
+    }
 
     quint32 type;
     in >> type;

--- a/src/common/message.h
+++ b/src/common/message.h
@@ -68,10 +68,11 @@ public:
     Q_DECLARE_FLAGS(Flags, Flag)
 
     Message(const BufferInfo &bufferInfo = BufferInfo(), Type type = Plain, const QString &contents = {},
-            const QString &sender = {}, const QString &senderPrefixes = {}, Flags flags = None);
+            const QString &sender = {}, const QString &senderPrefixes = {}, const QString &realName = {},
+            const QString &avatarUrl = {}, Flags flags = None);
     Message(const QDateTime &ts, const BufferInfo &buffer = BufferInfo(), Type type = Plain,
             const QString &contents = {}, const QString &sender = {}, const QString &senderPrefixes = {},
-            Flags flags = None);
+            const QString &realName = {}, const QString &avatarUrl = {}, Flags flags = None);
 
     inline static Message ChangeOfDay(const QDateTime &day) { return Message(day, BufferInfo(), DayChange); }
     inline const MsgId &msgId() const { return _msgId; }
@@ -83,6 +84,8 @@ public:
     inline const QString &contents() const { return _contents; }
     inline const QString &sender() const { return _sender; }
     inline const QString &senderPrefixes() const { return _senderPrefixes; }
+    inline const QString &realName() const { return _realName; }
+    inline const QString &avatarUrl() const { return _avatarUrl; }
     inline Type type() const { return _type; }
     inline Flags flags() const { return _flags; }
     inline void setFlags(Flags flags) { _flags = flags; }
@@ -99,6 +102,8 @@ private:
     QString _contents;
     QString _sender;
     QString _senderPrefixes;
+    QString _realName;
+    QString _avatarUrl;
     Type _type;
     Flags _flags;
 

--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -296,7 +296,14 @@ void Quassel::setupBuildInfo()
     if (!QString(GIT_HEAD).isEmpty()) {
         buildInfo.commitHash = GIT_HEAD;
         QDateTime date;
-        date.setTime_t(GIT_COMMIT_DATE);
+#if QT_VERSION >= 0x050800
+        date.setSecsSinceEpoch(GIT_COMMIT_DATE);
+#else
+        // toSecsSinceEpoch() was added in Qt 5.8.  Manually downconvert to seconds for now.
+        // See https://doc.qt.io/qt-5/qdatetime.html#toMSecsSinceEpoch
+        // Warning generated if not converting the 1000 to a qint64 first.
+        date.setMSecsSinceEpoch(GIT_COMMIT_DATE * (qint64)1000);
+#endif
         buildInfo.commitDate = date.toString();
     }
     else if (!QString(DIST_HASH).contains("Format")) {

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -137,6 +137,7 @@ public:
 #if QT_VERSION >= 0x050500
         EcdsaCertfpKeys,          ///< ECDSA keys for CertFP in identities
 #endif
+        LongMessageId,            ///< 64-bit IDs for messages
     };
     Q_ENUMS(Feature)
 

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -133,6 +133,7 @@ public:
         ExtendedFeatures,         ///< Extended features
         LongMessageTime,          ///< Serialize message time as 64-bit
         RichMessages,             ///< Real Name and Avatar URL in backlog
+        BacklogFilterType,        ///< BacklogManager supports filtering backlog by MessageType
 #if QT_VERSION >= 0x050500
         EcdsaCertfpKeys,          ///< ECDSA keys for CertFP in identities
 #endif

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -131,7 +131,7 @@ public:
         SenderPrefixes,           ///< Show prefixes for senders in backlog
         RemoteDisconnect,         ///< Allow this peer to be remotely disconnected
         ExtendedFeatures,         ///< Extended features
-        LongMessageTime,          ///< Serialize message time as 64-bit
+        LongTime,                 ///< Serialize time as 64-bit values
         RichMessages,             ///< Real Name and Avatar URL in backlog
         BacklogFilterType,        ///< BacklogManager supports filtering backlog by MessageType
 #if QT_VERSION >= 0x050500

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -131,6 +131,7 @@ public:
         SenderPrefixes,           ///< Show prefixes for senders in backlog
         RemoteDisconnect,         ///< Allow this peer to be remotely disconnected
         ExtendedFeatures,         ///< Extended features
+        LongMessageTime,          ///< Serialize message time as 64-bit
 #if QT_VERSION >= 0x050500
         EcdsaCertfpKeys,          ///< ECDSA keys for CertFP in identities
 #endif

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -132,6 +132,7 @@ public:
         RemoteDisconnect,         ///< Allow this peer to be remotely disconnected
         ExtendedFeatures,         ///< Extended features
         LongMessageTime,          ///< Serialize message time as 64-bit
+        RichMessages,             ///< Real Name and Avatar URL in backlog
 #if QT_VERSION >= 0x050500
         EcdsaCertfpKeys,          ///< ECDSA keys for CertFP in identities
 #endif

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -58,20 +58,53 @@ public:
     friend QDataStream &operator>>(QDataStream &in, SignedId &signedId);
 };
 
-
 inline QDataStream &operator<<(QDataStream &out, const SignedId &signedId) { out << signedId.toInt(); return out; }
 inline QDataStream &operator>>(QDataStream &in, SignedId &signedId) { in >> signedId.id; return in; }
 inline QTextStream &operator<<(QTextStream &out, const SignedId &signedId) { out << QString::number(signedId.toInt()); return out; }
 inline QDebug operator<<(QDebug dbg, const SignedId &signedId) { dbg.space() << signedId.toInt(); return dbg; }
 inline uint qHash(const SignedId &id) { return qHash(id.toInt()); }
 
+class SignedId64
+{
+protected:
+    qint64 id;
+
+public:
+    inline SignedId64(qint64 _id = 0) { id = _id; }
+    inline qint64 toQint64() const { return id; }
+    inline bool isValid() const { return id > 0; }
+
+    inline bool operator==(const SignedId64 &other) const { return id == other.id; }
+    inline bool operator!=(const SignedId64 &other) const { return id != other.id; }
+    inline bool operator<(const SignedId64 &other) const { return id < other.id; }
+    inline bool operator<=(const SignedId64 &other) const { return id <= other.id; }
+    inline bool operator>(const SignedId64 &other) const { return id > other.id; }
+    inline bool operator>=(const SignedId64 &other) const { return id >= other.id; }
+    inline bool operator==(qint64 i) const { return id == i; }
+    inline bool operator!=(qint64 i) const { return id != i; }
+    inline bool operator<(qint64 i) const { return id < i; }
+    inline bool operator>(qint64 i) const { return id > i; }
+    inline bool operator<=(qint64 i) const { return id <= i; }
+
+    inline SignedId64 operator++(int) { id++; return *this; }
+    //inline operator int() const { return toQint64(); } // no automatic conversion!
+
+    friend QDataStream &operator>>(QDataStream &in, SignedId64 &signedId);
+};
+
+QDataStream &operator<<(QDataStream &out, const SignedId64 &signedId);
+QDataStream &operator>>(QDataStream &in, SignedId64 &signedId);
+inline QTextStream &operator<<(QTextStream &out, const SignedId64 &signedId) { out << QString::number(signedId.toQint64()); return out; }
+inline QDebug operator<<(QDebug dbg, const SignedId64 &signedId) { dbg.space() << signedId.toQint64(); return dbg; }
+inline uint qHash(const SignedId64 &id) { return qHash(id.toQint64()); }
+
 struct UserId : public SignedId {
     inline UserId(int _id = 0) : SignedId(_id) {}
     //inline operator QVariant() const { return QVariant::fromValue<UserId>(*this); }  // no automatic conversion!
 };
 
-struct MsgId : public SignedId {
-    inline MsgId(int _id = 0) : SignedId(_id) {}
+struct MsgId : public SignedId64 {
+    inline MsgId(qint64 _id = 0) : SignedId64(_id) {}
     //inline operator QVariant() const { return QVariant::fromValue<MsgId>(*this); }
 };
 

--- a/src/core/SQL/PostgreSQL/insert_core_state.sql
+++ b/src/core/SQL/PostgreSQL/insert_core_state.sql
@@ -1,0 +1,2 @@
+INSERT INTO core_state (key, value)
+VALUES (:key, :value)

--- a/src/core/SQL/PostgreSQL/insert_sender.sql
+++ b/src/core/SQL/PostgreSQL/insert_sender.sql
@@ -1,3 +1,3 @@
-INSERT INTO sender (sender)
-VALUES ($1)
+INSERT INTO sender (sender, realname, avatarurl)
+VALUES ($1, $2, $3)
 RETURNING senderid

--- a/src/core/SQL/PostgreSQL/migrate_write_buffer.sql
+++ b/src/core/SQL/PostgreSQL/migrate_write_buffer.sql
@@ -1,2 +1,2 @@
-INSERT INTO buffer (bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, key, joined, cipher)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO buffer (bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, highlightcount, key, joined, cipher)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/src/core/SQL/PostgreSQL/migrate_write_buffer.sql
+++ b/src/core/SQL/PostgreSQL/migrate_write_buffer.sql
@@ -1,2 +1,2 @@
-INSERT INTO buffer (bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, key, joined)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO buffer (bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, key, joined, cipher)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/src/core/SQL/PostgreSQL/migrate_write_corestate.sql
+++ b/src/core/SQL/PostgreSQL/migrate_write_corestate.sql
@@ -1,0 +1,2 @@
+INSERT INTO core_state (key, value)
+VALUES (?, ?)

--- a/src/core/SQL/PostgreSQL/migrate_write_sender.sql
+++ b/src/core/SQL/PostgreSQL/migrate_write_sender.sql
@@ -1,2 +1,2 @@
-INSERT INTO sender (senderid, sender)
-VALUES (?, ?)
+INSERT INTO sender (senderid, sender, realname, avatarurl)
+VALUES (?, ?, ?, ?)

--- a/src/core/SQL/PostgreSQL/select_buffer_ciphers.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_ciphers.sql
@@ -1,0 +1,3 @@
+SELECT buffername, cipher
+FROM buffer
+WHERE userid = :userid AND networkid = :networkid AND buffertype IN (2, 4)

--- a/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
@@ -1,0 +1,7 @@
+SELECT COALESCE(t.sum,0)
+FROM
+  (SELECT COUNT(*) AS sum FROM backlog
+   WHERE bufferid = :bufferid
+     AND flags & 2 != 0
+     AND flags & 1 = 0
+     AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/PostgreSQL/select_buffer_highlightcounts.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_highlightcounts.sql
@@ -1,0 +1,3 @@
+SELECT bufferid, highlightcount
+FROM buffer
+WHERE userid = :userid

--- a/src/core/SQL/PostgreSQL/select_core_state.sql
+++ b/src/core/SQL/PostgreSQL/select_core_state.sql
@@ -1,0 +1,3 @@
+SELECT value
+FROM core_state
+WHERE key = :key

--- a/src/core/SQL/PostgreSQL/select_messagesAll.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesAll.sql
@@ -1,4 +1,4 @@
-SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)

--- a/src/core/SQL/PostgreSQL/select_messagesAllNew.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesAllNew.sql
@@ -1,4 +1,4 @@
-SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)

--- a/src/core/SQL/PostgreSQL/select_messagesAllNew_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesAllNew_filtered.sql
@@ -1,0 +1,9 @@
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
+    AND backlog.messageid >= :firstmsg
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+-- Unlike SQLite, no LIMIT clause, mimicking the unfiltered version - investigate later..?

--- a/src/core/SQL/PostgreSQL/select_messagesAll_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesAll_filtered.sql
@@ -1,0 +1,10 @@
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
+    AND backlog.messageid >= :firstmsg
+    AND backlog.messageid < :lastmsg
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+-- Unlike SQLite, no LIMIT clause, mimicking the unfiltered version - investigate later..?

--- a/src/core/SQL/PostgreSQL/select_messagesNewerThan.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesNewerThan.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= $1

--- a/src/core/SQL/PostgreSQL/select_messagesNewerThan_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesNewerThan_filtered.sql
@@ -1,0 +1,10 @@
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.messageid >= :first
+    AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :buffer)
+    AND bufferid = :buffer
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/PostgreSQL/select_messagesNewestK.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesNewestK.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE bufferid = $1

--- a/src/core/SQL/PostgreSQL/select_messagesNewestK_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesNewestK_filtered.sql
@@ -1,0 +1,9 @@
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE bufferid = :buffer
+    AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :buffer)
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/PostgreSQL/select_messagesRange.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesRange.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= $1

--- a/src/core/SQL/PostgreSQL/select_messagesRange_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesRange_filtered.sql
@@ -1,0 +1,10 @@
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.messageid >= :first
+    AND backlog.messageid < :last
+    AND bufferid = :buffer
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/PostgreSQL/select_senderid.sql
+++ b/src/core/SQL/PostgreSQL/select_senderid.sql
@@ -1,3 +1,3 @@
 SELECT senderid
 FROM sender
-WHERE sender = $1
+WHERE sender = $1 AND realname = $2 AND avatarurl = $3

--- a/src/core/SQL/PostgreSQL/select_senderid.sql
+++ b/src/core/SQL/PostgreSQL/select_senderid.sql
@@ -1,3 +1,3 @@
 SELECT senderid
 FROM sender
-WHERE sender = $1 AND realname = $2 AND avatarurl = $3
+WHERE sender = $1 AND coalesce(realname, '') = coalesce($2, '') AND coalesce(avatarurl, '') = coalesce($3, '')

--- a/src/core/SQL/PostgreSQL/setup_010_sender.sql
+++ b/src/core/SQL/PostgreSQL/setup_010_sender.sql
@@ -1,5 +1,5 @@
 CREATE TABLE sender ( -- THE SENDER OF IRC MESSAGES
-       senderid serial NOT NULL PRIMARY KEY,
+       senderid bigserial NOT NULL PRIMARY KEY,
        sender varchar(128) NOT NULL,
        realname TEXT,
        avatarurl TEXT

--- a/src/core/SQL/PostgreSQL/setup_010_sender.sql
+++ b/src/core/SQL/PostgreSQL/setup_010_sender.sql
@@ -1,4 +1,6 @@
 CREATE TABLE sender ( -- THE SENDER OF IRC MESSAGES
        senderid serial NOT NULL PRIMARY KEY,
-       sender varchar(128) UNIQUE NOT NULL
-)
+       sender varchar(128) NOT NULL,
+       realname TEXT,
+       avatarurl TEXT
+);

--- a/src/core/SQL/PostgreSQL/setup_050_buffer.sql
+++ b/src/core/SQL/PostgreSQL/setup_050_buffer.sql
@@ -10,6 +10,7 @@ create TABLE buffer (
 	lastseenmsgid integer NOT NULL DEFAULT 0,
 	markerlinemsgid integer NOT NULL DEFAULT 0,
 	bufferactivity integer NOT NULL DEFAULT 0,
+	highlightcount integer NOT NULL DEFAULT 0,
 	key varchar(128),
 	joined boolean NOT NULL DEFAULT FALSE, -- BOOL
 	cipher TEXT,

--- a/src/core/SQL/PostgreSQL/setup_050_buffer.sql
+++ b/src/core/SQL/PostgreSQL/setup_050_buffer.sql
@@ -6,9 +6,9 @@ create TABLE buffer (
 	buffername varchar(128) NOT NULL,
 	buffercname varchar(128) NOT NULL, -- CANONICAL BUFFER NAME (lowercase version)
 	buffertype integer NOT NULL DEFAULT 0,
-	lastmsgid integer NOT NULL DEFAULT 0,
-	lastseenmsgid integer NOT NULL DEFAULT 0,
-	markerlinemsgid integer NOT NULL DEFAULT 0,
+	lastmsgid bigint NOT NULL DEFAULT 0,
+	lastseenmsgid bigint NOT NULL DEFAULT 0,
+	markerlinemsgid bigint NOT NULL DEFAULT 0,
 	bufferactivity integer NOT NULL DEFAULT 0,
 	highlightcount integer NOT NULL DEFAULT 0,
 	key varchar(128),

--- a/src/core/SQL/PostgreSQL/setup_050_buffer.sql
+++ b/src/core/SQL/PostgreSQL/setup_050_buffer.sql
@@ -12,6 +12,7 @@ create TABLE buffer (
 	bufferactivity integer NOT NULL DEFAULT 0,
 	key varchar(128),
 	joined boolean NOT NULL DEFAULT FALSE, -- BOOL
+	cipher TEXT,
 	UNIQUE(userid, networkid, buffercname),
 	CHECK (buffer.lastseenmsgid <= buffer.lastmsgid)
 )

--- a/src/core/SQL/PostgreSQL/setup_060_backlog.sql
+++ b/src/core/SQL/PostgreSQL/setup_060_backlog.sql
@@ -1,10 +1,10 @@
 CREATE TABLE backlog (
-	messageid serial PRIMARY KEY,
+	messageid bigserial PRIMARY KEY,
 	time timestamp NOT NULL,
 	bufferid integer NOT NULL REFERENCES buffer (bufferid) ON DELETE CASCADE,
 	type integer NOT NULL,
 	flags integer NOT NULL,
-	senderid integer NOT NULL REFERENCES sender (senderid) ON DELETE SET NULL,
+	senderid bigint NOT NULL REFERENCES sender (senderid) ON DELETE SET NULL,
 	senderprefixes TEXT,
 	message TEXT
 )

--- a/src/core/SQL/PostgreSQL/setup_140_sender_idx.sql
+++ b/src/core/SQL/PostgreSQL/setup_140_sender_idx.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX sender_sender_realname_avatarurl_uindex ON sender(sender, realname, avatarurl);

--- a/src/core/SQL/PostgreSQL/setup_150_corestate.sql
+++ b/src/core/SQL/PostgreSQL/setup_150_corestate.sql
@@ -1,0 +1,5 @@
+CREATE TABLE core_state (
+    key TEXT NOT NULL,
+    value bytea,
+    PRIMARY KEY (key)
+)

--- a/src/core/SQL/PostgreSQL/update_buffer_cipher.sql
+++ b/src/core/SQL/PostgreSQL/update_buffer_cipher.sql
@@ -1,0 +1,3 @@
+UPDATE buffer
+SET cipher = :cipher
+WHERE userid = :userid AND networkid = :networkid AND buffercname = :buffercname

--- a/src/core/SQL/PostgreSQL/update_buffer_highlightcount.sql
+++ b/src/core/SQL/PostgreSQL/update_buffer_highlightcount.sql
@@ -1,0 +1,3 @@
+UPDATE buffer
+SET highlightcount = :highlightcount
+WHERE userid = :userid AND bufferid = :bufferid

--- a/src/core/SQL/PostgreSQL/update_core_state.sql
+++ b/src/core/SQL/PostgreSQL/update_core_state.sql
@@ -1,0 +1,3 @@
+UPDATE core_state
+SET value = :value
+WHERE key = :key

--- a/src/core/SQL/PostgreSQL/version/25/upgrade_000_alter_buffer_add_cipher.sql
+++ b/src/core/SQL/PostgreSQL/version/25/upgrade_000_alter_buffer_add_cipher.sql
@@ -1,0 +1,2 @@
+ALTER TABLE buffer
+ADD COLUMN cipher TEXT

--- a/src/core/SQL/PostgreSQL/version/26/upgrade_000_alter_buffer_add_highlightcount.sql
+++ b/src/core/SQL/PostgreSQL/version/26/upgrade_000_alter_buffer_add_highlightcount.sql
@@ -1,0 +1,2 @@
+ALTER TABLE buffer
+ADD COLUMN highlightcount integer NOT NULL DEFAULT 0

--- a/src/core/SQL/PostgreSQL/version/27/upgrade_000_update_sender_add_realname.sql
+++ b/src/core/SQL/PostgreSQL/version/27/upgrade_000_update_sender_add_realname.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sender ADD realname TEXT NULL;

--- a/src/core/SQL/PostgreSQL/version/27/upgrade_010_update_sender_add_avatarurl.sql
+++ b/src/core/SQL/PostgreSQL/version/27/upgrade_010_update_sender_add_avatarurl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sender ADD avatarurl TEXT NULL;

--- a/src/core/SQL/PostgreSQL/version/27/upgrade_020_update_sender_add_new_constraint.sql
+++ b/src/core/SQL/PostgreSQL/version/27/upgrade_020_update_sender_add_new_constraint.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX sender_sender_realname_avatarurl_uindex ON sender(sender, realname, avatarurl);

--- a/src/core/SQL/PostgreSQL/version/27/upgrade_030_upgrade_sender_drop_old_constraint.sql
+++ b/src/core/SQL/PostgreSQL/version/27/upgrade_030_upgrade_sender_drop_old_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sender DROP CONSTRAINT sender_sender_key;

--- a/src/core/SQL/PostgreSQL/version/28/upgrade_000_create_corestate.sql
+++ b/src/core/SQL/PostgreSQL/version/28/upgrade_000_create_corestate.sql
@@ -1,0 +1,5 @@
+CREATE TABLE core_state (
+    key TEXT NOT NULL,
+    value bytea,
+    PRIMARY KEY (key)
+)

--- a/src/core/SQL/PostgreSQL/version/29/upgrade_010_alter_sender_64bit_ids.sql
+++ b/src/core/SQL/PostgreSQL/version/29/upgrade_010_alter_sender_64bit_ids.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sender
+ALTER COLUMN senderid TYPE bigint

--- a/src/core/SQL/PostgreSQL/version/29/upgrade_050_alter_buffer_64bit_ids.sql
+++ b/src/core/SQL/PostgreSQL/version/29/upgrade_050_alter_buffer_64bit_ids.sql
@@ -1,0 +1,4 @@
+ALTER TABLE buffer
+ALTER COLUMN lastmsgid TYPE bigint,
+ALTER COLUMN lastseenmsgid TYPE bigint,
+ALTER COLUMN markerlinemsgid TYPE bigint

--- a/src/core/SQL/PostgreSQL/version/29/upgrade_060_alter_backlog_64bit_ids.sql
+++ b/src/core/SQL/PostgreSQL/version/29/upgrade_060_alter_backlog_64bit_ids.sql
@@ -1,0 +1,3 @@
+ALTER TABLE backlog
+ALTER COLUMN messageid TYPE bigint,
+ALTER COLUMN senderid TYPE bigint

--- a/src/core/SQL/SQLite/insert_core_state.sql
+++ b/src/core/SQL/SQLite/insert_core_state.sql
@@ -1,0 +1,2 @@
+INSERT INTO core_state (key, value)
+VALUES (:key, :value)

--- a/src/core/SQL/SQLite/insert_message.sql
+++ b/src/core/SQL/SQLite/insert_message.sql
@@ -1,2 +1,5 @@
 INSERT INTO backlog (time, bufferid, type, flags, senderid, senderprefixes, message)
-VALUES (:time, :bufferid, :type, :flags, (SELECT senderid FROM sender WHERE sender = :sender), :senderprefixes, :message)
+VALUES (:time, :bufferid, :type, :flags,
+	(SELECT senderid FROM sender WHERE sender = :sender AND coalesce(realname, '') = coalesce(:realname, '') AND coalesce(avatarurl, '') = coalesce(:avatarurl, '')),
+	:senderprefixes, :message
+)

--- a/src/core/SQL/SQLite/insert_sender.sql
+++ b/src/core/SQL/SQLite/insert_sender.sql
@@ -1,2 +1,2 @@
-INSERT INTO sender (sender)
-VALUES (:sender)
+INSERT INTO sender (sender, realname, avatarurl)
+VALUES (:sender, :realname, :avatarurl)

--- a/src/core/SQL/SQLite/migrate_read_buffer.sql
+++ b/src/core/SQL/SQLite/migrate_read_buffer.sql
@@ -1,2 +1,2 @@
-SELECT bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, key, joined, cipher
+SELECT bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, highlightcount, key, joined, cipher
 FROM buffer

--- a/src/core/SQL/SQLite/migrate_read_buffer.sql
+++ b/src/core/SQL/SQLite/migrate_read_buffer.sql
@@ -1,2 +1,2 @@
-SELECT bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, key, joined
+SELECT bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, key, joined, cipher
 FROM buffer

--- a/src/core/SQL/SQLite/migrate_read_corestate.sql
+++ b/src/core/SQL/SQLite/migrate_read_corestate.sql
@@ -1,0 +1,3 @@
+SELECT key, value
+FROM core_state
+

--- a/src/core/SQL/SQLite/migrate_read_sender.sql
+++ b/src/core/SQL/SQLite/migrate_read_sender.sql
@@ -1,5 +1,4 @@
-SELECT senderid, sender
+SELECT senderid, sender, realname, avatarurl
 FROM sender
 WHERE senderid > ? AND senderid <= ?
 ORDER BY senderid ASC
-

--- a/src/core/SQL/SQLite/select_buffer_ciphers.sql
+++ b/src/core/SQL/SQLite/select_buffer_ciphers.sql
@@ -1,0 +1,3 @@
+SELECT buffername, cipher
+FROM buffer
+WHERE userid = :userid AND networkid = :networkid AND buffertype IN (2, 4)

--- a/src/core/SQL/SQLite/select_buffer_highlightcount.sql
+++ b/src/core/SQL/SQLite/select_buffer_highlightcount.sql
@@ -1,0 +1,7 @@
+SELECT COALESCE(t.sum,0)
+FROM
+  (SELECT COUNT(*) AS sum FROM backlog
+   WHERE bufferid = :bufferid
+     AND flags & 2 != 0
+     AND flags & 1 = 0
+     AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/SQLite/select_buffer_highlightcounts.sql
+++ b/src/core/SQL/SQLite/select_buffer_highlightcounts.sql
@@ -1,0 +1,3 @@
+SELECT bufferid, highlightcount
+FROM buffer
+WHERE userid = :userid

--- a/src/core/SQL/SQLite/select_core_state.sql
+++ b/src/core/SQL/SQLite/select_core_state.sql
@@ -1,0 +1,3 @@
+SELECT value
+FROM core_state
+WHERE key = :key

--- a/src/core/SQL/SQLite/select_messagesAll.sql
+++ b/src/core/SQL/SQLite/select_messagesAll.sql
@@ -1,4 +1,4 @@
-SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)

--- a/src/core/SQL/SQLite/select_messagesAllNew.sql
+++ b/src/core/SQL/SQLite/select_messagesAllNew.sql
@@ -1,4 +1,4 @@
-SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)

--- a/src/core/SQL/SQLite/select_messagesAllNew_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesAllNew_filtered.sql
@@ -1,0 +1,9 @@
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
+    AND backlog.messageid >= :firstmsg
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesAll_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesAll_filtered.sql
@@ -1,0 +1,10 @@
+SELECT messageid, bufferid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
+    AND backlog.messageid >= :firstmsg
+    AND backlog.messageid < :lastmsg
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesNewerThan.sql
+++ b/src/core/SQL/SQLite/select_messagesNewerThan.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= :firstmsg

--- a/src/core/SQL/SQLite/select_messagesNewerThan_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesNewerThan_filtered.sql
@@ -1,0 +1,10 @@
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE backlog.messageid >= :firstmsg
+    AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferid)
+    AND bufferid = :bufferid
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesNewestK.sql
+++ b/src/core/SQL/SQLite/select_messagesNewestK.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE bufferid = :bufferid

--- a/src/core/SQL/SQLite/select_messagesNewestK_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesNewestK_filtered.sql
@@ -1,0 +1,9 @@
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE bufferid = :bufferid
+AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferid)
+AND backlog.type & :type != 0
+AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesRange.sql
+++ b/src/core/SQL/SQLite/select_messagesRange.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time,  type, flags, sender, senderprefixes, message
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE bufferid = :bufferid

--- a/src/core/SQL/SQLite/select_messagesRange_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesRange_filtered.sql
@@ -1,0 +1,10 @@
+SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarurl, message
+FROM backlog
+JOIN sender ON backlog.senderid = sender.senderid
+WHERE bufferid = :bufferid
+    AND backlog.messageid >= :firstmsg
+    AND backlog.messageid < :lastmsg
+    AND backlog.type & :type != 0
+    AND (:flags = 0 OR backlog.flags & :flags != 0)
+ORDER BY messageid DESC
+LIMIT :limit

--- a/src/core/SQL/SQLite/setup_010_sender.sql
+++ b/src/core/SQL/SQLite/setup_010_sender.sql
@@ -1,6 +1,6 @@
 CREATE TABLE sender ( -- THE SENDER OF IRC MESSAGES
        senderid INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-       sender TEXT UNIQUE NOT NULL
-)
-
-	  
+       sender TEXT NOT NULL,
+       realname TEXT,
+       avatarurl TEXT
+);

--- a/src/core/SQL/SQLite/setup_030_buffer.sql
+++ b/src/core/SQL/SQLite/setup_030_buffer.sql
@@ -10,6 +10,7 @@ CREATE TABLE buffer (
 	lastseenmsgid INTEGER NOT NULL DEFAULT 0,
 	markerlinemsgid INTEGER NOT NULL DEFAULT 0,
 	bufferactivity INTEGER NOT NULL DEFAULT 0,
+	highlightcount INTEGER NOT NULL DEFAULT 0,
 	key TEXT,
 	joined INTEGER NOT NULL DEFAULT 0, -- BOOL
 	cipher TEXT,

--- a/src/core/SQL/SQLite/setup_030_buffer.sql
+++ b/src/core/SQL/SQLite/setup_030_buffer.sql
@@ -12,5 +12,6 @@ CREATE TABLE buffer (
 	bufferactivity INTEGER NOT NULL DEFAULT 0,
 	key TEXT,
 	joined INTEGER NOT NULL DEFAULT 0, -- BOOL
+	cipher TEXT,
 	CHECK (lastseenmsgid <= lastmsgid)
 )

--- a/src/core/SQL/SQLite/setup_150_sender_idx.sql
+++ b/src/core/SQL/SQLite/setup_150_sender_idx.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX sender_index ON sender(sender, realname, avatarurl);

--- a/src/core/SQL/SQLite/setup_160_corestate.sql
+++ b/src/core/SQL/SQLite/setup_160_corestate.sql
@@ -1,0 +1,5 @@
+CREATE TABLE core_state (
+    key TEXT NOT NULL,
+    value bytea,
+    PRIMARY KEY (key)
+)

--- a/src/core/SQL/SQLite/update_buffer_cipher.sql
+++ b/src/core/SQL/SQLite/update_buffer_cipher.sql
@@ -1,0 +1,3 @@
+UPDATE buffer
+SET cipher = :cipher
+WHERE userid = :userid AND networkid = :networkid AND buffercname = :buffercname

--- a/src/core/SQL/SQLite/update_buffer_highlightcount.sql
+++ b/src/core/SQL/SQLite/update_buffer_highlightcount.sql
@@ -1,0 +1,3 @@
+UPDATE buffer
+SET highlightcount = :highlightcount
+WHERE userid = :userid AND bufferid = :bufferid

--- a/src/core/SQL/SQLite/update_core_state.sql
+++ b/src/core/SQL/SQLite/update_core_state.sql
@@ -1,0 +1,3 @@
+UPDATE core_state
+SET value = :value
+WHERE key = :key

--- a/src/core/SQL/SQLite/version/27/upgrade_000_alter_buffer_add_cipher.sql
+++ b/src/core/SQL/SQLite/version/27/upgrade_000_alter_buffer_add_cipher.sql
@@ -1,0 +1,2 @@
+ALTER TABLE buffer
+ADD COLUMN cipher TEXT

--- a/src/core/SQL/SQLite/version/28/upgrade_000_alter_buffer_add_highlightcount.sql
+++ b/src/core/SQL/SQLite/version/28/upgrade_000_alter_buffer_add_highlightcount.sql
@@ -1,0 +1,2 @@
+ALTER TABLE buffer
+ADD COLUMN highlightcount integer NOT NULL DEFAULT 0

--- a/src/core/SQL/SQLite/version/29/upgrade_000_create_sender_tmp.sql
+++ b/src/core/SQL/SQLite/version/29/upgrade_000_create_sender_tmp.sql
@@ -1,0 +1,1 @@
+CREATE TABLE sender_tmp (senderid INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, sender TEXT NOT NULL, realname TEXT, avatarurl TEXT);

--- a/src/core/SQL/SQLite/version/29/upgrade_010_copy_sender_sender_tmp.sql
+++ b/src/core/SQL/SQLite/version/29/upgrade_010_copy_sender_sender_tmp.sql
@@ -1,0 +1,1 @@
+INSERT INTO sender_tmp SELECT senderid, sender, NULL as realname, NULL as avatarurl FROM sender;

--- a/src/core/SQL/SQLite/version/29/upgrade_020_drop_sender.sql
+++ b/src/core/SQL/SQLite/version/29/upgrade_020_drop_sender.sql
@@ -1,0 +1,1 @@
+DROP TABLE sender;

--- a/src/core/SQL/SQLite/version/29/upgrade_030_rename_sender_tmp_sender.sql
+++ b/src/core/SQL/SQLite/version/29/upgrade_030_rename_sender_tmp_sender.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sender_tmp RENAME TO sender;

--- a/src/core/SQL/SQLite/version/29/upgrade_040_update_sender_add_realname_avatarurl.sql
+++ b/src/core/SQL/SQLite/version/29/upgrade_040_update_sender_add_realname_avatarurl.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX sender_index ON sender(sender, realname, avatarurl);

--- a/src/core/SQL/SQLite/version/30/upgrade_000_create_corestate.sql
+++ b/src/core/SQL/SQLite/version/30/upgrade_000_create_corestate.sql
@@ -1,0 +1,5 @@
+CREATE TABLE core_state (
+    key TEXT NOT NULL,
+    value bytea,
+    PRIMARY KEY (key)
+)

--- a/src/core/SQL/SQLite/version/31/upgrade_000_update_buffer_set_time_extended.sql
+++ b/src/core/SQL/SQLite/version/31/upgrade_000_update_buffer_set_time_extended.sql
@@ -1,0 +1,1 @@
+UPDATE backlog SET time = time * 1000

--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -584,3 +584,13 @@ bool AbstractSqlMigrationReader::transferMo(MigrationObject moType, T &mo)
     qDebug() << "Done.";
     return true;
 }
+
+uint qHash(const SenderData &key) {
+    return qHash(QString(key.sender + "\n" + key.realname + "\n" + key.avatarurl));
+}
+
+bool operator==(const SenderData &a, const SenderData &b) {
+    return a.sender == b.sender &&
+        a.realname == b.realname &&
+        a.avatarurl == b.avatarurl;
+}

--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -116,9 +116,11 @@ void AbstractSqlStorage::dbConnect(QSqlDatabase &db)
 }
 
 
-Storage::State AbstractSqlStorage::init(const QVariantMap &settings)
+Storage::State AbstractSqlStorage::init(const QVariantMap &settings,
+                                        const QProcessEnvironment &environment,
+                                        bool loadFromEnvironment)
 {
-    setConnectionProperties(settings);
+    setConnectionProperties(settings, environment, loadFromEnvironment);
 
     _debug = Quassel::isOptionSet("debug");
 
@@ -192,9 +194,10 @@ QStringList AbstractSqlStorage::setupQueries()
 }
 
 
-bool AbstractSqlStorage::setup(const QVariantMap &settings)
+bool AbstractSqlStorage::setup(const QVariantMap &settings, const QProcessEnvironment &environment,
+                               bool loadFromEnvironment)
 {
-    setConnectionProperties(settings);
+    setConnectionProperties(settings, environment, loadFromEnvironment);
     QSqlDatabase db = logDb();
     if (!db.isOpen()) {
         qCritical() << "Unable to setup Logging Backend!";

--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -409,6 +409,8 @@ QString AbstractSqlMigrator::migrationObject(MigrationObject moType)
         return "IrcServer";
     case UserSetting:
         return "UserSetting";
+    case CoreState:
+        return "CoreState";
     };
     return QString();
 }
@@ -500,6 +502,10 @@ bool AbstractSqlMigrationReader::migrateTo(AbstractSqlMigrationWriter *writer)
 
     UserSettingMO userSettingMo;
     if (!transferMo(UserSetting, userSettingMo))
+        return false;
+
+    CoreStateMO coreStateMO;
+    if (!transferMo(CoreState, coreStateMO))
         return false;
 
     if (!_writer->postProcess())

--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -139,11 +139,20 @@ Storage::State AbstractSqlStorage::init(const QVariantMap &settings,
     }
 
     if (installedSchemaVersion() < schemaVersion()) {
-        qWarning() << qPrintable(tr("Installed Schema (version %1) is not up to date. Upgrading to version %2...").arg(installedSchemaVersion()).arg(schemaVersion()));
+        qWarning() << qPrintable(tr("Installed Schema (version %1) is not up to date. Upgrading to "
+                                    "version %2...  This may take a while for major upgrades."
+                                    ).arg(installedSchemaVersion()).arg(schemaVersion()));
+        // TODO: The monolithic client won't show this message unless one looks into the debug log.
+        // This should be made more friendly, e.g. a popup message in the GUI.
         if (!upgradeDb()) {
             qWarning() << qPrintable(tr("Upgrade failed..."));
             return NotAvailable;
         }
+        // Warning messages are also sent to the console, while Info messages aren't.  Add a message
+        // when migration succeeds to avoid confusing folks by implying the schema upgrade failed if
+        // later functionality does not work.
+        qWarning() << qPrintable(tr("Installed Schema successfully upgraded to version %1."
+                                    ).arg(schemaVersion()));
     }
 
     quInfo() << qPrintable(displayName()) << "storage backend is ready. Schema version:" << installedSchemaVersion();

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -43,8 +43,12 @@ public:
     virtual std::unique_ptr<AbstractSqlMigrationWriter> createMigrationWriter() { return {}; }
 
 public slots:
-    virtual State init(const QVariantMap &settings = QVariantMap());
-    virtual bool setup(const QVariantMap &settings = QVariantMap());
+    virtual State init(const QVariantMap &settings = QVariantMap(),
+                       const QProcessEnvironment &environment = {},
+                       bool loadFromEnvironment = false);
+    virtual bool setup(const QVariantMap &settings = QVariantMap(),
+                       const QProcessEnvironment &environment = {},
+                       bool loadFromEnvironment = false);
 
 protected:
     inline virtual void sync() {};
@@ -82,7 +86,9 @@ protected:
     virtual bool updateSchemaVersion(int newVersion) = 0;
     virtual bool setupSchemaVersion(int version) = 0;
 
-    virtual void setConnectionProperties(const QVariantMap &properties) = 0;
+    virtual void setConnectionProperties(const QVariantMap &properties,
+                                         const QProcessEnvironment &environment,
+                                         bool loadFromEnvironment) = 0;
     virtual QString driverName() = 0;
     inline virtual QString hostName() { return QString(); }
     inline virtual int port() { return -1; }

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -236,6 +236,7 @@ public:
         int bufferactivity;
         QString key;
         bool joined;
+        QString cipher;
     };
 
     struct BacklogMO {

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -285,6 +285,11 @@ public:
         QByteArray settingvalue;
     };
 
+    struct CoreStateMO {
+        QString key;
+        QByteArray value;
+    };
+
     enum MigrationObject {
         QuasselUser,
         Sender,
@@ -294,7 +299,8 @@ public:
         Buffer,
         Backlog,
         IrcServer,
-        UserSetting
+        UserSetting,
+        CoreState
     };
 
     AbstractSqlMigrator();
@@ -340,6 +346,7 @@ public:
     virtual bool readMo(BacklogMO &backlog) = 0;
     virtual bool readMo(IrcServerMO &ircserver) = 0;
     virtual bool readMo(UserSettingMO &userSetting) = 0;
+    virtual bool readMo(CoreStateMO &coreState) = 0;
 
     bool migrateTo(AbstractSqlMigrationWriter *writer);
 
@@ -365,6 +372,7 @@ public:
     virtual bool writeMo(const BacklogMO &backlog) = 0;
     virtual bool writeMo(const IrcServerMO &ircserver) = 0;
     virtual bool writeMo(const UserSettingMO &userSetting) = 0;
+    virtual bool writeMo(const CoreStateMO &coreState) = 0;
 
     inline bool migrateFrom(AbstractSqlMigrationReader *reader) { return reader->migrateTo(this); }
 

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -118,6 +118,14 @@ private:
     QHash<QThread *, Connection *> _connectionPool;
 };
 
+struct SenderData {
+    QString sender;
+    QString realname;
+    QString avatarurl;
+
+    friend uint qHash(const SenderData &key);
+    friend bool operator==(const SenderData &a, const SenderData &b);
+};
 
 // ========================================
 //  AbstractSqlStorage::Connection
@@ -155,6 +163,8 @@ public:
     struct SenderMO {
         int senderId;
         QString sender;
+        QString realname;
+        QString avatarurl;
         SenderMO() : senderId(0) {}
     };
 

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -234,6 +234,7 @@ public:
         int lastseenmsgid;
         int markerlinemsgid;
         int bufferactivity;
+        int highlightcount;
         QString key;
         bool joined;
         QString cipher;

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -167,7 +167,7 @@ public:
     };
 
     struct SenderMO {
-        int senderId;
+        qint64 senderId;
         QString sender;
         QString realname;
         QString avatarurl;
@@ -189,7 +189,7 @@ public:
         bool autoAwayReasonEnabled;
         bool detachAwayEnabled;
         QString detachAwayReason;
-        bool detchAwayReasonEnabled;
+        bool detachAwayReasonEnabled;
         QString ident;
         QString kickReason;
         QString partReason;
@@ -246,9 +246,9 @@ public:
         QString buffername;
         QString buffercname;
         int buffertype;
-        int lastmsgid;
-        int lastseenmsgid;
-        int markerlinemsgid;
+        qint64 lastmsgid;
+        qint64 lastseenmsgid;
+        qint64 markerlinemsgid;
         int bufferactivity;
         int highlightcount;
         QString key;
@@ -262,7 +262,7 @@ public:
         BufferId bufferid;
         int type;
         int flags;
-        int senderid;
+        qint64 senderid;
         QString senderprefixes;
         QString message;
     };

--- a/src/core/authenticator.h
+++ b/src/core/authenticator.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <QObject>
+#include <QProcessEnvironment>
 #include <QString>
 #include <QStringList>
 #include <QVariant>
@@ -81,13 +82,17 @@ public slots:
      *  \param settings   Hostname, port, username, password, ...
      *  \return True if and only if the authenticator provider was initialized successfully.
      */
-    virtual bool setup(const QVariantMap &settings = QVariantMap()) = 0;
+    virtual bool setup(const QVariantMap &settings = QVariantMap(),
+                       const QProcessEnvironment &environment = {},
+                       bool loadFromEnvironment = false) = 0;
 
     //! Initialize the authenticator provider
     /** \param settings   Hostname, port, username, password, ...
      *  \return the State the authenticator backend is now in (see authenticator::State)
      */
-    virtual State init(const QVariantMap &settings = QVariantMap()) = 0;
+    virtual State init(const QVariantMap &settings = QVariantMap(),
+                       const QProcessEnvironment &environment = {},
+                       bool loadFromEnvironment = false) = 0;
 
     //! Validate a username with a given password.
     /** \param user     The username to validate

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -259,14 +259,10 @@ Core::~Core()
 
 void Core::saveState()
 {
-    CoreSettings s;
-    QVariantMap state;
     QVariantList activeSessions;
     foreach(UserId user, instance()->_sessions.keys())
         activeSessions << QVariant::fromValue<UserId>(user);
-    state["CoreStateVersion"] = 1;
-    state["ActiveSessions"] = activeSessions;
-    s.setCoreState(state);
+    instance()->_storage->setCoreState(activeSessions);
 }
 
 
@@ -289,7 +285,9 @@ void Core::restoreState()
     }
     */
 
-    QVariantList activeSessions = s.coreState().toMap()["ActiveSessions"].toList();
+    const QList<QVariant> &activeSessionsFallback = s.coreState().toMap()["ActiveSessions"].toList();
+    QVariantList activeSessions = instance()->_storage->getCoreState(activeSessionsFallback);
+
     if (activeSessions.count() > 0) {
         quInfo() << "Restoring previous core state...";
         foreach(QVariant v, activeSessions) {

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -376,7 +376,7 @@ QString Core::setupCoreForInternalUsage()
 {
     Q_ASSERT(!_registeredStorageBackends.empty());
 
-    qsrand(QDateTime::currentDateTime().toTime_t());
+    qsrand(QDateTime::currentDateTime().toMSecsSinceEpoch());
     int pass = 0;
     for (int i = 0; i < 10; i++) {
         pass *= 10;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -718,8 +718,12 @@ private slots:
     void incomingConnection();
     void clientDisconnected();
 
-    bool initStorage(const QString &backend, const QVariantMap &settings, bool setup = false);
-    bool initAuthenticator(const QString &backend, const QVariantMap &settings, bool setup = false);
+    bool initStorage(const QString &backend, const QVariantMap &settings,
+                     const QProcessEnvironment &environment, bool loadFromEnvironment,
+                     bool setup = false);
+    bool initAuthenticator(const QString &backend, const QVariantMap &settings,
+                           const QProcessEnvironment &environment, bool loadFromEnvironment,
+                           bool setup = false);
 
     void socketError(QAbstractSocket::SocketError err, const QString &errorString);
     void setupClientSession(RemotePeer *, UserId);

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -429,6 +429,22 @@ public:
     }
 
 
+    //! Request a certain number messages stored in a given buffer, matching certain filters
+    /** \param buffer   The buffer we request messages from
+     *  \param first    if != -1 return only messages with a MsgId >= first
+     *  \param last     if != -1 return only messages with a MsgId < last
+     *  \param limit    if != -1 limit the returned list to a max of \limit entries
+     *  \param type     The Message::Types that should be returned
+     *  \return The requested list of messages
+     */
+    static inline QList<Message> requestMsgsFiltered(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1,
+                                                     int limit = -1, Message::Types type = Message::Types{-1},
+                                                     Message::Flags flags = Message::Flags{-1})
+    {
+        return instance()->_storage->requestMsgsFiltered(user, bufferId, first, last, limit, type, flags);
+    }
+
+
     //! Request a certain number of messages across all buffers
     /** \param first    if != -1 return only messages with a MsgId >= first
      *  \param last     if != -1 return only messages with a MsgId < last
@@ -438,6 +454,21 @@ public:
     static inline QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1)
     {
         return instance()->_storage->requestAllMsgs(user, first, last, limit);
+    }
+
+
+    //! Request a certain number of messages across all buffers, matching certain filters
+    /** \param first    if != -1 return only messages with a MsgId >= first
+     *  \param last     if != -1 return only messages with a MsgId < last
+     *  \param limit    Max amount of messages
+     *  \param type     The Message::Types that should be returned
+     *  \return The requested list of messages
+     */
+    static inline QList<Message> requestAllMsgsFiltered(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1,
+                                                        Message::Types type = Message::Types{-1},
+                                                        Message::Flags flags = Message::Flags{-1})
+    {
+        return instance()->_storage->requestAllMsgsFiltered(user, first, last, limit, type, flags);
     }
 
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -273,6 +273,33 @@ public:
     }
 
 
+    //! Get a hash of buffers with their ciphers for a given network
+    /** The keys are channel names and values are ciphers (possibly empty)
+     *  \note This method is threadsafe
+     *
+     *  \param user       The id of the networks owner
+     *  \param networkId  The Id of the network
+     */
+    static inline QHash<QString, QByteArray> bufferCiphers(UserId user, const NetworkId &networkId)
+    {
+        return instance()->_storage->bufferCiphers(user, networkId);
+    }
+
+
+    //! Update the cipher of a buffer
+    /** \note This method is threadsafe
+     *
+     *  \param user        The Id of the networks owner
+     *  \param networkId   The Id of the network
+     *  \param bufferName The Cname of the buffer
+     *  \param cipher      The cipher for the buffer
+     */
+    static inline void setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher)
+    {
+        return instance()->_storage->setBufferCipher(user, networkId, bufferName, cipher);
+    }
+
+
     //! Update the key of a channel
     /** \note This method is threadsafe
      *

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -606,6 +606,39 @@ public:
         return instance()->_storage->bufferActivity(bufferId, lastSeenMsgId);
     }
 
+    //! Update the highlight count for a Buffer
+    /** This Method is used to make the highlight count state of a Buffer persistent
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of that Buffer
+     * \param bufferId  The buffer id
+     * \param MsgId     The Message id where the marker line should be placed
+     */
+    static inline void setHighlightCount(UserId user, BufferId bufferId, int highlightCount) {
+        return instance()->_storage->setHighlightCount(user, bufferId, highlightCount);
+    }
+
+
+    //! Get a Hash of all highlight count states
+    /** This Method is called when the Quassel Core is started to restore the highlight count
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of the buffers
+     */
+    static inline QHash<BufferId, int> highlightCounts(UserId user) {
+        return instance()->_storage->highlightCounts(user);
+    }
+    //! Get the highlight count states for a buffer
+    /** This method is used to load the highlight count of a buffer when its last seen message changes.
+     *  \note This method is threadsafe.
+     *
+     * \param bufferId The buffer
+     * \param lastSeenMsgId     The last seen message
+     */
+    static inline int highlightCount(BufferId bufferId, MsgId lastSeenMsgId) {
+        return instance()->_storage->highlightCount(bufferId, lastSeenMsgId);
+    }
+
     static inline QDateTime startTime() { return instance()->_startTime; }
     static inline bool isConfigured() { return instance()->_configured; }
     static bool sslSupported();

--- a/src/core/corebacklogmanager.h
+++ b/src/core/corebacklogmanager.h
@@ -37,7 +37,11 @@ public:
 
 public slots:
     virtual QVariantList requestBacklog(BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0);
+    QVariantList requestBacklogFiltered(BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1,
+                                        int additional = 0, int type = -1, int flags = -1) override;
     virtual QVariantList requestBacklogAll(MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0);
+    QVariantList requestBacklogAllFiltered(MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0,
+                                           int type = -1, int flags = -1) override;
 
 private:
     CoreSession *_coreSession;

--- a/src/core/corebacklogmanager.h
+++ b/src/core/corebacklogmanager.h
@@ -36,10 +36,10 @@ public:
     CoreSession *coreSession() { return _coreSession; }
 
 public slots:
-    virtual QVariantList requestBacklog(BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0);
+    QVariantList requestBacklog(BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0) override;
     QVariantList requestBacklogFiltered(BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1,
                                         int additional = 0, int type = -1, int flags = -1) override;
-    virtual QVariantList requestBacklogAll(MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0);
+    QVariantList requestBacklogAll(MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0) override;
     QVariantList requestBacklogAllFiltered(MsgId first = -1, MsgId last = -1, int limit = -1, int additional = 0,
                                            int type = -1, int flags = -1) override;
 

--- a/src/core/corebuffersyncer.h
+++ b/src/core/corebuffersyncer.h
@@ -47,7 +47,16 @@ public slots:
         }
     }
 
+    void addCoreHighlight(const Message &message) {
+        auto oldHighlightCount = highlightCount(message.bufferId());
+        if (message.flags().testFlag(Message::Flag::Highlight) && !message.flags().testFlag(Message::Flag::Self)) {
+            setHighlightCount(message.bufferId(), oldHighlightCount + 1);
+        }
+    }
+
     void setBufferActivity(BufferId buffer, int activity) override;
+
+    void setHighlightCount(BufferId buffer, int highlightCount) override;
 
     inline void requestRenameBuffer(BufferId buffer, QString newName) override { renameBuffer(buffer, newName); }
     void renameBuffer(BufferId buffer, QString newName) override;
@@ -60,6 +69,7 @@ public slots:
     inline void requestMarkBufferAsRead(BufferId buffer) override {
         int activity = Message::Types();
         setBufferActivity(buffer, activity);
+        setHighlightCount(buffer, 0);
         markBufferAsRead(buffer);
     }
 
@@ -75,6 +85,7 @@ private:
     QSet<BufferId> dirtyLastSeenBuffers;
     QSet<BufferId> dirtyMarkerLineBuffers;
     QSet<BufferId> dirtyActivities;
+    QSet<BufferId> dirtyHighlights;
 
     void purgeBufferIds();
 };

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -908,12 +908,17 @@ void CoreNetwork::doAutoReconnect()
 
 void CoreNetwork::sendPing()
 {
-    uint now = QDateTime::currentDateTime().toTime_t();
+    qint64 now = QDateTime::currentDateTime().toMSecsSinceEpoch();
     if (_pingCount != 0) {
         qDebug() << "UserId:" << userId() << "Network:" << networkName() << "missed" << _pingCount << "pings."
                  << "BA:" << socket.bytesAvailable() << "BTW:" << socket.bytesToWrite();
     }
-    if ((int)_pingCount >= networkConfig()->maxPingCount() && now - _lastPingTime <= (uint)(_pingTimer.interval() / 1000) + 1) {
+    if ((int)_pingCount >= networkConfig()->maxPingCount()
+            && (now - _lastPingTime) <= (_pingTimer.interval() + (1 * 1000))) {
+        // In transitioning to 64-bit time, the interval no longer needs converted down to seconds.
+        // However, to reduce the risk of breaking things by changing past behavior, we still allow
+        // up to 1 second missed instead of enforcing a stricter 1 millisecond allowance.
+        //
         // the second check compares the actual elapsed time since the last ping and the pingTimer interval
         // if the interval is shorter then the actual elapsed time it means that this thread was somehow blocked
         // and unable to even handle a ping answer. So we ignore those misses.

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -63,6 +63,11 @@ CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
         _channelKeys[chan.toLower()] = channels[chan];
     }
 
+    QHash<QString, QByteArray> bufferCiphers = coreSession()->bufferCiphers(networkId());
+    foreach(QString buffer, bufferCiphers.keys()) {
+        storeChannelCipherKey(buffer.toLower(), bufferCiphers[buffer]);
+    }
+
     connect(networkConfig(), SIGNAL(pingTimeoutEnabledSet(bool)), SLOT(enablePingTimeout(bool)));
     connect(networkConfig(), SIGNAL(pingIntervalSet(int)), SLOT(setPingInterval(int)));
     connect(networkConfig(), SIGNAL(autoWhoEnabledSet(bool)), SLOT(setAutoWhoEnabled(bool)));
@@ -442,6 +447,7 @@ void CoreNetwork::setCipherKey(const QString &target, const QByteArray &key)
     CoreIrcChannel *c = qobject_cast<CoreIrcChannel*>(ircChannel(target));
     if (c) {
         c->setEncrypted(c->cipher()->setKey(key));
+        coreSession()->setBufferCipher(networkId(), target, key);
         return;
     }
 
@@ -451,6 +457,7 @@ void CoreNetwork::setCipherKey(const QString &target, const QByteArray &key)
 
     if (u) {
         u->setEncrypted(u->cipher()->setKey(key));
+        coreSession()->setBufferCipher(networkId(), target, key);
         return;
     }
 }

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -477,7 +477,7 @@ private:
     int _lastUsedServerIndex;
 
     QTimer _pingTimer;
-    uint _lastPingTime;
+    qint64 _lastPingTime;
     uint _pingCount;
     bool _sendPings;
 

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -385,8 +385,9 @@ void CoreSession::processMessages()
             Q_ASSERT(!createBuffer);
             bufferInfo = Core::bufferInfo(user(), rawMsg.networkId, BufferInfo::StatusBuffer, "");
         }
-        Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender,
-                    senderPrefixes(rawMsg.sender, bufferInfo), rawMsg.flags);
+        Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender, senderPrefixes(rawMsg.sender, bufferInfo),
+                    realName(rawMsg.sender, rawMsg.networkId),  avatarUrl(rawMsg.sender, rawMsg.networkId),
+                    rawMsg.flags);
         if(Core::storeMessage(msg))
             emit displayMsg(msg);
     }
@@ -410,8 +411,9 @@ void CoreSession::processMessages()
                 }
                 bufferInfoCache[rawMsg.networkId][rawMsg.target] = bufferInfo;
             }
-            Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender,
-                        senderPrefixes(rawMsg.sender, bufferInfo), rawMsg.flags);
+            Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender, senderPrefixes(rawMsg.sender, bufferInfo),
+                        realName(rawMsg.sender, rawMsg.networkId),  avatarUrl(rawMsg.sender, rawMsg.networkId),
+                        rawMsg.flags);
             messages << msg;
         }
 
@@ -427,8 +429,9 @@ void CoreSession::processMessages()
                 // add the StatusBuffer to the Cache in case there are more Messages for the original target
                 bufferInfoCache[rawMsg.networkId][rawMsg.target] = bufferInfo;
             }
-            Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender,
-                        senderPrefixes(rawMsg.sender, bufferInfo), rawMsg.flags);
+            Message msg(bufferInfo, rawMsg.type, rawMsg.text, rawMsg.sender, senderPrefixes(rawMsg.sender, bufferInfo),
+                        realName(rawMsg.sender, rawMsg.networkId),  avatarUrl(rawMsg.sender, rawMsg.networkId),
+                        rawMsg.flags);
             messages << msg;
         }
 
@@ -461,6 +464,33 @@ QString CoreSession::senderPrefixes(const QString &sender, const BufferInfo &buf
 
     const QString modes = currentChannel->userModes(nickFromMask(sender).toLower());
     return currentNetwork->modesToPrefixes(modes);
+}
+
+QString CoreSession::realName(const QString &sender, NetworkId networkId) const
+{
+    CoreNetwork *currentNetwork = network(networkId);
+    if (!currentNetwork) {
+        return {};
+    }
+
+    IrcUser *currentUser = currentNetwork->ircUser(nickFromMask(sender));
+    if (!currentUser) {
+        return {};
+    }
+
+    return currentUser->realName();
+}
+
+QString CoreSession::avatarUrl(const QString &sender, NetworkId networkId) const
+{
+    Q_UNUSED(sender);
+    Q_UNUSED(networkId);
+    // Currently we do not have a way to retrieve this value yet.
+    //
+    // This likely will require implementing IRCv3's METADATA spec.
+    // See https://ircv3.net/irc/
+    // And https://blog.irccloud.com/avatars/
+    return "";
 }
 
 Protocol::SessionState CoreSession::sessionState() const

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -262,8 +262,12 @@ void CoreSession::restoreSessionState()
 
 void CoreSession::addClient(RemotePeer *peer)
 {
+    signalProxy()->setTargetPeer(peer);
+
     peer->dispatch(sessionState());
     signalProxy()->addPeer(peer);
+
+    signalProxy()->setTargetPeer(nullptr);
 }
 
 

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -288,6 +288,17 @@ QHash<QString, QString> CoreSession::persistentChannels(NetworkId id) const
 }
 
 
+QHash<QString, QByteArray> CoreSession::bufferCiphers(NetworkId id) const
+{
+    return Core::bufferCiphers(user(), id);
+}
+
+void CoreSession::setBufferCipher(NetworkId id, const QString &bufferName, const QByteArray &cipher) const
+{
+    Core::setBufferCipher(user(), id, bufferName, cipher);
+}
+
+
 // FIXME switch to BufferId
 void CoreSession::msgFromClient(BufferInfo bufinfo, QString msg)
 {

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -138,6 +138,9 @@ public slots:
 
     QHash<QString, QString> persistentChannels(NetworkId) const;
 
+    QHash<QString, QByteArray> bufferCiphers(NetworkId id) const;
+    void setBufferCipher(NetworkId id, const QString &bufferName, const QByteArray &cipher) const;
+
     /**
      * Marks us away (or unaway) on all networks
      *

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -241,6 +241,20 @@ private:
      * @param bufferInfo The BufferInfo object of the buffer
      */
     QString senderPrefixes(const QString &sender, const BufferInfo &bufferInfo) const;
+
+    /**
+     * This method obtains the realname of the message's sender.
+     * @param sender The hostmask of the sender
+     * @param networkId The network the user is on
+     */
+    QString realName(const QString &sender, NetworkId networkId) const;
+
+    /**
+     * This method obtains the avatar of the message's sender.
+     * @param sender The hostmask of the sender
+     * @param networkId The network the user is on
+     */
+    QString avatarUrl(const QString &sender, NetworkId networkId) const;
     QList<RawMessage> _messageQueue;
     bool _processMessages;
     CoreIgnoreListManager _ignoreListManager;

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -846,7 +846,9 @@ void CoreSessionEventProcessor::processIrcEvent301(IrcEvent *e)
     if (ircuser) {
         ircuser->setAway(true);
         ircuser->setAwayMessage(e->params().at(1));
-        //ircuser->setLastAwayMessage(now);
+        // lastAwayMessageTime is set in EventStringifier::processIrcEvent301(), no need to set it
+        // here too
+        //ircuser->setLastAwayMessageTime(now);
     }
 }
 

--- a/src/core/eventstringifier.cpp
+++ b/src/core/eventstringifier.cpp
@@ -453,9 +453,9 @@ void EventStringifier::processIrcEvent301(IrcEvent *e)
             now.setTimeSpec(Qt::UTC);
             // Don't print "user is away" messages more often than this
             const int silenceTime = 60;
-            if (ircuser->lastAwayMessage().addSecs(silenceTime) >= now)
+            if (ircuser->lastAwayMessageTime().addSecs(silenceTime) >= now)
                 send = false;
-            ircuser->setLastAwayMessage(now);
+            ircuser->setLastAwayMessageTime(now);
         }
     }
     if (send)

--- a/src/core/eventstringifier.cpp
+++ b/src/core/eventstringifier.cpp
@@ -449,13 +449,11 @@ void EventStringifier::processIrcEvent301(IrcEvent *e)
         target = nick;
         IrcUser *ircuser = e->network()->ircUser(nick);
         if (ircuser) {
-            // FIXME: This needs converted to 64-bit time.
-            // For legacy protocol, keep the 32-bit signed int time.  For modern protocol, just send
-            // the actual QDateTime() instead, don't bother converting it.
-            int now = QDateTime::currentDateTime().toTime_t();
-            // FIXME: Convert to millisecond comparison, comment the constant value as needed
+            QDateTime now = QDateTime::currentDateTime();
+            now.setTimeSpec(Qt::UTC);
+            // Don't print "user is away" messages more often than this
             const int silenceTime = 60;
-            if (ircuser->lastAwayMessage() + silenceTime >= now)
+            if (ircuser->lastAwayMessage().addSecs(silenceTime) >= now)
                 send = false;
             ircuser->setLastAwayMessage(now);
         }

--- a/src/core/ldapauthenticator.cpp
+++ b/src/core/ldapauthenticator.cpp
@@ -100,15 +100,27 @@ QVariantList LdapAuthenticator::setupData() const
 }
 
 
-void LdapAuthenticator::setAuthProperties(const QVariantMap &properties)
+void LdapAuthenticator::setAuthProperties(const QVariantMap &properties,
+                                          const QProcessEnvironment &environment,
+                                          bool loadFromEnvironment)
 {
-    _hostName = properties["Hostname"].toString();
-    _port = properties["Port"].toInt();
-    _bindDN = properties["BindDN"].toString();
-    _bindPassword = properties["BindPassword"].toString();
-    _baseDN = properties["BaseDN"].toString();
-    _filter = properties["Filter"].toString();
-    _uidAttribute = properties["UidAttribute"].toString();
+    if (loadFromEnvironment) {
+        _hostName = environment.value("AUTH_LDAP_HOSTNAME");
+        _port = environment.value("AUTH_LDAP_PORT").toInt();
+        _bindDN = environment.value("AUTH_LDAP_BIND_DN");
+        _bindPassword = environment.value("AUTH_LDAP_BIND_PASSWORD");
+        _baseDN = environment.value("AUTH_LDAP_BASE_DN");
+        _filter = environment.value("AUTH_LDAP_FILTER");
+        _uidAttribute = environment.value("AUTH_LDAP_UID_ATTRIBUTE");
+    } else {
+        _hostName = properties["Hostname"].toString();
+        _port = properties["Port"].toInt();
+        _bindDN = properties["BindDN"].toString();
+        _bindPassword = properties["BindPassword"].toString();
+        _baseDN = properties["BaseDN"].toString();
+        _filter = properties["Filter"].toString();
+        _uidAttribute = properties["UidAttribute"].toString();
+    }
 }
 
 // TODO: this code is sufficiently general that in the future, perhaps an abstract
@@ -142,17 +154,21 @@ UserId LdapAuthenticator::validateUser(const QString &username, const QString &p
 }
 
 
-bool LdapAuthenticator::setup(const QVariantMap &settings)
+bool LdapAuthenticator::setup(const QVariantMap &settings,
+                              const QProcessEnvironment &environment,
+                              bool loadFromEnvironment)
 {
-    setAuthProperties(settings);
+    setAuthProperties(settings, environment, loadFromEnvironment);
     bool status = ldapConnect();
     return status;
 }
 
 
-Authenticator::State LdapAuthenticator::init(const QVariantMap &settings)
+Authenticator::State LdapAuthenticator::init(const QVariantMap &settings,
+                                             const QProcessEnvironment &environment,
+                                             bool loadFromEnvironment)
 {
-    setAuthProperties(settings);
+    setAuthProperties(settings, environment, loadFromEnvironment);
 
     bool status = ldapConnect();
     if (!status) {

--- a/src/core/ldapauthenticator.h
+++ b/src/core/ldapauthenticator.h
@@ -63,12 +63,15 @@ public slots:
 
     bool canChangePassword() const override { return false; }
 
-    bool setup(const QVariantMap &settings = {}) override;
-    State init(const QVariantMap &settings = {}) override;
+    bool setup(const QVariantMap &settings, const QProcessEnvironment &environment,
+               bool loadFromEnvironment) override;
+    State init(const QVariantMap &settings, const QProcessEnvironment &environment,
+               bool loadFromEnvironment) override;
     UserId validateUser(const QString &user, const QString &password) override;
 
 protected:
-    void setAuthProperties(const QVariantMap &properties);
+    void setAuthProperties(const QVariantMap &properties, const QProcessEnvironment &environment,
+                           bool loadFromEnvironment);
     bool ldapConnect();
     void ldapDisconnect();
     bool ldapAuth(const QString &username, const QString &password);

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<AbstractSqlMigrationWriter> PostgreSqlStorage::createMigrationWr
     properties["Hostname"] = _hostName;
     properties["Port"] = _port;
     properties["Database"] = _databaseName;
-    writer->setConnectionProperties(properties);
+    writer->setConnectionProperties(properties, {}, false);
     return std::unique_ptr<AbstractSqlMigrationWriter>{writer};
 }
 
@@ -147,13 +147,23 @@ bool PostgreSqlStorage::initDbSession(QSqlDatabase &db)
 }
 
 
-void PostgreSqlStorage::setConnectionProperties(const QVariantMap &properties)
+void PostgreSqlStorage::setConnectionProperties(const QVariantMap &properties,
+                                                const QProcessEnvironment &environment,
+                                                bool loadFromEnvironment)
 {
-    _userName = properties["Username"].toString();
-    _password = properties["Password"].toString();
-    _hostName = properties["Hostname"].toString();
-    _port = properties["Port"].toInt();
-    _databaseName = properties["Database"].toString();
+    if (loadFromEnvironment) {
+        _userName = environment.value("DB_PGSQL_USERNAME");
+        _password = environment.value("DB_PGSQL_PASSWORD");
+        _hostName = environment.value("DB_PGSQL_HOSTNAME");
+        _port = environment.value("DB_PGSQL_PORT").toInt();
+        _databaseName = environment.value("DB_PGSQL_DATABASE");
+    } else {
+        _userName = properties["Username"].toString();
+        _password = properties["Password"].toString();
+        _hostName = properties["Hostname"].toString();
+        _port = properties["Port"].toInt();
+        _databaseName = properties["Database"].toString();
+    }
 }
 
 

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1634,6 +1634,8 @@ bool PostgreSqlStorage::logMessage(Message &msg)
     }
 
     QVariantList params;
+    // PostgreSQL handles QDateTime()'s serialized format by default, and QDateTime() serializes
+    // to a 64-bit time compatible format by default.
     params << msg.timestamp()
            << msg.bufferInfo().bufferId().toInt()
            << msg.type()
@@ -1718,6 +1720,8 @@ bool PostgreSqlStorage::logMessages(MessageList &msgs)
     for (int i = 0; i < msgs.count(); i++) {
         Message &msg = msgs[i];
         QVariantList params;
+        // PostgreSQL handles QDateTime()'s serialized format by default, and QDateTime() serializes
+        // to a 64-bit time compatible format by default.
         params << msg.timestamp()
                << msg.bufferInfo().bufferId().toInt()
                << msg.type()
@@ -1797,6 +1801,8 @@ QList<Message> PostgreSqlStorage::requestMsgs(UserId user, BufferId bufferId, Ms
 
     QDateTime timestamp;
     while (query.next()) {
+        // PostgreSQL returns date/time in ISO 8601 format, no 64-bit handling needed
+        // See https://www.postgresql.org/docs/current/static/datatype-datetime.html#DATATYPE-DATETIME-OUTPUT
         timestamp = query.value(1).toDateTime();
         timestamp.setTimeSpec(Qt::UTC);
         Message msg(timestamp,
@@ -1861,6 +1867,8 @@ QList<Message> PostgreSqlStorage::requestMsgsFiltered(UserId user, BufferId buff
 
     QDateTime timestamp;
     while (query.next()) {
+        // PostgreSQL returns date/time in ISO 8601 format, no 64-bit handling needed
+        // See https://www.postgresql.org/docs/current/static/datatype-datetime.html#DATATYPE-DATETIME-OUTPUT
         timestamp = query.value(1).toDateTime();
         timestamp.setTimeSpec(Qt::UTC);
         Message msg(timestamp,
@@ -1916,6 +1924,8 @@ QList<Message> PostgreSqlStorage::requestAllMsgs(UserId user, MsgId first, MsgId
 
     QDateTime timestamp;
     for (int i = 0; i < limit && query.next(); i++) {
+        // PostgreSQL returns date/time in ISO 8601 format, no 64-bit handling needed
+        // See https://www.postgresql.org/docs/current/static/datatype-datetime.html#DATATYPE-DATETIME-OUTPUT
         timestamp = query.value(2).toDateTime();
         timestamp.setTimeSpec(Qt::UTC);
         Message msg(timestamp,
@@ -1978,6 +1988,8 @@ QList<Message> PostgreSqlStorage::requestAllMsgsFiltered(UserId user, MsgId firs
 
     QDateTime timestamp;
     for (int i = 0; i < limit && query.next(); i++) {
+        // PostgreSQL returns date/time in ISO 8601 format, no 64-bit handling needed
+        // See https://www.postgresql.org/docs/current/static/datatype-datetime.html#DATATYPE-DATETIME-OUTPUT
         timestamp = query.value(2).toDateTime();
         timestamp.setTimeSpec(Qt::UTC);
         Message msg(timestamp,

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1801,13 +1801,13 @@ QList<Message> PostgreSqlStorage::requestMsgs(UserId user, BufferId bufferId, Ms
         timestamp.setTimeSpec(Qt::UTC);
         Message msg(timestamp,
             bufferInfo,
-            (Message::Type)query.value(2).toUInt(),
+            (Message::Type)query.value(2).toInt(),
             query.value(8).toString(),
             query.value(4).toString(),
             query.value(5).toString(),
             query.value(6).toString(),
             query.value(7).toString(),
-            (Message::Flags)query.value(3).toUInt());
+            (Message::Flags)query.value(3).toInt());
         msg.setMsgId(query.value(0).toLongLong());
         messagelist << msg;
     }
@@ -1865,7 +1865,7 @@ QList<Message> PostgreSqlStorage::requestMsgsFiltered(UserId user, BufferId buff
         timestamp.setTimeSpec(Qt::UTC);
         Message msg(timestamp,
                     bufferInfo,
-                    (Message::Type)query.value(2).toUInt(),
+                    (Message::Type)query.value(2).toInt(),
                     query.value(8).toString(),
                     query.value(4).toString(),
                     query.value(5).toString(),
@@ -1920,13 +1920,13 @@ QList<Message> PostgreSqlStorage::requestAllMsgs(UserId user, MsgId first, MsgId
         timestamp.setTimeSpec(Qt::UTC);
         Message msg(timestamp,
             bufferInfoHash[query.value(1).toInt()],
-            (Message::Type)query.value(3).toUInt(),
+            (Message::Type)query.value(3).toInt(),
             query.value(9).toString(),
             query.value(5).toString(),
             query.value(6).toString(),
             query.value(7).toString(),
             query.value(8).toString(),
-            (Message::Flags)query.value(4).toUInt());
+            (Message::Flags)query.value(4).toInt());
         msg.setMsgId(query.value(0).toLongLong());
         messagelist << msg;
     }
@@ -1982,7 +1982,7 @@ QList<Message> PostgreSqlStorage::requestAllMsgsFiltered(UserId user, MsgId firs
         timestamp.setTimeSpec(Qt::UTC);
         Message msg(timestamp,
                     bufferInfoHash[query.value(1).toInt()],
-                    (Message::Type)query.value(3).toUInt(),
+                    (Message::Type)query.value(3).toInt(),
                     query.value(9).toString(),
                     query.value(5).toString(),
                     query.value(6).toString(),

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -98,6 +98,8 @@ public slots:
     void setBufferActivity(UserId id, BufferId bufferId, Message::Types type) override;
     QHash<BufferId, Message::Types> bufferActivities(UserId id) override;
     Message::Types bufferActivity(BufferId bufferId, MsgId lastSeenMsgId) override;
+    QHash<QString, QByteArray> bufferCiphers(UserId user, const NetworkId &networkId) override;
+    void setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher) override;
 
     /* Message handling */
     bool logMessage(Message &msg) override;

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -108,7 +108,13 @@ public slots:
     bool logMessage(Message &msg) override;
     bool logMessages(MessageList &msgs) override;
     QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) override;
+    QList<Message> requestMsgsFiltered(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1,
+                                       int limit = -1, Message::Types type = Message::Types{-1},
+                                       Message::Flags flags = Message::Flags{-1}) override;
     QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
+    QList<Message> requestAllMsgsFiltered(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1,
+                                          Message::Types type = Message::Types{-1},
+                                          Message::Flags flags = Message::Flags{-1}) override;
 
     /* Sysident handling */
     QMap<UserId, QString> getAllAuthUserNames() override;

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -57,6 +57,8 @@ public slots:
     void delUser(UserId user) override;
     void setUserSetting(UserId userId, const QString &settingName, const QVariant &data) override;
     QVariant getUserSetting(UserId userId, const QString &settingName, const QVariant &defaultData = QVariant()) override;
+    void setCoreState(const QVariantList &data) override;
+    QVariantList getCoreState(const QVariantList &data) override;
 
     /* Identity handling */
     IdentityId createIdentity(UserId user, CoreIdentity &identity) override;
@@ -178,6 +180,7 @@ public:
     bool writeMo(const BacklogMO &backlog) override;
     bool writeMo(const IrcServerMO &ircserver) override;
     bool writeMo(const UserSettingMO &userSetting) override;
+    bool writeMo(const CoreStateMO &coreState) override;
 
     bool prepareQuery(MigrationObject mo) override;
 

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -98,6 +98,9 @@ public slots:
     void setBufferActivity(UserId id, BufferId bufferId, Message::Types type) override;
     QHash<BufferId, Message::Types> bufferActivities(UserId id) override;
     Message::Types bufferActivity(BufferId bufferId, MsgId lastSeenMsgId) override;
+    void setHighlightCount(UserId id, BufferId bufferId, int count) override;
+    QHash<BufferId, int> highlightCounts(UserId id) override;
+    int highlightCount(BufferId bufferId, MsgId lastSeenMsgId) override;
     QHash<QString, QByteArray> bufferCiphers(UserId user, const NetworkId &networkId) override;
     void setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher) override;
 

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -124,7 +124,9 @@ public slots:
 
 protected:
     bool initDbSession(QSqlDatabase &db) override;
-    void setConnectionProperties(const QVariantMap &properties) override;
+    void setConnectionProperties(const QVariantMap &properties,
+                                 const QProcessEnvironment &environment,
+                                 bool loadFromEnvironment) override;
     QString driverName()  override { return "QPSQL"; }
     QString hostName()  override { return _hostName; }
     int port()  override { return _port; }

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -81,6 +81,7 @@
     <file>./SQL/PostgreSQL/setup_110_alter_sender_seq.sql</file>
     <file>./SQL/PostgreSQL/setup_120_alter_messageid_seq.sql</file>
     <file>./SQL/PostgreSQL/setup_130_function_lastmsgid.sql</file>
+    <file>./SQL/PostgreSQL/setup_140_sender_idx.sql</file>
     <file>./SQL/PostgreSQL/update_backlog_bufferid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_bufferactivity.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_cipher.sql</file>
@@ -118,6 +119,10 @@
     <file>./SQL/PostgreSQL/version/24/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
     <file>./SQL/PostgreSQL/version/25/upgrade_000_alter_buffer_add_cipher.sql</file>
     <file>./SQL/PostgreSQL/version/26/upgrade_000_alter_buffer_add_highlightcount.sql</file>
+    <file>./SQL/PostgreSQL/version/27/upgrade_000_update_sender_add_realname.sql</file>
+    <file>./SQL/PostgreSQL/version/27/upgrade_010_update_sender_add_avatarurl.sql</file>
+    <file>./SQL/PostgreSQL/version/27/upgrade_020_update_sender_add_new_constraint.sql</file>
+    <file>./SQL/PostgreSQL/version/27/upgrade_030_upgrade_sender_drop_old_constraint.sql</file>
     <file>./SQL/SQLite/delete_backlog_by_uid.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_buffer.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_network.sql</file>
@@ -201,6 +206,7 @@
     <file>./SQL/SQLite/setup_120_user_setting.sql</file>
     <file>./SQL/SQLite/setup_130_identity.sql</file>
     <file>./SQL/SQLite/setup_140_identity_nick.sql</file>
+    <file>./SQL/SQLite/setup_150_sender_idx.sql</file>
     <file>./SQL/SQLite/update_backlog_bufferid.sql</file>
     <file>./SQL/SQLite/update_buffer_bufferactivity.sql</file>
     <file>./SQL/SQLite/update_buffer_cipher.sql</file>
@@ -311,5 +317,10 @@
     <file>./SQL/SQLite/version/26/upgrade_000_create_buffer_idx.sql</file>
     <file>./SQL/SQLite/version/27/upgrade_000_alter_buffer_add_cipher.sql</file>
     <file>./SQL/SQLite/version/28/upgrade_000_alter_buffer_add_highlightcount.sql</file>
+    <file>./SQL/SQLite/version/29/upgrade_000_create_sender_tmp.sql</file>
+    <file>./SQL/SQLite/version/29/upgrade_010_copy_sender_sender_tmp.sql</file>
+    <file>./SQL/SQLite/version/29/upgrade_020_drop_sender.sql</file>
+    <file>./SQL/SQLite/version/29/upgrade_030_rename_sender_tmp_sender.sql</file>
+    <file>./SQL/SQLite/version/29/upgrade_040_update_sender_add_realname_avatarurl.sql</file>
 </qresource>
 </RCC>

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -52,9 +52,14 @@
     <file>./SQL/PostgreSQL/select_internaluser.sql</file>
     <file>./SQL/PostgreSQL/select_messagesAll.sql</file>
     <file>./SQL/PostgreSQL/select_messagesAllNew.sql</file>
+    <file>./SQL/PostgreSQL/select_messagesAllNew_filtered.sql</file>
+    <file>./SQL/PostgreSQL/select_messagesAll_filtered.sql</file>
     <file>./SQL/PostgreSQL/select_messagesNewerThan.sql</file>
+    <file>./SQL/PostgreSQL/select_messagesNewerThan_filtered.sql</file>
     <file>./SQL/PostgreSQL/select_messagesNewestK.sql</file>
+    <file>./SQL/PostgreSQL/select_messagesNewestK_filtered.sql</file>
     <file>./SQL/PostgreSQL/select_messagesRange.sql</file>
+    <file>./SQL/PostgreSQL/select_messagesRange_filtered.sql</file>
     <file>./SQL/PostgreSQL/select_networkExists.sql</file>
     <file>./SQL/PostgreSQL/select_network_awaymsg.sql</file>
     <file>./SQL/PostgreSQL/select_network_usermode.sql</file>
@@ -176,9 +181,14 @@
     <file>./SQL/SQLite/select_internaluser.sql</file>
     <file>./SQL/SQLite/select_messagesAll.sql</file>
     <file>./SQL/SQLite/select_messagesAllNew.sql</file>
+    <file>./SQL/SQLite/select_messagesAllNew_filtered.sql</file>
+    <file>./SQL/SQLite/select_messagesAll_filtered.sql</file>
     <file>./SQL/SQLite/select_messagesNewerThan.sql</file>
+    <file>./SQL/SQLite/select_messagesNewerThan_filtered.sql</file>
     <file>./SQL/SQLite/select_messagesNewestK.sql</file>
+    <file>./SQL/SQLite/select_messagesNewestK_filtered.sql</file>
     <file>./SQL/SQLite/select_messagesRange.sql</file>
+    <file>./SQL/SQLite/select_messagesRange_filtered.sql</file>
     <file>./SQL/SQLite/select_networkExists.sql</file>
     <file>./SQL/SQLite/select_network_awaymsg.sql</file>
     <file>./SQL/SQLite/select_network_usermode.sql</file>

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -39,6 +39,7 @@
     <file>./SQL/PostgreSQL/select_buffer_bufferactivities.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_bufferactivity.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_by_id.sql</file>
+    <file>./SQL/PostgreSQL/select_buffer_ciphers.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_lastseen_messages.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_markerlinemsgids.sql</file>
     <file>./SQL/PostgreSQL/select_buffers.sql</file>
@@ -80,6 +81,7 @@
     <file>./SQL/PostgreSQL/setup_130_function_lastmsgid.sql</file>
     <file>./SQL/PostgreSQL/update_backlog_bufferid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_bufferactivity.sql</file>
+    <file>./SQL/PostgreSQL/update_buffer_cipher.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_lastseen.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_markerlinemsgid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_name.sql</file>
@@ -111,6 +113,7 @@
     <file>./SQL/PostgreSQL/version/22/upgrade_000_alter_quasseluser_add_authenticator.sql</file>
     <file>./SQL/PostgreSQL/version/23/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/PostgreSQL/version/24/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
+    <file>./SQL/PostgreSQL/version/25/upgrade_000_alter_buffer_add_cipher.sql</file>
     <file>./SQL/SQLite/delete_backlog_by_uid.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_buffer.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_network.sql</file>
@@ -150,6 +153,7 @@
     <file>./SQL/SQLite/select_buffer_bufferactivities.sql</file>
     <file>./SQL/SQLite/select_buffer_bufferactivity.sql</file>
     <file>./SQL/SQLite/select_buffer_by_id.sql</file>
+    <file>./SQL/SQLite/select_buffer_ciphers.sql</file>
     <file>./SQL/SQLite/select_buffer_lastseen_messages.sql</file>
     <file>./SQL/SQLite/select_buffer_markerlinemsgids.sql</file>
     <file>./SQL/SQLite/select_buffers.sql</file>
@@ -193,6 +197,7 @@
     <file>./SQL/SQLite/setup_140_identity_nick.sql</file>
     <file>./SQL/SQLite/update_backlog_bufferid.sql</file>
     <file>./SQL/SQLite/update_buffer_bufferactivity.sql</file>
+    <file>./SQL/SQLite/update_buffer_cipher.sql</file>
     <file>./SQL/SQLite/update_buffer_lastseen.sql</file>
     <file>./SQL/SQLite/update_buffer_markerlinemsgid.sql</file>
     <file>./SQL/SQLite/update_buffer_name.sql</file>
@@ -297,5 +302,6 @@
     <file>./SQL/SQLite/version/24/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/SQLite/version/25/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
     <file>./SQL/SQLite/version/26/upgrade_000_create_buffer_idx.sql</file>
+    <file>./SQL/SQLite/version/27/upgrade_000_alter_buffer_add_cipher.sql</file>
 </qresource>
 </RCC>

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -40,6 +40,8 @@
     <file>./SQL/PostgreSQL/select_buffer_bufferactivity.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_by_id.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_ciphers.sql</file>
+    <file>./SQL/PostgreSQL/select_buffer_highlightcount.sql</file>
+    <file>./SQL/PostgreSQL/select_buffer_highlightcounts.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_lastseen_messages.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_markerlinemsgids.sql</file>
     <file>./SQL/PostgreSQL/select_buffers.sql</file>
@@ -82,6 +84,7 @@
     <file>./SQL/PostgreSQL/update_backlog_bufferid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_bufferactivity.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_cipher.sql</file>
+    <file>./SQL/PostgreSQL/update_buffer_highlightcount.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_lastseen.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_markerlinemsgid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_name.sql</file>
@@ -114,6 +117,7 @@
     <file>./SQL/PostgreSQL/version/23/upgrade_000_create_senderprefixes.sql</file>
     <file>./SQL/PostgreSQL/version/24/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
     <file>./SQL/PostgreSQL/version/25/upgrade_000_alter_buffer_add_cipher.sql</file>
+    <file>./SQL/PostgreSQL/version/26/upgrade_000_alter_buffer_add_highlightcount.sql</file>
     <file>./SQL/SQLite/delete_backlog_by_uid.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_buffer.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_network.sql</file>
@@ -154,6 +158,8 @@
     <file>./SQL/SQLite/select_buffer_bufferactivity.sql</file>
     <file>./SQL/SQLite/select_buffer_by_id.sql</file>
     <file>./SQL/SQLite/select_buffer_ciphers.sql</file>
+    <file>./SQL/SQLite/select_buffer_highlightcount.sql</file>
+    <file>./SQL/SQLite/select_buffer_highlightcounts.sql</file>
     <file>./SQL/SQLite/select_buffer_lastseen_messages.sql</file>
     <file>./SQL/SQLite/select_buffer_markerlinemsgids.sql</file>
     <file>./SQL/SQLite/select_buffers.sql</file>
@@ -198,6 +204,7 @@
     <file>./SQL/SQLite/update_backlog_bufferid.sql</file>
     <file>./SQL/SQLite/update_buffer_bufferactivity.sql</file>
     <file>./SQL/SQLite/update_buffer_cipher.sql</file>
+    <file>./SQL/SQLite/update_buffer_highlightcount.sql</file>
     <file>./SQL/SQLite/update_buffer_lastseen.sql</file>
     <file>./SQL/SQLite/update_buffer_markerlinemsgid.sql</file>
     <file>./SQL/SQLite/update_buffer_name.sql</file>
@@ -303,5 +310,6 @@
     <file>./SQL/SQLite/version/25/upgrade_000_alter_buffer_add_bufferactivity.sql</file>
     <file>./SQL/SQLite/version/26/upgrade_000_create_buffer_idx.sql</file>
     <file>./SQL/SQLite/version/27/upgrade_000_alter_buffer_add_cipher.sql</file>
+    <file>./SQL/SQLite/version/28/upgrade_000_alter_buffer_add_highlightcount.sql</file>
 </qresource>
 </RCC>

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -13,6 +13,7 @@
     <file>./SQL/PostgreSQL/delete_nicks.sql</file>
     <file>./SQL/PostgreSQL/delete_quasseluser.sql</file>
     <file>./SQL/PostgreSQL/insert_buffer.sql</file>
+    <file>./SQL/PostgreSQL/insert_core_state.sql</file>
     <file>./SQL/PostgreSQL/insert_identity.sql</file>
     <file>./SQL/PostgreSQL/insert_message.sql</file>
     <file>./SQL/PostgreSQL/insert_network.sql</file>
@@ -23,6 +24,7 @@
     <file>./SQL/PostgreSQL/insert_user_setting.sql</file>
     <file>./SQL/PostgreSQL/migrate_write_backlog.sql</file>
     <file>./SQL/PostgreSQL/migrate_write_buffer.sql</file>
+    <file>./SQL/PostgreSQL/migrate_write_corestate.sql</file>
     <file>./SQL/PostgreSQL/migrate_write_identity.sql</file>
     <file>./SQL/PostgreSQL/migrate_write_identity_nick.sql</file>
     <file>./SQL/PostgreSQL/migrate_write_ircserver.sql</file>
@@ -48,6 +50,7 @@
     <file>./SQL/PostgreSQL/select_buffers_for_network.sql</file>
     <file>./SQL/PostgreSQL/select_checkidentity.sql</file>
     <file>./SQL/PostgreSQL/select_connected_networks.sql</file>
+    <file>./SQL/PostgreSQL/select_core_state.sql</file>
     <file>./SQL/PostgreSQL/select_identities.sql</file>
     <file>./SQL/PostgreSQL/select_internaluser.sql</file>
     <file>./SQL/PostgreSQL/select_messagesAll.sql</file>
@@ -87,6 +90,7 @@
     <file>./SQL/PostgreSQL/setup_120_alter_messageid_seq.sql</file>
     <file>./SQL/PostgreSQL/setup_130_function_lastmsgid.sql</file>
     <file>./SQL/PostgreSQL/setup_140_sender_idx.sql</file>
+    <file>./SQL/PostgreSQL/setup_150_corestate.sql</file>
     <file>./SQL/PostgreSQL/update_backlog_bufferid.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_bufferactivity.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_cipher.sql</file>
@@ -96,6 +100,7 @@
     <file>./SQL/PostgreSQL/update_buffer_name.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_persistent_channel.sql</file>
     <file>./SQL/PostgreSQL/update_buffer_set_channel_key.sql</file>
+    <file>./SQL/PostgreSQL/update_core_state.sql</file>
     <file>./SQL/PostgreSQL/update_identity.sql</file>
     <file>./SQL/PostgreSQL/update_network.sql</file>
     <file>./SQL/PostgreSQL/update_network_connected.sql</file>
@@ -128,6 +133,7 @@
     <file>./SQL/PostgreSQL/version/27/upgrade_010_update_sender_add_avatarurl.sql</file>
     <file>./SQL/PostgreSQL/version/27/upgrade_020_update_sender_add_new_constraint.sql</file>
     <file>./SQL/PostgreSQL/version/27/upgrade_030_upgrade_sender_drop_old_constraint.sql</file>
+    <file>./SQL/PostgreSQL/version/28/upgrade_000_create_corestate.sql</file>
     <file>./SQL/SQLite/delete_backlog_by_uid.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_buffer.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_network.sql</file>
@@ -141,6 +147,7 @@
     <file>./SQL/SQLite/delete_nicks.sql</file>
     <file>./SQL/SQLite/delete_quasseluser.sql</file>
     <file>./SQL/SQLite/insert_buffer.sql</file>
+    <file>./SQL/SQLite/insert_core_state.sql</file>
     <file>./SQL/SQLite/insert_identity.sql</file>
     <file>./SQL/SQLite/insert_message.sql</file>
     <file>./SQL/SQLite/insert_network.sql</file>
@@ -151,6 +158,7 @@
     <file>./SQL/SQLite/insert_user_setting.sql</file>
     <file>./SQL/SQLite/migrate_read_backlog.sql</file>
     <file>./SQL/SQLite/migrate_read_buffer.sql</file>
+    <file>./SQL/SQLite/migrate_read_corestate.sql</file>
     <file>./SQL/SQLite/migrate_read_identity.sql</file>
     <file>./SQL/SQLite/migrate_read_identity_nick.sql</file>
     <file>./SQL/SQLite/migrate_read_ircserver.sql</file>
@@ -177,6 +185,7 @@
     <file>./SQL/SQLite/select_buffers_for_network.sql</file>
     <file>./SQL/SQLite/select_checkidentity.sql</file>
     <file>./SQL/SQLite/select_connected_networks.sql</file>
+    <file>./SQL/SQLite/select_core_state.sql</file>
     <file>./SQL/SQLite/select_identities.sql</file>
     <file>./SQL/SQLite/select_internaluser.sql</file>
     <file>./SQL/SQLite/select_messagesAll.sql</file>
@@ -217,6 +226,7 @@
     <file>./SQL/SQLite/setup_130_identity.sql</file>
     <file>./SQL/SQLite/setup_140_identity_nick.sql</file>
     <file>./SQL/SQLite/setup_150_sender_idx.sql</file>
+    <file>./SQL/SQLite/setup_160_corestate.sql</file>
     <file>./SQL/SQLite/update_backlog_bufferid.sql</file>
     <file>./SQL/SQLite/update_buffer_bufferactivity.sql</file>
     <file>./SQL/SQLite/update_buffer_cipher.sql</file>
@@ -226,6 +236,7 @@
     <file>./SQL/SQLite/update_buffer_name.sql</file>
     <file>./SQL/SQLite/update_buffer_persistent_channel.sql</file>
     <file>./SQL/SQLite/update_buffer_set_channel_key.sql</file>
+    <file>./SQL/SQLite/update_core_state.sql</file>
     <file>./SQL/SQLite/update_identity.sql</file>
     <file>./SQL/SQLite/update_network.sql</file>
     <file>./SQL/SQLite/update_network_connected.sql</file>
@@ -332,5 +343,6 @@
     <file>./SQL/SQLite/version/29/upgrade_020_drop_sender.sql</file>
     <file>./SQL/SQLite/version/29/upgrade_030_rename_sender_tmp_sender.sql</file>
     <file>./SQL/SQLite/version/29/upgrade_040_update_sender_add_realname_avatarurl.sql</file>
+    <file>./SQL/SQLite/version/30/upgrade_000_create_corestate.sql</file>
 </qresource>
 </RCC>

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -347,5 +347,6 @@
     <file>./SQL/SQLite/version/29/upgrade_030_rename_sender_tmp_sender.sql</file>
     <file>./SQL/SQLite/version/29/upgrade_040_update_sender_add_realname_avatarurl.sql</file>
     <file>./SQL/SQLite/version/30/upgrade_000_create_corestate.sql</file>
+    <file>./SQL/SQLite/version/31/upgrade_000_update_buffer_set_time_extended.sql</file>
 </qresource>
 </RCC>

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -134,6 +134,9 @@
     <file>./SQL/PostgreSQL/version/27/upgrade_020_update_sender_add_new_constraint.sql</file>
     <file>./SQL/PostgreSQL/version/27/upgrade_030_upgrade_sender_drop_old_constraint.sql</file>
     <file>./SQL/PostgreSQL/version/28/upgrade_000_create_corestate.sql</file>
+    <file>./SQL/PostgreSQL/version/29/upgrade_010_alter_sender_64bit_ids.sql</file>
+    <file>./SQL/PostgreSQL/version/29/upgrade_050_alter_buffer_64bit_ids.sql</file>
+    <file>./SQL/PostgreSQL/version/29/upgrade_060_alter_backlog_64bit_ids.sql</file>
     <file>./SQL/SQLite/delete_backlog_by_uid.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_buffer.sql</file>
     <file>./SQL/SQLite/delete_backlog_for_network.sql</file>

--- a/src/core/sqlauthenticator.cpp
+++ b/src/core/sqlauthenticator.cpp
@@ -72,16 +72,23 @@ UserId SqlAuthenticator::validateUser(const QString &user, const QString &passwo
 }
 
 
-bool SqlAuthenticator::setup(const QVariantMap &settings)
+bool SqlAuthenticator::setup(const QVariantMap &settings, const QProcessEnvironment &environment,
+                             bool loadFromEnvironment)
 {
     Q_UNUSED(settings)
+    Q_UNUSED(environment)
+    Q_UNUSED(loadFromEnvironment)
     return true;
 }
 
 
-Authenticator::State SqlAuthenticator::init(const QVariantMap &settings)
+Authenticator::State SqlAuthenticator::init(const QVariantMap &settings,
+                                            const QProcessEnvironment &environment,
+                                            bool loadFromEnvironment)
 {
     Q_UNUSED(settings)
+    Q_UNUSED(environment)
+    Q_UNUSED(loadFromEnvironment)
 
     // TODO: FIXME: this should check if the storage provider is ready, but I don't
     // know if there's an exposed way to do that at the moment.

--- a/src/core/sqlauthenticator.h
+++ b/src/core/sqlauthenticator.h
@@ -40,8 +40,10 @@ public slots:
 
     virtual inline bool canChangePassword() const { return true; }
 
-    bool setup(const QVariantMap &settings = QVariantMap());
-    State init(const QVariantMap &settings = QVariantMap());
+    bool setup(const QVariantMap &settings, const QProcessEnvironment &environment,
+               bool loadFromEnvironment);
+    State init(const QVariantMap &settings, const QProcessEnvironment &environment,
+               bool loadFromEnvironment);
     UserId validateUser(const QString &user, const QString &password);
 
     /* User handling */

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1708,6 +1708,8 @@ bool SqliteStorage::logMessage(Message &msg)
         logMessageQuery.bindValue(":type", msg.type());
         logMessageQuery.bindValue(":flags", (int)msg.flags());
         logMessageQuery.bindValue(":sender", msg.sender());
+        logMessageQuery.bindValue(":realname", msg.realName());
+        logMessageQuery.bindValue(":avatarurl", msg.avatarUrl());
         logMessageQuery.bindValue(":senderprefixes", msg.senderPrefixes());
         logMessageQuery.bindValue(":message", msg.contents());
 
@@ -1789,6 +1791,8 @@ bool SqliteStorage::logMessages(MessageList &msgs)
             logMessageQuery.bindValue(":type", msg.type());
             logMessageQuery.bindValue(":flags", (int)msg.flags());
             logMessageQuery.bindValue(":sender", msg.sender());
+            logMessageQuery.bindValue(":realname", msg.realName());
+            logMessageQuery.bindValue(":avatarurl", msg.avatarUrl());
             logMessageQuery.bindValue(":senderprefixes", msg.senderPrefixes());
             logMessageQuery.bindValue(":message", msg.contents());
 

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1931,13 +1931,13 @@ QList<Message> SqliteStorage::requestMsgs(UserId user, BufferId bufferId, MsgId 
         while (query.next()) {
             Message msg(QDateTime::fromTime_t(query.value(1).toInt()),
                 bufferInfo,
-                (Message::Type)query.value(2).toUInt(),
+                (Message::Type)query.value(2).toInt(),
                 query.value(8).toString(),
                 query.value(4).toString(),
                 query.value(5).toString(),
                 query.value(6).toString(),
                 query.value(7).toString(),
-                (Message::Flags)query.value(3).toUInt());
+                (Message::Flags)query.value(3).toInt());
             msg.setMsgId(query.value(0).toLongLong());
             messagelist << msg;
         }
@@ -2007,7 +2007,7 @@ QList<Message> SqliteStorage::requestMsgsFiltered(UserId user, BufferId bufferId
         while (query.next()) {
             Message msg(QDateTime::fromTime_t(query.value(1).toInt()),
                         bufferInfo,
-                        (Message::Type)query.value(2).toUInt(),
+                        (Message::Type)query.value(2).toInt(),
                         query.value(8).toString(),
                         query.value(4).toString(),
                         query.value(5).toString(),
@@ -2064,13 +2064,13 @@ QList<Message> SqliteStorage::requestAllMsgs(UserId user, MsgId first, MsgId las
         while (query.next()) {
             Message msg(QDateTime::fromTime_t(query.value(2).toInt()),
                 bufferInfoHash[query.value(1).toInt()],
-                (Message::Type)query.value(3).toUInt(),
+                (Message::Type)query.value(3).toInt(),
                 query.value(9).toString(),
                 query.value(5).toString(),
                 query.value(6).toString(),
                 query.value(7).toString(),
                 query.value(8).toString(),
-                (Message::Flags)query.value(4).toUInt());
+                (Message::Flags)query.value(4).toInt());
             msg.setMsgId(query.value(0).toLongLong());
             messagelist << msg;
         }
@@ -2123,7 +2123,7 @@ QList<Message> SqliteStorage::requestAllMsgsFiltered(UserId user, MsgId first, M
         while (query.next()) {
             Message msg(QDateTime::fromTime_t(query.value(2).toInt()),
                         bufferInfoHash[query.value(1).toInt()],
-                        (Message::Type)query.value(3).toUInt(),
+                        (Message::Type)query.value(3).toInt(),
                         query.value(9).toString(),
                         query.value(5).toString(),
                         query.value(6).toString(),

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -2427,7 +2427,7 @@ bool SqliteMigrationReader::readMo(SenderMO &sender)
 
 bool SqliteMigrationReader::readMo(BacklogMO &backlog)
 {
-    int skipSteps = 0;
+    qint64 skipSteps = 0;
     while (!next()) {
         if (backlog.messageid < _maxId) {
             bindValue(0, backlog.messageid.toQint64() + (skipSteps * stepSize()));

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -184,7 +184,7 @@ protected:
 
 private:
     void setMaxId(MigrationObject mo);
-    int _maxId;
+    qint64 _maxId;
 };
 
 

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -124,7 +124,14 @@ public slots:
     QString getAuthUserName(UserId user) override;
 
 protected:
-    void setConnectionProperties(const QVariantMap & /* properties */)  override {}
+    void setConnectionProperties(const QVariantMap &properties,
+                                 const QProcessEnvironment &environment,
+                                 bool loadFromEnvironment) override {
+        Q_UNUSED(properties);
+        Q_UNUSED(environment);
+        Q_UNUSED(loadFromEnvironment);
+    }
+    // SQLite does not have any connection properties to set
     QString driverName()  override { return "QSQLITE"; }
     QString databaseName()  override { return backlogFile(); }
     int installedSchemaVersion() override;

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -58,6 +58,8 @@ public slots:
     void delUser(UserId user) override;
     void setUserSetting(UserId userId, const QString &settingName, const QVariant &data) override;
     QVariant getUserSetting(UserId userId, const QString &settingName, const QVariant &defaultData = QVariant()) override;
+    void setCoreState(const QVariantList &data) override;
+    QVariantList getCoreState(const QVariantList &data) override;
 
     /* Identity handling */
     IdentityId createIdentity(UserId user, CoreIdentity &identity) override;
@@ -162,6 +164,7 @@ public:
     bool readMo(BacklogMO &backlog) override;
     bool readMo(IrcServerMO &ircserver) override;
     bool readMo(UserSettingMO &userSetting) override;
+    bool readMo(CoreStateMO &coreState) override;
 
     bool prepareQuery(MigrationObject mo) override;
 

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -99,6 +99,8 @@ public slots:
     void setBufferActivity(UserId id, BufferId bufferId, Message::Types type) override;
     QHash<BufferId, Message::Types> bufferActivities(UserId id) override;
     Message::Types bufferActivity(BufferId bufferId, MsgId lastSeenMsgId) override;
+    QHash<QString, QByteArray> bufferCiphers(UserId user, const NetworkId &networkId) override;
+    void setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher) override;
 
     /* Message handling */
     bool logMessage(Message &msg) override;

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -99,6 +99,9 @@ public slots:
     void setBufferActivity(UserId id, BufferId bufferId, Message::Types type) override;
     QHash<BufferId, Message::Types> bufferActivities(UserId id) override;
     Message::Types bufferActivity(BufferId bufferId, MsgId lastSeenMsgId) override;
+    void setHighlightCount(UserId id, BufferId bufferId, int count) override;
+    QHash<BufferId, int> highlightCounts(UserId id) override;
+    int highlightCount(BufferId bufferId, MsgId lastSeenMsgId) override;
     QHash<QString, QByteArray> bufferCiphers(UserId user, const NetworkId &networkId) override;
     void setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher) override;
 

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -109,7 +109,13 @@ public slots:
     bool logMessage(Message &msg) override;
     bool logMessages(MessageList &msgs) override;
     QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) override;
+    QList<Message> requestMsgsFiltered(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1,
+                                       int limit = -1, Message::Types type = Message::Types{-1},
+                                       Message::Flags flags = Message::Flags{-1}) override;
     QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
+    QList<Message> requestAllMsgsFiltered(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1,
+                                          Message::Types type = Message::Types{-1},
+                                          Message::Flags flags = Message::Flags{-1}) override;
 
     /* Sysident handling */
     QMap<UserId, QString> getAllAuthUserNames() override;

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -175,7 +175,7 @@ public:
 
     bool prepareQuery(MigrationObject mo) override;
 
-    int stepSize() { return 50000; }
+    qint64 stepSize() { return 50000; }
 
 protected:
     bool transaction()  override { return logDb().transaction(); }

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -411,6 +411,25 @@ public slots:
      */
     virtual Message::Types bufferActivity(BufferId bufferId, MsgId lastSeenMsgId) = 0;
 
+    //! Get a hash of buffers with their ciphers for a given network
+    /** The keys are channel names and values are ciphers (possibly empty)
+     *  \note This method is threadsafe
+     *
+     *  \param user       The id of the networks owner
+     *  \param networkId  The Id of the network
+     */
+    virtual QHash<QString, QByteArray> bufferCiphers(UserId user, const NetworkId &networkId) = 0;
+
+    //! Update the cipher of a buffer
+    /** \note This method is threadsafe
+     *
+     *  \param user        The Id of the networks owner
+     *  \param networkId   The Id of the network
+     *  \param bufferName The Cname of the buffer
+     *  \param cipher      The cipher for the buffer
+     */
+    virtual void setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher) = 0;
+
     /* Message handling */
 
     //! Store a Message in the storage backend and set its unique Id.

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -85,13 +85,17 @@ public slots:
      *  \param settings   Hostname, port, username, password, ...
      *  \return True if and only if the storage provider was initialized successfully.
      */
-    virtual bool setup(const QVariantMap &settings = QVariantMap()) = 0;
+    virtual bool setup(const QVariantMap &settings = QVariantMap(),
+                       const QProcessEnvironment &environment = {},
+                       bool loadFromEnvironment = false) = 0;
 
     //! Initialize the storage provider
     /** \param settings   Hostname, port, username, password, ...
      *  \return the State the storage backend is now in (see Storage::State)
      */
-    virtual State init(const QVariantMap &settings = QVariantMap()) = 0;
+    virtual State init(const QVariantMap &settings = QVariantMap(),
+                       const QProcessEnvironment &environment = {},
+                       bool loadFromEnvironment = false) = 0;
 
     //! Makes temp data persistent
     /** This Method is periodically called by the Quassel Core to make temporary

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -480,6 +480,18 @@ public slots:
      */
     virtual QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) = 0;
 
+    //! Request a certain number messages stored in a given buffer, matching certain filters
+    /** \param buffer   The buffer we request messages from
+     *  \param first    if != -1 return only messages with a MsgId >= first
+     *  \param last     if != -1 return only messages with a MsgId < last
+     *  \param limit    if != -1 limit the returned list to a max of \limit entries
+     *  \param type     The Message::Types that should be returned
+     *  \return The requested list of messages
+     */
+    virtual QList<Message> requestMsgsFiltered(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1,
+                                               int limit = -1, Message::Types type = Message::Types{-1},
+                                               Message::Flags flags = Message::Flags{-1}) = 0;
+
     //! Request a certain number of messages across all buffers
     /** \param first    if != -1 return only messages with a MsgId >= first
      *  \param last     if != -1 return only messages with a MsgId < last
@@ -487,6 +499,17 @@ public slots:
      *  \return The requested list of messages
      */
     virtual QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) = 0;
+
+    //! Request a certain number of messages across all buffers, matching certain filters
+    /** \param first    if != -1 return only messages with a MsgId >= first
+     *  \param last     if != -1 return only messages with a MsgId < last
+     *  \param limit    Max amount of messages
+     *  \param type     The Message::Types that should be returned
+     *  \return The requested list of messages
+     */
+    virtual QList<Message> requestAllMsgsFiltered(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1,
+                                                  Message::Types type = Message::Types{-1},
+                                                  Message::Flags flags = Message::Flags{-1}) = 0;
 
     //! Fetch all authusernames
     /** \return      Map of all current UserIds to permitted idents

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -430,6 +430,33 @@ public slots:
      */
     virtual void setBufferCipher(UserId user, const NetworkId &networkId, const QString &bufferName, const QByteArray &cipher) = 0;
 
+    //! Update the highlight count for a Buffer
+    /** This Method is used to make the activity state of a Buffer persistent
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of that Buffer
+     * \param bufferId  The buffer id
+     * \param MsgId     The Message id where the marker line should be placed
+     */
+    virtual void setHighlightCount(UserId id, BufferId bufferId, int count) = 0;
+
+    //! Get a Hash of all highlight count states
+    /** This Method is called when the Quassel Core is started to restore the HighlightCounts
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of the buffers
+     */
+    virtual QHash<BufferId, int> highlightCounts(UserId id) = 0;
+
+    //! Get the highlight count states for a buffer
+    /** This method is used to load the activity state of a buffer when its last seen message changes.
+     *  \note This method is threadsafe.
+     *
+     * \param bufferId The buffer
+     * \param lastSeenMsgId     The last seen message
+     */
+    virtual int highlightCount(BufferId bufferId, MsgId lastSeenMsgId) = 0;
+
     /* Message handling */
 
     //! Store a Message in the storage backend and set its unique Id.

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -171,6 +171,19 @@ public slots:
      */
     virtual QVariant getUserSetting(UserId userId, const QString &settingName, const QVariant &data = QVariant()) = 0;
 
+    //! Store core state
+    /**
+     * \param data         Active Sessions
+     */
+    virtual void setCoreState(const QVariantList &data) = 0;
+
+    //! Retrieve core state
+    /**
+     * \param default      Value to return in case it's unset.
+     * \return Active Sessions
+     */
+    virtual QVariantList getCoreState(const QVariantList &data = QVariantList()) = 0;
+
     /* Identity handling */
     virtual IdentityId createIdentity(UserId user, CoreIdentity &identity) = 0;
     virtual bool updateIdentity(UserId user, const CoreIdentity &identity) = 0;

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -245,7 +245,7 @@ void ChatItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
 //   }
 // 2) draw MsgId over the time column
 //   if(column() == 0) {
-//     QString msgIdString = QString::number(data(MessageModel::MsgIdRole).value<MsgId>().toInt());
+//     QString msgIdString = QString::number(data(MessageModel::MsgIdRole).value<MsgId>().toLongLong());
 //     QPointF bottomPoint = boundingRect().bottomLeft();
 //     bottomPoint.ry() -= 2;
 //     painter->drawText(bottomPoint, msgIdString);

--- a/src/qtui/chatlinemodelitem.cpp
+++ b/src/qtui/chatlinemodelitem.cpp
@@ -65,7 +65,7 @@ bool ChatLineModelItem::setData(int column, const QVariant &value, int role)
 {
     switch (role) {
     case MessageModel::FlagsRole:
-        _styledMsg.setFlags((Message::Flags)value.toUInt());
+        _styledMsg.setFlags((Message::Flags)value.toInt());
         return true;
     default:
         return MessageModelItem::setData(column, value, role);


### PR DESCRIPTION
## In short

* **A:** Persist Blowfish keys in the database, [pull request #332](https://github.com/quassel/quassel/pull/332 )
  * Keeps encrypted chats working after core restart/etc
  * Modernizing Quassel's encryption is for a later pull request
* **B:** Store highlight status per buffer coreside, [pull request #333](https://github.com/quassel/quassel/pull/333 )
  * Feature `BufferActivitySync`, see if buffer has highlights without fetching backlog!
  * Needed by QuasselDroid to improve notification handling
* **C:** Avoid Y2038 problem, [pull request #340](https://github.com/quassel/quassel/pull/340 )
  * Implement 64-bit message timestamps, guard protocol behind feature `LongMessageTime`
  * Older clients will work until year 2038
* **D:** Implement sender realname/avatarurl storage, [pull request #351](https://github.com/quassel/quassel/pull/351 )
  * Store sender `realname` and `avatarurl`, guard protocol behind feature `RichMessages`
  * Avatar URLs not stored yet, needs IRCv3 `METADATA`
  * Needed by QuasselDroid for display name and fallback avatar loading
* **E:** Support core-side filtering of backlog by type, [pull request #339](https://github.com/quassel/quassel/pull/339 )
  * Feature `BacklogFilterType`, allows fetching only messages of a type, e.g. if filtering join/part/quit
  * Needed by QuasselDroid for better backlog fetching performance
* **F:** Improve containerization, [pull request #341](https://github.com/quassel/quassel/pull/341 )
  * Move core state to database, allow reading configuration from environment variables
  * Allows disregarding the configuration file entirely
* **G:** Use 64-bit IDs for messages, [pull request #343](https://github.com/quassel/quassel/pull/343 )
  * Allows many more total messages, e.g. for shared cores
  * Guard protocol behind feature `LongMessageId`, old clients still work
* Cleanups
  * PRs modified to merge, fixed bugs, etc
  * Fix remaining use of 32-bit time, hopefully solving all Y2038 bugs
  * Rename `LongMessageTime` to `LongTime` due to other protocol changes
  * Change `Message::Flags`/`Type` cast to `Int`, not `UInt`
* Modify SQLite to store to milliseconds, not seconds
  * Modify all backlog, setting `time = time * 1000`
  * **This may take a long time, mention upgrade delay in release notes**
  * Modify schema upgrade message, adding `This may take a while for major upgrades.`
  * Monolithic will show client UI and appear to do nothing while upgrading

*Nearly all of the work done by @mamarley and @justjanne, this just represents coordinating merging the pull requests and fixing up migration/style/etc.*

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | User-facing changes and features, server hosting features
Risk | ★★★ *3/3* | Many moving parts, database and protocol changes
Intrusiveness | ★★★ *3/3* | Changes all over the code base, database changes

*This might be the first triple-3 pull request.. granted, it's a roll-up so that's expected, but I still find it amusing.*

## Rationale
*Please see the individual pull requests linked in the introduction.*

## Examples
*Please see the individual pull requests linked in the introduction.*

## Testing
---

# Overview - 2018-5-13
## Summary
* **All tests pass!**
* 64-bit time/message IDs will cause non-crashing oddness when no longer castable to 32-bit values
  * Can't really be avoided
* SQLite inserts duplicate senders in `SqliteStorage::logMessages()`
  * Issue existed before this PR, notes on ways to fix mentioned below
* Some oddities with core-side highlights, existed before this PR
* Windows builds do not have QCA, disabling `/keyx`
* `0.13` detects LegacyFeatures (`0.12.5`) but still warns they are missing
  * Issue existed before this PR
* On first setup, `Nick list` is hidden
  * Issue existed before this PR, looking into it

## Steps for a successful test
### Initial setup
1.  Initialize Quassel core (*completing first run wizard*)
2.  Verify first setup intact
    * Network shows, connects, joins expected channel
3.  Setup additional tests
    * **A, blowfish keys:** `/keyx` with other test Quassel user (*this user stays for duration of test*)
    * **B, highlight sync:** Until [highlight polish PR](https://github.com/quassel/quassel/pull/336 ) is merged, disable Local nick highlight, enable for Remote
    * **B, highlight sync:** Join `#quassel-test-highlight`, switch away, highlight this user via other user
    * **F, core state:** Add additional network, connect then disconnect
    * **E, filter backlog:** *For new client, new core*, join `#quassel-test-fetch`, [via QuasselDroid beta][qd-ng] filter join/part/quit, generate messages/activity via other user
    * **C+G, 64-bit:** *For new client, new core*, stop core, insert **64-bit test content** (*e.g. `MARKER_MSG`*)
4.  Continue with **Regular tests**

### Upgrade/migrate core setup
1.  Do the **Initial setup** with older/SQLite core
2.  Do the **Regular tests** with older/SQLite core
    * Mark as successful when passed, come back here
3.  Upgrade the core/migrate to PostgreSQL
    * Before migration (*not upgrades*), add in the **64-bit test content**
4.  Repeat **Regular tests**, skipping to after *Restart the core*

### Regular tests
1.  Verify behavior
    * **Basics:** Send message, receive message
    * **B, highlight sync:** Check that highlight status set in `#quassel-test-highlight`, make sure it's clearable, switch away and cause nick highlight again (*for next test*)
    * **C+G, 64-bit:** *For new client, new core*, check test message date, `Debug Message Model` shows ID
    * **D, sender data:** *For new client, new core*, [via QuasselDroid beta][qd-ng], check realname shows
    * **E, filter backlog:** *For new client, new core*, [via QuasselDroid beta][qd-ng] check `#quassel-test-fetch` backlog fetching works
2.  Restart the core
3.  Verify everything intact
    * **Basics:** Backlog loads
    * **A, blowfish keys:** *For new core,* Encrypted chat continues to work, `/showkey` shows a key
    * **B, highlight sync:** Highlight status shows in `#quassel-test-highlight`
    * **F, core state:** Networks correctly connect/stay disconnected as before restart
    * **D, sender data:** *For new client, new core, Linux-only*, check that sender table is reasonable: has needed entries, no duplicates
4.  **C+G, 64-bit:** *For old client, new core, Linux-only*, do the **Failure expected old client tests**

### Failure expected old client tests
*These tests are merely to document what happens with an older client connecting to newer core that has untranslatable differences, e.g. new messages making use of 64-bit IDs.*
1.  Setup additional tests expected to fail
    * **C+G, 64-bit:** Insert **64-bit test content**
2.  Reconnect old client, see what happens

### Teardown when test run completed
1.  Clear any set encryption keys for other test Quassel user, `/delkey nickname`

### 64-bit test content
**SQLite**
*Manual method*
```sql
INSERT INTO backlog (messageid, time, bufferid, type, flags, senderid, senderprefixes, message)
VALUES (5000000000, 5000000000000, [Known Buffer ID], 1, 1, [Known Sender ID], '', 'Test 64-bit message');
```

*Alternatively, send one message with the text `MARKER_MSG` and make sure no other of that message exist...*
```sql
INSERT INTO backlog (messageid, time, bufferid, type, flags, senderid, senderprefixes, message)
VALUES (5000000000, 5000000000000, (SELECT bufferid FROM backlog WHERE message = 'MARKER_MSG'), 1, 1, (SELECT senderid FROM backlog WHERE message = 'MARKER_MSG'), '', 'Test 64-bit message');
```

**PostgreSQL**
*Manual method*
```sql
INSERT INTO backlog (messageid, time, bufferid, type, flags, senderid, senderprefixes, message)
VALUES (5000000000, to_timestamp(5000000000000 / 1000), [Known Buffer ID], 1, 1, [Known Sender ID], '', 'Test 64-bit message');
ALTER SEQUENCE backlog_messageid_seq RESTART WITH 5000000001;
```

*Alternatively, send one message with the text `MARKER_MSG` and make sure no other of that message exist...*
```sql
INSERT INTO backlog (messageid, time, bufferid, type, flags, senderid, senderprefixes, message)
VALUES (5000000000, to_timestamp(5000000000000 / 1000), (SELECT bufferid FROM backlog WHERE message = 'MARKER_MSG'), 1, 1, (SELECT senderid FROM backlog WHERE message = 'MARKER_MSG'), '', 'Test 64-bit message');
ALTER SEQUENCE backlog_messageid_seq RESTART WITH 5000000001;
```

## Notes
* Older clients will show wrong dates and message IDs on newer cores that have messages/timestamps with values above what 32-bits can store - this cannot easily be avoided
  * Message ID `5000000000` becomes `705032704`, timestamp of `5000000000` seconds becomes `February 7, 2106` (*correct is `June 11, 2128`*)
  * Basic functionality still appears to work, though this wasn't tested with `faketime`
* [`SqliteStorage::logMessages()` needlessly inserts duplicates, not checking if senders exist](https://github.com/quassel/quassel/blob/fa3449061f17d7e8db1387f0758fd052f22f4c3b/src/core/sqlitestorage.cpp#L1637-L1697 )
  * This issue existed before this pull request and can be fixed separately
  * [`PostgreSqlStorage::logMessages()` requests sender IDs using savepoints](https://github.com/quassel/quassel/blob/fa3449061f17d7e8db1387f0758fd052f22f4c3b/src/core/postgresqlstorage.cpp#L1505-L1585), avoiding duplicates
  * SQLite may need to be in [WAL mode for checkpoint support](https://sqlite.org/wal.html ), which imposes performance costs until SQLite v3.11 (*available in Ubuntu 16.04, not in 14.04*)
  * SQLite might not be able to [add a uniqueness constraint](https://stackoverflow.com/questions/19337029/insert-if-not-exists-statement-in-sqlite ) due to existing duplicates
  * Alternatively, SQLite's [insert_sender.sql](https://github.com/quassel/quassel/blob/79018517e9f9c91142bba94921e81e948ebd9e50/src/core/SQL/SQLite/insert_sender.sql ) could be hackily modified to work around this
```sql
INSERT INTO sender (sender, realname, avatarurl) VALUES (:sender, :realname, :avatarurl) WHERE NOT EXISTS (SELECT 1 FROM sender WHERE sender = :sender AND coalesce(realname, '') = coalesce(:realname, '') AND coalesce(avatarurl, '') = coalesce(:avatarurl, ''))
```
* On first setup of Quassel core, core-side highlights won't work
  * **This issue existed before this pull request, just noting it**
  * Set up a blank Quassel core on SQLite, blank Quassel client.  Change the Local Highlights to None, Remote Highlights to Current Nick.  Highlights work (*show up*), but notifications don't (*no sound/notification/etc, with KF5*).
  * Now, set to "Current Nick", verify it still doesn't work, then restart the core.  Reconnect.  Highlights AND notifications work with no changes, merely restarting the core.
  * Weirdly enough, you can disable core-side highlights after one restart, and they get correctly disabled
* Windows builds of Quassel do not have QCA enabled
  * This prevents testing `/keyx` and friends
* `0.13` does not consider `LegacyFeatures` in the "peer does not support" warnings
  * E.g. `0.12.5` connecting to a `0.13` core results in warnings about not supporting `SaslAuthentication`
  * Issue existed before this PR
  * [Probably involves this code...](https://github.com/quassel/quassel/blob/e17fca767d60c06ca02bc5898ced04f06d3670bd/src/core/coreauthhandler.cpp#L246-L261 )
```cpp
const auto &clientFeatures = _peer->features();
auto unsupported = clientFeatures.toStringList(false);
```
* On first setup of client, `Nick list` is hidden
  * Issue existed before this PR
  * Might involve [this commit that hides nick list on disconnect](https://github.com/quassel/quassel/commit/66e6d26b38fb6e4528654e6525d205e9e9ca3243 ), will investigate

# Test results - ✅ pass
## Linux - ✅ pass
### Fresh configuration - ✅ pass
*Quassel core from this PR set up without any initial data*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite, new core, new client | ✅ *pass* |
SQLite, new core, old client | ✅ *pass* |
SQLite, old core, new client | ✅ *pass* |
SQLite, new monolithic | ✅ *pass* |
Postgres, new core, new client | ✅ *pass* |
Postgres, new core, old client | ✅ *pass* |
Postgres, old core, new client | ✅ *pass* |

### Migration - ✅ pass
*Quassel core from this PR set up with new core, new client data, then migrated*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite → Postgres, new core, new client | ✅ *pass* |

### Upgrading existing - ✅ pass
*Quassel core 0.13-git-master set up, then upgraded to this PR*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite, old → new core | ✅ *pass* |
SQLite, old monolithic → new monolithic | ✅ *pass* |
Postgres, old → new core | ✅ *pass* |

## Windows - ✅ pass
### Fresh configuration - ✅ pass
*Quassel core from this PR set up without any initial data*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite, new core, new client | ✅ *pass* |
SQLite, new core, old client | ✅ *pass* |
SQLite, old core, new client | ✅ *pass* |
SQLite, new monolithic | ✅ *pass* |

### Migration - ❓ N/A
*Without Postgres on Windows, migration could not be tested*

### Upgrading existing - ✅ pass
*Quassel core 0.12.5 set up, then upgraded to this PR*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite, old → new core | ✅ *pass* |
SQLite, old monolithic → new monolithic | ✅ *pass* |

## Failed cases
None found!

[qd-ng]: https://quasseldroid.info/releases/