### PR TITLE
core: Fix CTCP TIME not specifying timezone

### DIFF
--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -1556,7 +1556,22 @@ void CoreSessionEventProcessor::handleCtcpPing(CtcpEvent *e)
 
 void CoreSessionEventProcessor::handleCtcpTime(CtcpEvent *e)
 {
-    e->setReply(QDateTime::currentDateTime().toString());
+    // Explicitly specify the Qt default DateTime format string to allow for modification
+    // Qt::TextDate default roughly corresponds to...
+    // > ddd MMM d yyyy HH:mm:ss
+    //
+    // See https://doc.qt.io/qt-5/qdatetime.html#toString
+    // And https://doc.qt.io/qt-5/qt.html#DateFormat-enum
+#if QT_VERSION > 0x050000
+    // Append the timezone identifier "t", so other other IRC users have a frame of reference for
+    // the current timezone.  This could be figured out before by manually comparing to UTC, so this
+    // is just convenience.
+
+    // Alas, "t" was only added in Qt 5
+    e->setReply(QDateTime::currentDateTime().toString("ddd MMM d yyyy HH:mm:ss t"));
+#else
+    e->setReply(QDateTime::currentDateTime().toString("ddd MMM d yyyy HH:mm:ss"));
+#endif
 }
 
 


### PR DESCRIPTION
## In short
* Specify timezone in `CTCP TIME` replies
  * Simplifies figuring out what timezone someone's in
  * Minimal privacy risk as timezone could be determined before by comparing with UTC
  * All of `CTCP` can be ignored as before

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | User-facing enhancement to rarely-used `CTCP TIME`
Risk | ★☆☆ *1/3* | Possible wrong formatting of `CTCP TIME` replies
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other pull requests

*Thanks to `wink` for finding the issue!*

## Rationale
`CTCP TIME` offers an easy way to get an idea of what time it is for someone else, useful to avoid waking them up or otherwise trying to align schedules.

Quassel already provided local time (*of the Quassel core*), but did not include timezone information, requiring others to manually compare to UTC to find out the timezone.  Including the timezone information makes this simpler and more obvious.

## Examples
### Before
```
* Received CTCP-TIME answer from digitalcircuit: Tue May 29 18:22:48 2018
```

### After
```
* Received CTCP-TIME answer from digitalcircuit: Tue May 29 2018 13:33:07 CDT
```

*If desired, I can move the year back to where it was.  This just seems more logical.*

### After, Qt 4
*Qt 4 does not support the timezone specifier*
```
* Received CTCP-TIME answer from digitalcircuit: Tue May 29 2018 13:33:07
```