### PR TITLE
common: Add '$i:identd' verified ident alias, polish

### DIFF
--- a/src/qtui/settingspages/aliasesmodel.cpp
+++ b/src/qtui/settingspages/aliasesmodel.cpp
@@ -58,19 +58,78 @@ QVariant AliasesModel::data(const QModelIndex &index, int role) const
                       "It can be used as a regular slash command.<br /><br />"
                       "<b>Example:</b> \"foo\" can be used per /foo");
         case 1:
-            return tr("<b>The string the shortcut will be expanded to</b><br />"
-                      "<b>special variables:</b><br />"
-                      " - <b>$i</b> represents the i'th parameter.<br />"
-                      " - <b>$i..j</b> represents the i'th to j'th parameter separated by spaces.<br />"
-                      " - <b>$i..</b> represents all parameters from i on separated by spaces.<br />"
-                      " - <b>$i:hostname</b> represents the hostname of the user identified by the i'th parameter or a * if unknown.<br />"
-                      " - <b>$i:ident</b> represents the ident of the user identified by the i'th parameter or a * if unknown.<br />"
-                      " - <b>$i:account</b> represents the account of the user identified by the i'th parameter or a * if logged out or unknown.<br />"
-                      " - <b>$0</b> the whole string.<br />"
-                      " - <b>$nick</b> your current nickname<br />"
-                      " - <b>$channel</b> the name of the selected channel<br /><br />"
-                      "Multiple commands can be separated with semicolons<br /><br />"
-                      "<b>Example:</b> \"Test $1; Test $2; Test All $0\" will be expanded to three separate messages \"Test 1\", \"Test 2\" and \"Test All 1 2 3\" when called like /test 1 2 3");
+        {
+            // To avoid overwhelming the user, organize things into a table
+            QString strTooltip;
+            QTextStream tooltip( &strTooltip, QIODevice::WriteOnly );
+            tooltip << "<qt><style>.bold { font-weight: bold; } .italic { font-style: italic; }</style>";
+
+            // Function to add a row to the tooltip table
+            auto addRow = [&](
+                    const QString& key, const QString& value = QString(), bool condition = true) {
+                if (condition) {
+                    if (value.isEmpty()) {
+                        tooltip << "<tr><td class='italic' align='left' colspan='2'>"
+                                      << key << "</td></tr>";
+                    } else {
+                        tooltip << "<tr><td class='bold' align='left'>"
+                                      << key << "</td><td>" << value << "</td></tr>";
+                    }
+                }
+            };
+
+            tooltip << "<p class='bold'>"
+                    << tr("The string the shortcut will be expanded to") << "</p>";
+
+            tooltip << "<p class='bold' align='center'>"
+                    << tr("Special variables") << "</p>";
+
+            // Variable option table
+            tooltip << "<table cellspacing='5' cellpadding='0'>";
+
+            // Parameter variables
+            addRow(tr("Parameter variables"));
+            addRow("$i", tr("i'th parameter"));
+            addRow("$i..j", tr("i'th to j'th parameter separated by spaces"));
+            addRow("$i..", tr("all parameters from i on separated by spaces"));
+
+            // IrcUser handling
+            addRow(tr("Nickname parameter variables"));
+            addRow("$i:account",
+                   tr("account of user identified by i'th parameter, or a '*' if logged out or "
+                      "unknown"));
+            addRow("$i:hostname",
+                   tr("hostname of user identified by i'th parameter, or a '*' if unknown"));
+            addRow("$i:ident",
+                   tr("ident of user identified by i'th parameter, or a '*' if unknown"));
+            addRow("$i:identd",
+                   tr("ident of user identified by i'th parameter if verified, or a '*' if unknown "
+                      "or unverified (prefixed with '~')"));
+
+            // General variables
+            addRow(tr("General variables"));
+            addRow("$0", tr("the whole string"));
+            addRow("$nick", tr("your current nickname"));
+            addRow("$channel", tr("the name of the selected channel"));
+
+            // End table
+            tooltip << "</table>";
+
+            // Example header
+            tooltip << "<p>"
+                    << tr("Multiple commands can be separated with semicolons") << "</p>";
+            // Example
+            tooltip << "<p>";
+            tooltip << QString("<p><span class='bold'>%1</span> %2<br />").arg(
+                           tr("Example:"), tr("\"Test $1; Test $2; Test All $0\""));
+            tooltip << tr("...will be expanded to three separate messages \"Test 1\", \"Test 2\" "
+                          "and \"Test All 1 2 3\" when called like <i>/test 1 2 3</i>")
+                    << "</p>";
+
+            // End tooltip
+            tooltip << "</qt>";
+            return strTooltip;
+        }
         default:
             return QVariant();
         }


### PR DESCRIPTION
## In short
* Add `$i:identd` parameter to aliases
  * Represents `ident` if verified, or `*` if unknown or unverified
  * Allows ban rules to respect identd, e.g. `/mode $channel +b *!$1:identd@$1:hostname; /kick $1`
* Replace empty nickname parameters with `*`
  * Using the variables for nicknames before `WHO`'ng them still provides results
  * May be dangerous if using above ban example on nickname without hostname available
* Update alias configuration tooltips
  * Add `identd`
  * Organize everything into a table
* Update comments

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing moderator improvement, tooltip cleanups
Risk | ★★☆ *2/3* | Possible confusion, small behavior change to existing aliases
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other pull requests

