### PR TITLE
client: Add formatting shortcuts, polish

### DIFF
--- a/src/qtui/inputwidget.h
+++ b/src/qtui/inputwidget.h
@@ -44,6 +44,49 @@ public:
 
     inline MultiLineEdit *inputLine() const { return ui.inputEdit; }
 
+public slots:
+    /**
+     * Apply the active color to the selected or typed text
+     *
+     * Active color is chosen using the UI menu.
+     */
+    void applyFormatActiveColor();
+
+    /**
+     * Apply the active fill color to the selected or typed text background
+     *
+     * Fill color is chosen using the UI menu.
+     */
+    void applyFormatActiveColorFill();
+
+    /**
+     * Toggle the boldness of the selected or typed text
+     *
+     * Bold becomes normal, and normal becomes bold.
+     */
+    void toggleFormatBold();
+
+    /**
+     * Toggle the italicness of the selected or typed text
+     *
+     * Italicized becomes normal, and normal becomes italicized.
+     */
+    void toggleFormatItalic();
+
+    /**
+     * Toggle the underlining of the selected or typed text
+     *
+     * Underlined becomes normal, and normal becomes underlined.
+     */
+    void toggleFormatUnderline();
+
+    /**
+     * Clear the formatting of the selected or typed text
+     *
+     * Clears the font weight (bold, italic, underline) and foreground/background coloring.
+     */
+    void clearFormat();
+
 protected:
     virtual bool eventFilter(QObject *watched, QEvent *event);
 
@@ -75,6 +118,13 @@ private slots:
 
     BufferInfo currentBufferInfo() const;
 
+    /**
+     * Set whether or not the style options frame is expanded
+     *
+     * @param visible If true, expand the style options frame, otherwise collapse it
+     */
+    void setStyleOptionsExpanded(const bool visible);
+
     void currentCharFormatChanged(const QTextCharFormat &format);
     void on_showStyleButton_toggled(bool checked);
     void on_boldButton_clicked(bool checked);
@@ -84,6 +134,36 @@ private slots:
     void colorHighlightChosen(QAction *action);
 
 private:
+    /**
+     * Clear the formatting of the text, globally or selected text only
+     *
+     * Clears the font weight (bold, italic, underline) and foreground/background coloring.
+     *
+     * @param global If true, clear all text formatting, otherwise only clear selected text
+     */
+    void setFormatClear(const bool global = false);
+
+    /**
+     * Sets the boldness of the selected or typed text
+     *
+     * @param bold If true, set text bold, otherwise set text normal
+     */
+    void setFormatBold(const bool bold);
+
+    /**
+     * Sets the italicness of the selected or typed text
+     *
+     * @param bold If true, set text italic, otherwise set text normal
+     */
+    void setFormatItalic(const bool italic);
+
+    /**
+     * Sets the underline of the selected or typed text
+     *
+     * @param bold If true, set text underlined, otherwise set text normal
+     */
+    void setFormatUnderline(const bool underline);
+
     Ui::InputWidget ui;
 
     NetworkId _networkId;

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -473,7 +473,7 @@ void MainWin::setupActions()
     coll->addAction("DebugLog", new Action(QIcon::fromTheme("tools-report-bug"), tr("Debug &Log"), coll,
             this, SLOT(on_actionDebugLog_triggered())));
     coll->addAction("ReloadStyle", new Action(QIcon::fromTheme("view-refresh"), tr("Reload Stylesheet"), coll,
-            QtUi::style(), SLOT(reload()), QKeySequence::Refresh));
+            QtUi::style(), SLOT(reload()), QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_R)));
 
     coll->addAction("HideCurrentBuffer", new Action(tr("Hide Current Buffer"), coll,
             this, SLOT(hideCurrentBuffer()), QKeySequence::Close));

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -478,6 +478,38 @@ void MainWin::setupActions()
     coll->addAction("HideCurrentBuffer", new Action(tr("Hide Current Buffer"), coll,
             this, SLOT(hideCurrentBuffer()), QKeySequence::Close));
 
