### PR TITLE
Properly fix the SettingsDlg layout

### DIFF
--- a/src/qtui/settingsdlg.cpp
+++ b/src/qtui/settingsdlg.cpp
@@ -45,22 +45,6 @@ SettingsDlg::SettingsDlg(QWidget *parent)
     connect(Client::instance(), SIGNAL(coreConnectionStateChanged(bool)), SLOT(coreConnectionStateChanged()));
 
     setButtonStates();
-
-    // Some settings panes can take a good bit of space.  To avoid squashing the settings tree, try
-    // to resize the dialog.  If needed, it can always be resized by the user to take less space.
-    //
-    // Only try to resize if the sizes are valid.  This shouldn't happen.. but better to be safe.
-    // See http://www.qtcentre.org/threads/3427-invalid-sizeHint()
-    if (ui.settingsTree->sizeHint().isValid() && ui.settingsTree->size().isValid()) {
-        // Find out how much width would make the settings tree happy
-        int wantedExtraWidth = ui.settingsTree->sizeHint().width()
-                - ui.settingsTree->size().width();
-        // If more space is needed, try to resize to allow for it.  Qt should keep the dialog within
-        // the bounds of the screen.
-        if (wantedExtraWidth > 0) {
-            this->resize(this->width() + wantedExtraWidth, this->height());
-        }
-    }
 }
 
 
@@ -112,7 +96,6 @@ void SettingsDlg::registerSettingsPage(SettingsPage *sp)
         item = new QTreeWidgetItem(cat, QStringList(sp->title()));
 
     item->setData(0, SettingsPageRole, QVariant::fromValue<QObject *>(sp));
-    ui.settingsTree->setMinimumWidth(ui.settingsTree->header()->sectionSizeHint(0) + 5);
     pageIsLoaded[sp] = false;
     if (!ui.settingsTree->selectedItems().count())
         ui.settingsTree->setCurrentItem(item);

--- a/src/qtui/ui/settingsdlg.ui
+++ b/src/qtui/ui/settingsdlg.ui
@@ -24,6 +24,12 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <widget class="QTreeWidget" name="settingsTree">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <property name="maximumSize">
        <size>
         <width>200</width>


### PR DESCRIPTION
We've suffered from the page tree in the settings dialog being
squashed horizontally for a long time. A previous commit (65c463f0)
tried to fix this by calculating a minimum size and explicitly
resizing the dialog, but this didn't properly work at least on HIDPI
displays.

Instead, fix layouting properly by setting the correct size policy
for the tree widget, and removing both the afforementioned workaround
and a previous hack that tried to set the minimum width manually
(and failed due to a still-hidden widget reporting wrong size hints).