### PR TITLE
Cleans protocol for highlight rules

### DIFF
--- a/src/common/highlightrulemanager.cpp
+++ b/src/common/highlightrulemanager.cpp
@@ -20,12 +20,14 @@
 
 #include "highlightrulemanager.h"
 
-#include "util.h"
-
 #include <QDebug>
 
+#include "util.h"
+
 INIT_SYNCABLE_OBJECT(HighlightRuleManager)
-HighlightRuleManager &HighlightRuleManager::operator=(const HighlightRuleManager &other) {
+
+HighlightRuleManager &HighlightRuleManager::operator=(const HighlightRuleManager &other)
+{
     if (this == &other)
         return *this;
 
@@ -37,7 +39,8 @@ HighlightRuleManager &HighlightRuleManager::operator=(const HighlightRuleManager
 }
 
 
-int HighlightRuleManager::indexOf(int id) const {
+int HighlightRuleManager::indexOf(int id) const
+{
     for (int i = 0; i < _highlightRuleList.count(); i++) {
         if (_highlightRuleList[i].id == id)
             return i;
@@ -45,7 +48,9 @@ int HighlightRuleManager::indexOf(int id) const {
     return -1;
 }
 
-int HighlightRuleManager::nextId() {
+
+int HighlightRuleManager::nextId()
+{
     int max = 0;
     for (int i = 0; i < _highlightRuleList.count(); i++) {
         int id = _highlightRuleList[i].id;
@@ -53,11 +58,12 @@ int HighlightRuleManager::nextId() {
             max = id;
         }
     }
-    return max+1;
+    return max + 1;
 }
 
 
-QVariantMap HighlightRuleManager::initHighlightRuleList() const {
+QVariantMap HighlightRuleManager::initHighlightRuleList() const
+{
     QVariantList id;
     QVariantMap highlightRuleListMap;
     QStringList name;
@@ -91,7 +97,8 @@ QVariantMap HighlightRuleManager::initHighlightRuleList() const {
 }
 
 
-void HighlightRuleManager::initSetHighlightRuleList(const QVariantMap &highlightRuleList) {
+void HighlightRuleManager::initSetHighlightRuleList(const QVariantMap &highlightRuleList)
+{
     QVariantList id = highlightRuleList["id"].toList();
     QStringList name = highlightRuleList["name"].toStringList();
     QVariantList isRegEx = highlightRuleList["isRegEx"].toList();
@@ -116,9 +123,11 @@ void HighlightRuleManager::initSetHighlightRuleList(const QVariantMap &highlight
     }
 }
 
+
 void HighlightRuleManager::addHighlightRule(int id, const QString &name, bool isRegEx, bool isCaseSensitive,
                                             bool isActive, bool isInverse, const QString &sender,
-                                            const QString &channel) {
+                                            const QString &channel)
+{
     if (contains(id)) {
         return;
     }
@@ -137,7 +146,8 @@ bool HighlightRuleManager::match(const QString &msgContents,
                                  Message::Flags msgFlags,
                                  const QString &bufferName,
                                  const QString &currentNick,
-                                 const QStringList identityNicks) {
+                                 const QStringList identityNicks)
+{
     if (!((msgType & (Message::Plain | Message::Notice | Message::Action)) && !(msgFlags & Message::Self))) {
        return false;
     }
@@ -207,13 +217,16 @@ bool HighlightRuleManager::match(const QString &msgContents,
     return false;
 }
 
-void HighlightRuleManager::removeHighlightRule(int highlightRule) {
+
+void HighlightRuleManager::removeHighlightRule(int highlightRule)
+{
     removeAt(indexOf(highlightRule));
     SYNC(ARG(highlightRule))
 }
 
 
-void HighlightRuleManager::toggleHighlightRule(int highlightRule) {
+void HighlightRuleManager::toggleHighlightRule(int highlightRule)
+{
     int idx = indexOf(highlightRule);
     if (idx == -1)
         return;
@@ -221,6 +234,8 @@ void HighlightRuleManager::toggleHighlightRule(int highlightRule) {
     SYNC(ARG(highlightRule))
 }
 
-bool HighlightRuleManager::match(const Message &msg, const QString &currentNick, const QStringList &identityNicks) {
+
+bool HighlightRuleManager::match(const Message &msg, const QString &currentNick, const QStringList &identityNicks)
+{
     return match(msg.contents(), msg.sender(), msg.type(), msg.flags(), msg.bufferInfo().bufferName(), currentNick, identityNicks);
 }

--- a/src/common/highlightrulemanager.h
+++ b/src/common/highlightrulemanager.h
@@ -38,6 +38,7 @@ class HighlightRuleManager : public SyncableObject
 
     Q_PROPERTY(int highlightNick READ highlightNick WRITE setHighlightNick)
     Q_PROPERTY(bool nicksCaseSensitive READ nicksCaseSensitive WRITE setNicksCaseSensitive)
+
 public:
     enum HighlightNickType {
         NoNick = 0x00,
@@ -48,7 +49,8 @@ public:
     inline HighlightRuleManager(QObject *parent = nullptr) : SyncableObject(parent) { setAllowClientUpdates(true); }
     HighlightRuleManager &operator=(const HighlightRuleManager &other);
 
-    struct HighlightRule {
+    struct HighlightRule
+    {
         int id;
         QString name;
         bool isRegEx = false;
@@ -61,10 +63,11 @@ public:
         HighlightRule(int id_, QString name_, bool isRegEx_, bool isCaseSensitive_, bool isEnabled_, bool isInverse_,
                       QString sender_, QString chanName_)
             : id(id_), name(std::move(name_)), isRegEx(isRegEx_), isCaseSensitive(isCaseSensitive_),
-              isEnabled(isEnabled_), isInverse(isInverse_), sender(std::move(sender_)), chanName(std::move(chanName_)) {
-        }
+              isEnabled(isEnabled_), isInverse(isInverse_), sender(std::move(sender_)), chanName(std::move(chanName_))
+        {}
 
-        bool operator!=(const HighlightRule &other) {
+        bool operator!=(const HighlightRule &other) const
+        {
             return (id != other.id ||
                     name != other.name ||
                     isRegEx != other.isRegEx ||
@@ -75,7 +78,8 @@ public:
                     chanName != other.chanName);
         }
     };
-    typedef QList<HighlightRule> HighlightRuleList;
+
+    using HighlightRuleList = QList<HighlightRule>;
 
     int indexOf(int rule) const;
     inline bool contains(int rule) const { return indexOf(rule) != -1; }
@@ -141,12 +145,14 @@ public slots:
     {
         REQUEST(ARG(highlightNick))
     }
+
     inline void setHighlightNick(int highlightNick) { _highlightNick = static_cast<HighlightNickType>(highlightNick); }
 
     virtual inline void requestSetNicksCaseSensitive(bool nicksCaseSensitive)
     {
         REQUEST(ARG(nicksCaseSensitive))
     }
+
     inline void setNicksCaseSensitive(bool nicksCaseSensitive) { _nicksCaseSensitive = nicksCaseSensitive; }
 
 protected:

--- a/src/core/corehighlightrulemanager.h
+++ b/src/core/corehighlightrulemanager.h
@@ -35,19 +35,19 @@ class CoreHighlightRuleManager : public HighlightRuleManager
 public:
     explicit CoreHighlightRuleManager(CoreSession *parent);
 
-    inline virtual const QMetaObject *syncMetaObject() const { return &HighlightRuleManager::staticMetaObject; }
+    virtual const QMetaObject *syncMetaObject() const override { return &HighlightRuleManager::staticMetaObject; }
 
     bool match(const RawMessage &msg, const QString &currentNick, const QStringList &identityNicks);
 
 public slots:
-    virtual inline void requestToggleHighlightRule(int highlightRule) { toggleHighlightRule(highlightRule); }
-    virtual inline void requestRemoveHighlightRule(int highlightRule) { removeHighlightRule(highlightRule); }
-    virtual inline void requestAddHighlightRule(int id, const QString &name, bool isRegEx, bool isCaseSensitive,
+    inline void requestToggleHighlightRule(int highlightRule) override { toggleHighlightRule(highlightRule); }
+    inline void requestRemoveHighlightRule(int highlightRule) override { removeHighlightRule(highlightRule); }
+    inline void requestAddHighlightRule(int id, const QString &name, bool isRegEx, bool isCaseSensitive,
                                                 bool isEnabled, bool isInverse, const QString &sender,
-                                                const QString &chanName) {
+                                                const QString &chanName) override
+    {
         addHighlightRule(id, name, isRegEx, isCaseSensitive, isEnabled, isInverse, sender, chanName);
     }
-
 
 private slots:
     void save() const;

--- a/src/core/corehighlightrulemanager.h
+++ b/src/core/corehighlightrulemanager.h
@@ -40,12 +40,12 @@ public:
     bool match(const RawMessage &msg, const QString &currentNick, const QStringList &identityNicks);
 
 public slots:
-    virtual inline void requestToggleHighlightRule(const QString &highlightRule) { toggleHighlightRule(highlightRule); }
-    virtual inline void requestRemoveHighlightRule(const QString &highlightRule) { removeHighlightRule(highlightRule); }
-    virtual inline void requestAddHighlightRule(const QString &name, bool isRegEx, bool isCaseSensitive, bool isEnabled,
-                                                bool isInverse, const QString &sender, const QString &chanName)
-    {
-        addHighlightRule(name, isRegEx, isCaseSensitive, isEnabled, isInverse, sender, chanName);
+    virtual inline void requestToggleHighlightRule(int highlightRule) { toggleHighlightRule(highlightRule); }
+    virtual inline void requestRemoveHighlightRule(int highlightRule) { removeHighlightRule(highlightRule); }
+    virtual inline void requestAddHighlightRule(int id, const QString &name, bool isRegEx, bool isCaseSensitive,
+                                                bool isEnabled, bool isInverse, const QString &sender,
+                                                const QString &chanName) {
+        addHighlightRule(id, name, isRegEx, isCaseSensitive, isEnabled, isInverse, sender, chanName);
     }
 
 

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -111,6 +111,7 @@ CoreHighlightSettingsPage::CoreHighlightSettingsPage(QWidget *parent)
     }
 }
 
+
 void CoreHighlightSettingsPage::coreConnectionStateChanged(bool state)
 {
     updateCoreSupportStatus(state);
@@ -121,6 +122,7 @@ void CoreHighlightSettingsPage::coreConnectionStateChanged(bool state)
         revert();
     }
 }
+
 
 void CoreHighlightSettingsPage::setupRuleTable(QTableWidget *table) const
 {
@@ -197,6 +199,7 @@ void CoreHighlightSettingsPage::setupRuleTable(QTableWidget *table) const
 #endif
 }
 
+
 void CoreHighlightSettingsPage::updateCoreSupportStatus(bool state)
 {
     // Assume connected state as enforced by the settings page UI
@@ -212,10 +215,12 @@ void CoreHighlightSettingsPage::updateCoreSupportStatus(bool state)
     }
 }
 
+
 void CoreHighlightSettingsPage::clientConnected()
 {
     connect(Client::highlightRuleManager(), SIGNAL(updated()), SLOT(revert()));
 }
+
 
 void CoreHighlightSettingsPage::revert()
 {
@@ -226,10 +231,12 @@ void CoreHighlightSettingsPage::revert()
     load();
 }
 
+
 bool CoreHighlightSettingsPage::hasDefaults() const
 {
     return true;
 }
+
 
 void CoreHighlightSettingsPage::defaults()
 {
@@ -242,6 +249,7 @@ void CoreHighlightSettingsPage::defaults()
 
     widgetHasChanged();
 }
+
 
 void CoreHighlightSettingsPage::addNewHighlightRow(bool enable, int id, const QString &name, bool regex, bool cs,
                                                    const QString &sender, const QString &chanName, bool self)
@@ -329,6 +337,7 @@ void CoreHighlightSettingsPage::addNewHighlightRow(bool enable, int id, const QS
     highlightList << HighlightRuleManager::HighlightRule(id, name, regex, cs, enable, false, sender, chanName);
 }
 
+
 void CoreHighlightSettingsPage::addNewIgnoredRow(bool enable, int id, const QString &name, bool regex, bool cs,
                                                  const QString &sender, const QString &chanName, bool self)
 {
@@ -403,6 +412,7 @@ void CoreHighlightSettingsPage::addNewIgnoredRow(bool enable, int id, const QStr
     ignoredList << HighlightRuleManager::HighlightRule(id, name, regex, cs, enable, true, sender, chanName);
 }
 
+
 void CoreHighlightSettingsPage::removeSelectedHighlightRows()
 {
     QList<int> selectedRows;
@@ -420,6 +430,7 @@ void CoreHighlightSettingsPage::removeSelectedHighlightRows()
         lastRow = row;
     }
 }
+
 
 void CoreHighlightSettingsPage::removeSelectedIgnoredRows()
 {
@@ -439,11 +450,14 @@ void CoreHighlightSettingsPage::removeSelectedIgnoredRows()
     }
 }
 
-void CoreHighlightSettingsPage::highlightNicksChanged(const int index) {
+
+void CoreHighlightSettingsPage::highlightNicksChanged(const int index)
+{
     // Only allow toggling "Case sensitive" when a nickname will be highlighted
     auto highlightNickType = ui.highlightNicksComboBox->itemData(index).value<int>();
     ui.nicksCaseSensitive->setEnabled(highlightNickType != HighlightRuleManager::NoNick);
 }
+
 
 void CoreHighlightSettingsPage::selectHighlightRow(QTableWidgetItem *item)
 {
@@ -454,6 +468,7 @@ void CoreHighlightSettingsPage::selectHighlightRow(QTableWidgetItem *item)
                            selected);
 }
 
+
 void CoreHighlightSettingsPage::selectIgnoredRow(QTableWidgetItem *item)
 {
     int row = item->row();
@@ -462,6 +477,7 @@ void CoreHighlightSettingsPage::selectIgnoredRow(QTableWidgetItem *item)
         ->setRangeSelected(QTableWidgetSelectionRange(row, 0, row, CoreHighlightSettingsPage::ColumnCount - 1),
                            selected);
 }
+
 
 void CoreHighlightSettingsPage::emptyHighlightTable()
 {
@@ -475,6 +491,7 @@ void CoreHighlightSettingsPage::emptyHighlightTable()
     highlightList.clear();
 }
 
+
 void CoreHighlightSettingsPage::emptyIgnoredTable()
 {
     // ui.highlight and highlightList should have the same size, but just to make sure.
@@ -486,6 +503,7 @@ void CoreHighlightSettingsPage::emptyIgnoredTable()
     }
     ignoredList.clear();
 }
+
 
 void CoreHighlightSettingsPage::highlightTableChanged(QTableWidgetItem *item)
 {
@@ -525,6 +543,7 @@ void CoreHighlightSettingsPage::highlightTableChanged(QTableWidgetItem *item)
     emit widgetHasChanged();
 }
 
+
 void CoreHighlightSettingsPage::ignoredTableChanged(QTableWidgetItem *item)
 {
     if (item->row() + 1 > ignoredList.size())
@@ -563,6 +582,7 @@ void CoreHighlightSettingsPage::ignoredTableChanged(QTableWidgetItem *item)
     emit widgetHasChanged();
 }
 
+
 void CoreHighlightSettingsPage::load()
 {
     emptyHighlightTable();
@@ -598,6 +618,7 @@ void CoreHighlightSettingsPage::load()
         defaults();
     }
 }
+
 
 void CoreHighlightSettingsPage::save()
 {
@@ -635,7 +656,9 @@ void CoreHighlightSettingsPage::save()
     load();
 }
 
-int CoreHighlightSettingsPage::nextId() {
+
+int CoreHighlightSettingsPage::nextId()
+{
     int max = 0;
     for (int i = 0; i < highlightList.count(); i++) {
         int id = highlightList[i].id;
@@ -649,13 +672,15 @@ int CoreHighlightSettingsPage::nextId() {
             max = id;
         }
     }
-    return max+1;
+    return max + 1;
 }
+
 
 void CoreHighlightSettingsPage::widgetHasChanged()
 {
     setChangedState(true);
 }
+
 
 void CoreHighlightSettingsPage::on_coreUnsupportedDetails_clicked()
 {
@@ -676,7 +701,9 @@ void CoreHighlightSettingsPage::on_coreUnsupportedDetails_clicked()
                          remoteHighlightsMsgText);
 }
 
-void CoreHighlightSettingsPage::importRules() {
+
+void CoreHighlightSettingsPage::importRules()
+{
     NotificationSettings notificationSettings;
 
     const auto localHighlightList = notificationSettings.highlightList();
@@ -740,7 +767,9 @@ void CoreHighlightSettingsPage::importRules() {
                                 ).arg(QString::number(localHighlightList.count())));
 }
 
-bool CoreHighlightSettingsPage::isSelectable() const {
+
+bool CoreHighlightSettingsPage::isSelectable() const
+{
     return Client::isConnected();
     // We check for Quassel::Feature::CoreSideHighlights when loading this page, allowing us to show
     // a friendly error message.

--- a/src/qtui/settingspages/corehighlightsettingspage.h
+++ b/src/qtui/settingspages/corehighlightsettingspage.h
@@ -49,14 +49,14 @@ public slots:
 private slots:
     void coreConnectionStateChanged(bool state);
     void widgetHasChanged();
-    void addNewHighlightRow(bool enable = true, const QString &name = tr("highlight rule"), bool regex = false,
+    void addNewHighlightRow(bool enable = true, int id = -1, const QString &name = tr("highlight rule"), bool regex = false,
                             bool cs = false, const QString &sender = "", const QString &chanName = "",
                             bool self = false);
-    void addNewIgnoredRow(bool enable = true, const QString &name = tr("highlight rule"), bool regex = false,
+    void addNewIgnoredRow(bool enable = true, int id = -1, const QString &name = tr("highlight rule"), bool regex = false,
                           bool cs = false, const QString &sender = "", const QString &chanName = "", bool self = false);
     void removeSelectedHighlightRows();
     void removeSelectedIgnoredRows();
-    void highlightNicksChanged(const int index);
+    void highlightNicksChanged(int index);
     void selectHighlightRow(QTableWidgetItem *item);
     void selectIgnoredRow(QTableWidgetItem *item);
     void highlightTableChanged(QTableWidgetItem *item);
@@ -102,6 +102,8 @@ private:
      * @param state  True if connected to core, otherwise false
      */
     void updateCoreSupportStatus(bool state);
+
+    int nextId();
 
     bool _initialized;
 };


### PR DESCRIPTION
# In Short
- Sync highlightNick and nicksCaseSensitive as actual Q_PROPERTY
- Identify rules by their id, not their name
- This allows multiple rules to have the same rule, but different scopes
  and senders

# Impact
This breaks the protocol with existing 0.13 clients. They can still connect, but cannot configure highlight rules.