+    // Text formatting
+    coll = QtUi::actionCollection("TextFormat", tr("Text formatting"));
+
+    coll->addAction("FormatApplyColor", new Action(
+                        QIcon::fromTheme("format-text-color"), tr("Apply foreground color"), coll,
+                        this, SLOT(on_inputFormatApplyColor_triggered()),
+                        QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_G)));
+
+    coll->addAction("FormatApplyColorFill", new Action(
+                        QIcon::fromTheme("format-fill-color"), tr("Apply background color"), coll,
+                        this, SLOT(on_inputFormatApplyColorFill_triggered()),
+                        QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_B)));
+
+    coll->addAction("FormatClear", new Action(
+                        QIcon::fromTheme("edit-clear"), tr("Clear formatting"), coll,
+                        this, SLOT(on_inputFormatClear_triggered()),
+                        QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_C)));
+
+    coll->addAction("FormatBold", new Action(
+                        QIcon::fromTheme("format-text-bold"), tr("Toggle bold"), coll,
+                        this, SLOT(on_inputFormatBold_triggered()),
+                        QKeySequence::Bold));
+
+    coll->addAction("FormatItalic", new Action(
+                        QIcon::fromTheme("format-text-italic"), tr("Toggle italics"), coll,
+                        this, SLOT(on_inputFormatItalic_triggered()),
+                        QKeySequence::Italic));
+
+    coll->addAction("FormatUnderline", new Action(
+                        QIcon::fromTheme("format-text-underline"), tr("Toggle underline"), coll,
+                        this, SLOT(on_inputFormatUnderline_triggered()), QKeySequence::Underline));
+
     // Navigation
     coll = QtUi::actionCollection("Navigation", tr("Navigation"));
 
@@ -1742,6 +1774,60 @@ void MainWin::connectOrDisconnectFromNet()
     if (!net) return;
     if (net->connectionState() == Network::Disconnected) net->requestConnect();
     else net->requestDisconnect();
+}
+
+
+void MainWin::on_inputFormatApplyColor_triggered()
+{
+    if (!_inputWidget)
+        return;
+
+    _inputWidget->applyFormatActiveColor();
+}
+
+
+void MainWin::on_inputFormatApplyColorFill_triggered()
+{
+    if (!_inputWidget)
+        return;
+
+    _inputWidget->applyFormatActiveColorFill();
+}
+
+
+void MainWin::on_inputFormatClear_triggered()
+{
+    if (!_inputWidget)
+        return;
+
+    _inputWidget->clearFormat();
+}
+
+
+void MainWin::on_inputFormatBold_triggered()
+{
+    if (!_inputWidget)
+        return;
+
+    _inputWidget->toggleFormatBold();
+}
+
+
+void MainWin::on_inputFormatItalic_triggered()
+{
+    if (!_inputWidget)
+        return;
+
+    _inputWidget->toggleFormatItalic();
+}
+
+
+void MainWin::on_inputFormatUnderline_triggered()
+{
+    if (!_inputWidget)
+        return;
+
+    _inputWidget->toggleFormatUnderline();
 }
 
 

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -401,7 +401,11 @@ void MainWin::setupActions()
             this, SLOT(showCoreInfoDlg())));
     coll->addAction("ConfigureNetworks", new Action(QIcon::fromTheme("configure"), tr("Configure &Networks..."), coll,
             this, SLOT(on_actionConfigureNetworks_triggered())));
-    // FIXME: use QKeySequence::Quit once we depend on Qt 4.6
+    // QKeySequence::Quit was added in Qt 4.6, and could be used instead.  However, that key
+    // sequence is empty by default on Windows, which would remove Ctrl-Q to quit.  It may be best
+    // to just keep it this way.
+    //
+    // See https://doc.qt.io/qt-5/qkeysequence.html
     coll->addAction("Quit", new Action(QIcon::fromTheme("application-exit"), tr("&Quit"), coll,
             this, SLOT(quit()), Qt::CTRL + Qt::Key_Q));
 

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -142,6 +142,49 @@ private slots:
     void on_actionConfigureNetworks_triggered();
     void on_actionConfigureViews_triggered();
     void on_actionLockLayout_toggled(bool lock);
+
+    /**
+     * Apply the active color to the input widget selected or typed text
+     *
+     * @seealso InputWidget::applyFormatActiveColor()
+     */
+    void on_inputFormatApplyColor_triggered();
+
+    /**
+     * Apply the active fill color to the input widget selected or typed text background
+     *
+     * @seealso InputWidget::applyFormatActiveColorFill()
+     */
+    void on_inputFormatApplyColorFill_triggered();
+
+    /**
+     * Toggle the boldness of the input widget selected or typed text
+     *
+     * @seealso InputWidget::toggleFormatBold()
+     */
+    void on_inputFormatBold_triggered();
+
+    /**
+     * Toggle the italicness of the input widget selected or typed text
+     *
+     * @seealso InputWidget::toggleFormatItalic()
+     */
+    void on_inputFormatItalic_triggered();
+
+    /**
+     * Toggle the underlining of the input widget selected or typed text
+     *
+     * @seealso InputWidget::toggleFormatUnderline()
+     */
+    void on_inputFormatUnderline_triggered();
+
+    /**
+     * Clear the formatting of the input widget selected or typed text
+     *
+     * @seealso InputWidget::clearFormat()
+     */
+    void on_inputFormatClear_triggered();
+
     void on_jumpHotBuffer_triggered();
     void on_bufferSearch_triggered();
     void on_actionDebugNetworkModel_triggered();

