### PR TITLE
Improve logger configuration

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -144,6 +144,11 @@ int main(int argc, char **argv)
     cliParser->addOption("configdir", 'c', "Specify the directory holding configuration files, the SQlite database and the SSL certificate", "path");
 #endif
     cliParser->addOption("datadir", 0, "DEPRECATED - Use --configdir instead", "path");
+    cliParser->addOption("loglevel", 'L', "Loglevel Debug|Info|Warning|Error", "level", "Info");
+#ifdef HAVE_SYSLOG
+    cliParser->addSwitch("syslog", 0, "Log to syslog");
+#endif
+    cliParser->addOption("logfile", 'l', "Log to a file", "path");
 
 #ifndef BUILD_CORE
     // put client-only arguments here
@@ -158,11 +163,6 @@ int main(int argc, char **argv)
     cliParser->addOption("listen", 0, "The address(es) quasselcore will listen on", "<address>[,<address>[,...]]", "::,0.0.0.0");
     cliParser->addOption("port", 'p', "The port quasselcore will listen at", "port", "4242");
     cliParser->addSwitch("norestore", 'n', "Don't restore last core's state");
-    cliParser->addOption("loglevel", 'L', "Loglevel Debug|Info|Warning|Error", "level", "Info");
-#ifdef HAVE_SYSLOG
-    cliParser->addSwitch("syslog", 0, "Log to syslog");
-#endif
-    cliParser->addOption("logfile", 'l', "Log to a file", "path");
     cliParser->addSwitch("config-from-environment", 0, "Load configuration from environment variables");
     cliParser->addOption("select-backend", 0, "Switch storage backend (migrating data if possible)", "backendidentifier");
     cliParser->addOption("select-authenticator", 0, "Select authentication backend", "authidentifier");

--- a/src/core/coreapplication.cpp
+++ b/src/core/coreapplication.cpp
@@ -18,10 +18,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#include "coreapplication.h"
-
 #include "core.h"
-#include "logger.h"
+#include "coreapplication.h"
 
 CoreApplicationInternal::CoreApplicationInternal()
     : _coreCreated(false)
@@ -40,18 +38,6 @@ CoreApplicationInternal::~CoreApplicationInternal()
 
 bool CoreApplicationInternal::init()
 {
-    /* FIXME
-    This is an initial check if logfile is writable since the warning would spam stdout if done
-    in current Logger implementation. Can be dropped whenever the logfile is only opened once.
-    */
-    QFile logFile;
-    if (!Quassel::optionValue("logfile").isEmpty()) {
-        logFile.setFileName(Quassel::optionValue("logfile"));
-        if (!logFile.open(QIODevice::Append | QIODevice::Text))
-            qWarning("Warning: Couldn't open logfile '%s' - will log to stdout instead", qPrintable(logFile.fileName()));
-        else logFile.close();
-    }
-
     Core::instance(); // create and init the core
     _coreCreated = true;
 
@@ -91,13 +77,5 @@ CoreApplication::~CoreApplication()
 
 bool CoreApplication::init()
 {
-    if (Quassel::init() && _internal->init()) {
-#if QT_VERSION < 0x050000
-        qInstallMsgHandler(Logger::logMessage);
-#else
-        qInstallMessageHandler(Logger::logMessage);
-#endif
-        return true;
-    }
-    return false;
+    return Quassel::init() && _internal->init();
 }


### PR DESCRIPTION
Initialize logging earlier, so output during core initialization
gets routed properly.

Enable the logging options also for quasselclient; there's no good
reason to limit this to the core and monolithic client. However, as
a side-effect, the default log level is now Info also for the client,
so "-l Debug" must be specified on the command line to get debug
output.