### PR TITLE
common: Fix out-of-order user prefix channelmodes

### DIFF
--- a/src/common/network.h
+++ b/src/common/network.h
@@ -204,6 +204,41 @@ public :
     }
     /**@}*/
 
+    /**
+     * Sorts the user channelmodes according to priority set by PREFIX
+     *
+     * Given a list of channel modes, sorts according to the order of PREFIX, putting the highest
+     * modes first.  Any unknown modes are moved to the end in no given order.
+     *
+     * If prefix modes cannot be determined from the network, no changes will be made.
+     *
+     * @param modes User channelmodes
+     * @return Priority-sorted user channelmodes
+     */
+    QString sortPrefixModes(const QString &modes) const;
+
+    /**@{*/
+    /**
+     * Sorts the list of users' channelmodes according to priority set by PREFIX
+     *
+     * Maintains order of the modes list.
+     *
+     * @seealso Network::sortPrefixModes()
+     *
+     * @param modesList List of users' channel modes
+     * @return Priority-sorted list of users' channel modes
+     */
+    inline QStringList sortPrefixModes(const QStringList &modesList) const {
+        QStringList sortedModesList;
+        // Sort each individual mode string, appending back
+        // Must maintain the order received!
+        for (QString modes : modesList) {
+            sortedModesList << sortPrefixModes(modes);
+        }
+        return sortedModesList;
+    }
+    /**@}*/
+
     ChannelModeType channelModeType(const QString &mode);
     inline ChannelModeType channelModeType(const QCharRef &mode) { return channelModeType(QString(mode)); }
 


### PR DESCRIPTION
## In short
* Keep per-channel user modes sorted by priority
  * Sort by `prefixModes()` priority when adding/setting channel modes
  * Enables showing only the highest sender prefix to work

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes user-facing misleading display of sender modes
Risk | ★★☆ *2/3* | Might break user channel modes, potential performance penalty
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other pull requests

*Thanks to @justJanne for finding the issue!*

## Rationale
Quassel offers a way to prefix the channel mode to the nickname, e.g. `@nickOp` and `+nickVoice`.  With IRCv3 `multi-prefix` enabled, it's possible to see all applied modes instead of just the highest, but Quassel still allows for only seeing the highest while storing all modes.

However, adding modes can happen in any order, e.g. voice, then operator status.  Without sorting, Quassel would inaccurately show a nickname as only having voice if it gets operator afterwards.  Sorting by `prefixModes()` order fixes this.

Global user modes don't need sorted as they're not hierarchical and aren't stored anywhere.

## Example
### Debug log testing
*Prefix modes were randomly shuffled before sorting for testing purposes*
```
Warning: sortPrefixModes() given: "ao"
Warning: sortPrefixModes() modified: "oa"
Warning: sortPrefixModes() sorted: "ao"
Warning: -----------------
```