--- a/src/qtui/ui/inputwidget.ui
+++ b/src/qtui/ui/inputwidget.ui
@@ -27,9 +27,18 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="spacing">
-    <number>-1</number>
+    <number>6</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -45,6 +54,9 @@
        <width>0</width>
        <height>24</height>
       </size>
+     </property>
+     <property name="toolTip">
+      <string>View and change nick</string>
      </property>
      <property name="frame">
       <bool>true</bool>
@@ -88,7 +100,16 @@
       <property name="spacing">
        <number>1</number>
       </property>
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
@@ -113,6 +134,9 @@
           <width>26</width>
           <height>24</height>
          </size>
+        </property>
+        <property name="toolTip">
+         <string>Bold</string>
         </property>
         <property name="text">
          <string/>
@@ -150,6 +174,9 @@
           <width>26</width>
           <height>24</height>
          </size>
+        </property>
+        <property name="toolTip">
+         <string>Italic</string>
         </property>
         <property name="text">
          <string/>
@@ -191,6 +218,9 @@
           <height>24</height>
          </size>
         </property>
+        <property name="toolTip">
+         <string>Underline</string>
+        </property>
         <property name="text">
          <string/>
         </property>
@@ -228,6 +258,9 @@
           <height>24</height>
          </size>
         </property>
+        <property name="toolTip">
+         <string>Set foreground color</string>
+        </property>
         <property name="text">
          <string/>
         </property>
@@ -256,11 +289,51 @@
           <height>24</height>
          </size>
         </property>
+        <property name="toolTip">
+         <string>Set background color</string>
+        </property>
         <property name="text">
          <string/>
         </property>
         <property name="popupMode">
          <enum>QToolButton::MenuButtonPopup</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="clearButton">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>26</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>26</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Clear formatting</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
## In short

* Add keyboard shortcuts for formatting
  * <kbd>Ctrl+B</kbd>, <kbd>Ctrl+I</kbd>, <kbd>Ctrl+U</kbd> for **bold**, *italic*, and `_underline_` (*imagine that one*)
  * <kbd>Ctrl+Shift+G</kbd> and <kbd>Ctrl+Shift+B</kbd> applies selected foreground or background color, respectively
  * <kbd>Ctrl+Shift+C</kbd> clears formatting of selected text
  * All shortcuts customizable, like the other shortcuts
* Polish formatting UI
  * Add button to clear formatting
  * Add tooltips to make it more accessible
* Remap `Reload Stylesheet` from <kbd>Ctrl+R</kbd> to <kbd>Ctrl+Shift+R</kbd>
  * Avoids conflict with default `Set Marker Line`, <kbd>Ctrl+R</kbd>
  * Can be customized as usual
* Clean up comments

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing requested feature, matches text editing expectations
Risk | ★★☆ *2/3* | New shortcuts may conflict with custom ones, can be remapped
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other PRs

## Examples
### Clear formatting button
![Clear formatting button on the input widget formatting toolbar](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-keyboard-format/Clear%20formatting%20button.png#v1 )

### Keyboard shortcuts
*In Settings → Configure Quassel… → Configure Shortcuts…, using the KDE Frameworks integration*
![Configure Shortcuts dialog, showing Text Formatting shortcut list](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-keyboard-format/Text%20formatting%20keyboard%20shortcuts.png#v1 )

> \[previous shortcuts above here\]
> 
> Text formatting:
> 
> Action | Shortcut
> -------|---------
> Apply background color | <kbd>Ctrl+Shift+B</kbd>
> Apply foreground color | <kbd>Ctrl+Shift+G</kbd>
> Clear formatting | <kbd>Ctrl+Shift+C</kbd>
> Toggle bold | <kbd>Ctrl+B</kbd>
> Toggle italics | <kbd>Ctrl+I</kbd>
> Toggle underline | <kbd>Ctrl+U</kbd>