### PR TITLE
core: Rename strict-ident, apply to non-identd response

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -168,9 +168,9 @@ int main(int argc, char **argv)
     cliParser->addOption("select-authenticator", 0, "Select authentication backend", "authidentifier");
     cliParser->addSwitch("add-user", 0, "Starts an interactive session to add a new core user");
     cliParser->addOption("change-userpass", 0, "Starts an interactive session to change the password of the user identified by <username>", "username");
-    cliParser->addSwitch("oidentd", 0, "Enable oidentd integration");
+    cliParser->addSwitch("oidentd", 0, "Enable oidentd integration.  In most cases you should also enable --strict-ident");
     cliParser->addOption("oidentd-conffile", 0, "Set path to oidentd configuration file", "file");
-    cliParser->addSwitch("oidentd-strict", 0, "Use users' quasselcore username as ident reply. Ignores each user's configured ident setting. Only meaningful with --oidentd.");
+    cliParser->addSwitch("strict-ident", 0, "Use users' quasselcore username as ident reply. Ignores each user's configured ident setting.");
 #ifdef HAVE_SSL
     cliParser->addSwitch("require-ssl", 0, "Require SSL for remote (non-loopback) client connections");
     cliParser->addOption("ssl-cert", 0, "Specify the path to the SSL Certificate", "path", "configdir/quasselCert.pem");

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -271,11 +271,13 @@ void Core::init()
     connect(&_v6server, SIGNAL(newConnection()), this, SLOT(incomingConnection()));
     if (!startListening()) exit(1);  // TODO make this less brutal
 
+    _strictIdentEnabled = Quassel::isOptionSet("strict-ident");
+    if (_strictIdentEnabled) {
+        cacheSysIdent();
+    }
+
     if (Quassel::isOptionSet("oidentd")) {
-        _oidentdConfigGenerator = new OidentdConfigGenerator(Quassel::isOptionSet("oidentd-strict"), this);
-        if (Quassel::isOptionSet("oidentd-strict")) {
-            cacheSysIdent();
-        }
+        _oidentdConfigGenerator = new OidentdConfigGenerator(this);
     }
 }
 
@@ -825,7 +827,7 @@ SessionThread *Core::sessionForUser(UserId uid, bool restore)
     if (_sessions.contains(uid))
         return _sessions[uid];
 
-    SessionThread *session = new SessionThread(uid, restore, this);
+    SessionThread *session = new SessionThread(uid, restore, strictIdentEnabled(), this);
     _sessions[uid] = session;
     session->start();
     return session;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -672,6 +672,14 @@ public:
 
     static inline QDateTime startTime() { return instance()->_startTime; }
     static inline bool isConfigured() { return instance()->_configured; }
+
+    /**
+     * Whether or not strict ident mode is enabled, locking users' idents to Quassel username
+     *
+     * @return True if strict mode enabled, otherwise false
+     */
+    static inline bool strictIdentEnabled() { return instance()->_strictIdentEnabled; }
+
     static bool sslSupported();
 
     /**
@@ -786,6 +794,9 @@ private:
     QDateTime _startTime;
 
     bool _configured;
+
+    /// Whether or not strict ident mode is enabled, locking users' idents to Quassel username
+    bool _strictIdentEnabled;
 
     static std::unique_ptr<AbstractSqlMigrationReader> getMigrationReader(Storage *storage);
     static std::unique_ptr<AbstractSqlMigrationWriter> getMigrationWriter(Storage *storage);

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -583,7 +583,10 @@ void CoreNetwork::socketInitialized()
         nick = identity->nicks()[0];
     }
     putRawLine(serverEncode(QString("NICK %1").arg(nick)));
-    putRawLine(serverEncode(QString("USER %1 8 * :%2").arg(identity->ident(), identity->realName())));
+    // Only allow strict-compliant idents when strict mode is enabled
+    putRawLine(serverEncode(QString("USER %1 8 * :%2").arg(
+                                coreSession()->strictCompliantIdent(identity),
+                                identity->realName())));
 }
 
 

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -57,9 +57,10 @@ public:
 };
 
 
-CoreSession::CoreSession(UserId uid, bool restoreState, QObject *parent)
+CoreSession::CoreSession(UserId uid, bool restoreState, bool strictIdentEnabled, QObject *parent)
     : QObject(parent),
     _user(uid),
+    _strictIdentEnabled(strictIdentEnabled),
     _signalProxy(new SignalProxy(SignalProxy::Server, this)),
     _aliasManager(this),
     _bufferSyncer(new CoreBufferSyncer(this)),
@@ -553,8 +554,14 @@ void CoreSession::createIdentity(const Identity &identity, const QVariantMap &ad
         createIdentity(coreIdentity);
 }
 
-const QString CoreSession::strictSysident() {
-    return Core::instance()->strictSysIdent(_user);
+const QString CoreSession::strictCompliantIdent(const CoreIdentity *identity) {
+    if (_strictIdentEnabled) {
+        // Strict mode enabled: only allow the user's Quassel username as an ident
+        return Core::instance()->strictSysIdent(_user);
+    } else {
+        // Strict mode disabled: allow any identity specified
+        return identity->ident();
+    }
 }
 
 void CoreSession::createIdentity(const CoreIdentity &identity)

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -62,14 +62,24 @@ class CoreSession : public QObject
     Q_OBJECT
 
 public:
-    CoreSession(UserId, bool restoreState, QObject *parent = 0);
+    CoreSession(UserId, bool restoreState, bool strictIdentEnabled, QObject *parent = 0);
     ~CoreSession();
 
     QList<BufferInfo> buffers() const;
     inline UserId user() const { return _user; }
     CoreNetwork *network(NetworkId) const;
     CoreIdentity *identity(IdentityId) const;
-    const QString strictSysident();
+
+    /**
+     * Returns the optionally strict-compliant ident for the given user identity
+     *
+     * If strict mode is enabled, this will return the user's Quassel username for any identity,
+     * otherwise this will return the given identity's ident, whatever it may be.
+     *
+     * @return The user's ident, compliant with strict mode (when enabled)
+     */
+    const QString strictCompliantIdent(const CoreIdentity *identity);
+
     inline CoreNetworkConfig *networkConfig() const { return _networkConfig; }
     NetworkConnection *networkConnection(NetworkId) const;
 