*Thanks to `Exterminador` for suggesting the change, and @justJanne for further clarifications!*

## Rationale
### Background
Channel moderators will need to ban troublesome users quickly and effectively, while at the same time catching as few innocent people as possible.

IRC servers can enable `identd` checking to ask any connecting user to verify their identity.  If the check fails, the `ident` gets prefixed with `~`, distinguishing them as unverified.  Many shared bouncers have a strict `ident` policy with an `identd` server running to back it up, while many individual users do not bother with `identd`.

By distinguishing between `ident` for server-verified users and wildcard for unverified, aliases can easily ban either an entire IP address for home users, or just a single ident for shared bouncer users.

Though not perfect, this addresses most common cases.

### Motivation
Quassel should offer a way to distinguish between verified and unverified idents in aliases to allow for easy banning/moderation.

For example...
```
/mode $channel +b *!$1:identd@$1:hostname; /kick $1
```
...would target `*!*@no-identd.example.com` for someone connecting without an `identd` server, and `*!userid@shared.example.com` for someone connecting with an `identd` server.

Furthermore, empty parameters (*e.g. if no `/who` has been run on a user already in a channel*) should be replaced with `*` to allow them to still be usable.  **This may be dangerous if using the example ban alias without checking if the user has a hostmask first.**

*Note: Quassel currently returns `*` for any nonexistent nick, so if someone quits between typing a command and running it, this situation could happen before this pull request.  Alternatively, `$i:hostmask` could be made inconsistent with the rest of the parameters, kept as empty when empty, relying on the IRC server to return an error.  And [there's a suggestion for customizable fallbacks](https://github.com/quassel/quassel/pull/362#issuecomment-393972258 ), a potentially rather complex thing.*

## Examples
### Testing alias
*Alias `/testalias` created with text...*
*`/say nick: $1, account: $1:account, hostname: $1:hostname, ident: $1:ident, identd: $1:identd`*

Nickname | Reported ident | Configuration
---------|----------------|--------------
`justJanne` | `kuschku` | Verified, runs an `identd` server
`dcircuit_dev` | `~quasselde`| Unverified, does not run an `identd` server
`somenick` | *Empty* | No available information as no `/who` run

```
/testalias justJanne
nick: justJanne, account: justJanne, hostname: lithium.kuschku.de, ident: kuschku, identd: kuschku
/testalias dcircuit_dev
nick: dcircuit_dev, account: *, hostname: […], ident: ~quasselde, identd: *
/testalias anatolik
nick: somenick, account: *, hostname: *, ident: *, identd: *
```

### Tooltips
*Tooltips in `Settings` → `Configure Quassel…` → `IRC` → `Aliases` → hover over `Expansion` column*

**Before**
!['Configure Aliases' window in Quassel settings showing the tooltip from hovering over the 'Expansion' column, before the changes](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-alias-hammer-powers/Configure%20Aliases%20-%20tooltips%20-%20before.png#v1 )

> **The string the shortcut will be expanded to**
> **special variables**
> \- **$i** represents the i'th parameter.
> \- **$i..j** represents the i'th to j'th parameter separated by spaces.
> \- **$i..** represents all parameters from i on separated by spaces.
> \- **$i:hostname** represents the hostname of the user identified by the i'th parameter or a * if unknown.
> \- **$i:ident** represents the ident of the user identified by the i'th parameter or a * if unknown.
> \- **$i:account** represents the account of the user identified by the i'th parameter or a * if logged out or unknown.
> \- **$0** the whole string
> \- **$nick** your current nickname
> \- **$channel** the name of the selected channel
> 
> Multiple commands can be separated with semicolons
> 
> **Example:** "Test $1; Test $2; Test All $0" will be expanded to three separate messages "Test 1", "Test 2" and "Test All 1 2 3" when called like /test 1 2 3

**After**
!['Configure Aliases' window in Quassel settings showing the tooltip from hovering over the 'Expansion' column, after the changes](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-alias-hammer-powers/Configure%20Aliases%20-%20tooltips%20-%20after.png#v1 )

> **The string the shortcut will be expanded to**
> \[Following is centered\] **Special variables**
> 
> \[Column header invisible\] | \[Column header invisible\]
> ----------------------------|----------------------------
> \[Two-column cell\] | *Parameter variables*
> **$i** | i'th parameter
> **$i..j** | i'th to j'th parameter separated by spaces
> **$i..** | all parameters from i on separated by spaces
> \[Two-column cell\] | *Nickname parameter variables*
> **$i:account** | account of the user identified by the i'th parameter, or a '*' if logged out or unknown
> **$i:hostname** | hostname of the user identified by the i'th parameter, or a '*' if unknown
> **$i:ident** | ident of the user identified by the i'th parameter, or a '*' if unknown
> **$i:identd** | ident of the user identified by the i'th parameter if verified, or a '*' if unknown or unverified (prefixed with '~')
> \[Two-column cell\] | *General variables*
> **$0** | the whole string
> **$nick** | your current nickname
> **$channel** | the name of the selected channel
> 
> Multiple commands can be separated with semicolons
> 
> **Example:** "Test $1; Test $2; Test All $0"
> ...will be expanded to three separate messages "Test 1", "Test 2" and "Test All 1 2 3" when called like */test 1 2 3*