@@ -209,6 +219,9 @@ private:
     Q_INVOKABLE void processMessageEvent(MessageEvent *event);
 
     UserId _user;
+
+    /// Whether or not strict ident mode is enabled, locking users' idents to Quassel username
+    bool _strictIdentEnabled;
 
     SignalProxy *_signalProxy;
     CoreAliasManager _aliasManager;

--- a/src/core/oidentdconfiggenerator.cpp
+++ b/src/core/oidentdconfiggenerator.cpp
@@ -23,10 +23,9 @@
 #include "corenetwork.h"
 #include "oidentdconfiggenerator.h"
 
-OidentdConfigGenerator::OidentdConfigGenerator(bool strict, QObject *parent) :
+OidentdConfigGenerator::OidentdConfigGenerator(QObject *parent) :
     QObject(parent),
-    _initialized(false),
-    _strict(strict)
+    _initialized(false)
 {
     if (!_initialized)
         init();
@@ -71,11 +70,9 @@ bool OidentdConfigGenerator::init()
 
 
 QString OidentdConfigGenerator::sysIdentForIdentity(const CoreIdentity *identity) const {
-    if (!_strict) {
-        return identity->ident();
-    }
+    // Make sure the identity's ident complies with strict mode if enabled
     const CoreNetwork *network = qobject_cast<CoreNetwork *>(sender());
-    return network->coreSession()->strictSysident();
+    return network->coreSession()->strictCompliantIdent(identity);
 }
 
 

--- a/src/core/oidentdconfiggenerator.h
+++ b/src/core/oidentdconfiggenerator.h
@@ -59,11 +59,7 @@ class OidentdConfigGenerator : public QObject
 {
     Q_OBJECT
 public:
-    /**
-     * @param strict If false, any identity a user chooses is reported to servers as authoritative.
-     *               If true, the user's quassel username is always reported.
-     */
-    explicit OidentdConfigGenerator(bool strict = false, QObject *parent = 0);
+    explicit OidentdConfigGenerator(QObject *parent = 0);
     ~OidentdConfigGenerator();
 
 public slots:

--- a/src/core/sessionthread.cpp
+++ b/src/core/sessionthread.cpp
@@ -25,12 +25,13 @@
 #include "sessionthread.h"
 #include "signalproxy.h"
 
-SessionThread::SessionThread(UserId uid, bool restoreState, QObject *parent)
+SessionThread::SessionThread(UserId uid, bool restoreState, bool strictIdentEnabled, QObject *parent)
     : QThread(parent),
     _session(0),
     _user(uid),
     _sessionInitialized(false),
-    _restoreState(restoreState)
+    _restoreState(restoreState),
+    _strictIdentEnabled(strictIdentEnabled)
 {
     connect(this, SIGNAL(initialized()), this, SLOT(setSessionInitialized()));
 }
@@ -120,7 +121,7 @@ void SessionThread::addInternalClientToSession(InternalPeer *internalPeer)
 
 void SessionThread::run()
 {
-    _session = new CoreSession(user(), _restoreState);
+    _session = new CoreSession(user(), _restoreState, _strictIdentEnabled);
     connect(this, SIGNAL(addRemoteClient(RemotePeer*)), _session, SLOT(addClient(RemotePeer*)));
     connect(this, SIGNAL(addInternalClient(InternalPeer*)), _session, SLOT(addClient(InternalPeer*)));
     connect(_session, SIGNAL(sessionState(Protocol::SessionState)), Core::instance(), SIGNAL(sessionState(Protocol::SessionState)));

--- a/src/core/sessionthread.h
+++ b/src/core/sessionthread.h
@@ -36,7 +36,7 @@ class SessionThread : public QThread
     Q_OBJECT
 
 public:
-    SessionThread(UserId user, bool restoreState, QObject *parent = 0);
+    SessionThread(UserId user, bool restoreState, bool strictIdentEnabled, QObject *parent = 0);
     ~SessionThread();
 
     void run();
@@ -63,6 +63,9 @@ private:
     QList<QObject *> clientQueue;
     bool _sessionInitialized;
     bool _restoreState;
+
+    /// Whether or not strict ident mode is enabled, locking users' idents to Quassel username
+    bool _strictIdentEnabled;
 
     bool isSessionInitialized();
     void addClientToSession(QObject *peer);


### PR DESCRIPTION
## In short

* Let strict ident mode apply to normal ident responses, too
  * Allows using it with IRC networks that don't check for identd replies
  * Simplifies limiting ident responses if identd is not required
  * Follows functionality already available in ZNC
* Clean up matters
  * Rename `--oidentd-strict` to `--strict-ident`, to better match the functionality
  * Simplify functions

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Consistency, requirement for shared core on some networks
Risk | ★★☆ *2/3* | Easily reverted, potential complaints over ident vs identd
Intrusiveness | ★★☆ *2/3* | Command line flag changes, could interfere with other PRs

## Rationale
Networks need a fixed identifier to ban troublesome users.  For shared Quassel installations, banning by IP address is not viable.  Thankfully, there's a solution in the form of identity servers like [oidentd](https://en.wikipedia.org/wiki/Oidentd ) with strict oidentd responses.

However, not all users can set up an identd server, and not all networks check for identd responses.  Quassel should also apply the strict ident mode to normal `USER ...` idents set when connecting to accomodate these use cases at little cost.

For example, there's at least one network that currently requires unique idents without enabling identd checking (*UnrealIRCd's [`set::options::identd-check` configuration item](https://www.unrealircd.org/docs/Set_block#set::options::identd-check )*).  This change is necessary for a shared Quassel core to be considered as an alternative to the network-endorsed ZNC plus HexChat setup.

(*To be clear, ZNC and HexChat are both wonderful projects and offer a lot of power and flexibility.  However, there's some rough edges for the casual users, the "I don't care what a bouncer is just let me chat like I can in Discord/Slack/Telegram" folk.*)

## Examples
Item | Value
-----|------
Quassel username | dcircuit
Identity `ident` | quasseldev

*Note:  Freenode has a length limit on `ident` that removes the last letter of `quasseldev`.*

### Without `--strict-mode`
*Behaves as it does today, no identd set up*
```
--> dcircuit_dev (~quasselde@[hostmask]) has joined #quassel-test
<dcircuit_dev> Test message without --strict-ident enabled.
<dcircuit_dev> * [Whois] dcircuit_dev is dcircuit_dev!~quasselde@[hostmask] (Digital (development))
<-- dcircuit_dev (~quasselde@[hostmask]) has quit (Client Quit)
```

### With `--strict-mode`
*Forces ident, even without an identd set up*
```
--> dcircuit_dev (~dcircuit@[hostmask]) has joined #quassel-test
<dcircuit_dev> Test message with --strict-ident enabled.
<dcircuit_dev> * [Whois] dcircuit_dev is dcircuit_dev!~dcircuit@[hostmask] (Digital (development))
<-- dcircuit_dev (~dcircuit@[hostmask]) has left #quassel-test
```

### With identd
*Not yet tested, but should still work*

## Future work
Pending investigation, this can be extended to show in the client UI when an identity is forced, reducing confusion.

**Needed work for this:**
* Transmit when ident is forced (*likely @justjanne*)
  * Strict mode is enabled
  * Current forced ident (*to allow showing what ident will be*)
  * Don't rely on `authusername` as forced ident (*to allow for other core-enforced overrides*)
* Still allow editing ident, just show an information bar (*likely @digitalcircuit*)
  * Allows modifying ident for situation where strict ident is disabled in future
  * E.g. admin announces to users the change, users can prepare