### PR TITLE
client: Option for highest sender mode

### DIFF
--- a/src/qtui/chatviewsettings.h
+++ b/src/qtui/chatviewsettings.h
@@ -22,6 +22,7 @@
 #define CHATVIEWSETTINGS_H
 
 #include "qtuisettings.h"
+#include "uistyle.h"
 
 class ChatScene;
 class ChatView;
@@ -74,11 +75,21 @@ public:
     inline void setTimestampFormatString(const QString &format) { setLocalValue("TimestampFormat", format); }
 
     /**
-     * Gets if prefixmodes are shown before sender names
+     * Gets how prefix modes are shown before sender names
      *
-     * @returns True if sender prefixmodes enabled, otherwise false
+     * @returns SenderPrefixMode of what format to use for showing sender prefix modes
      */
-    inline bool showSenderPrefixes() { return localValue("ShowSenderPrefixes", false).toBool(); }
+    inline UiStyle::SenderPrefixMode SenderPrefixDisplay() {
+        return static_cast<UiStyle::SenderPrefixMode>(
+                    localValue("SenderPrefixMode",
+                               QVariant::fromValue<UiStyle::SenderPrefixMode>(
+                                   UiStyle::SenderPrefixMode::HighestMode)).toInt());
+        // Cast the QVariant to an integer, then cast that to the enum class.
+        // .canConvert<UiStyle::SenderPrefixMode>() returned true, but
+        // .value<UiStyle::SenderPrefixMode>(); always gave the default value 0.
+        //
+        // There's probably a cleaner way of doing this.  I couldn't find it within 4 hours, so...
+    }
 
     /**
      * Gets if brackets are shown around sender names

--- a/src/qtui/qtuiapplication.cpp
+++ b/src/qtui/qtuiapplication.cpp
@@ -270,6 +270,7 @@ bool QtUiApplication::applySettingsMigration(QtUiSettings settings, const uint n
         // --------
 
         // Migration complete!
+        return true;
     }
     case 7:
     {

--- a/src/qtui/qtuiapplication.cpp
+++ b/src/qtui/qtuiapplication.cpp
@@ -28,6 +28,7 @@
 #  include <KStandardDirs>
 #endif
 
+#include "chatviewsettings.h"
 #include "client.h"
 #include "cliparser.h"
 #include "mainwin.h"
@@ -158,7 +159,7 @@ bool QtUiApplication::migrateSettings()
     //
     // NOTE:  If you increase the minor version, you MUST ALSO add new version upgrade logic in
     // applySettingsMigration()!  Otherwise, settings upgrades will fail.
-    const uint VERSION_MINOR_CURRENT = 8;
+    const uint VERSION_MINOR_CURRENT = 9;
     // Stored minor version
     uint versionMinor = s.versionMinor();
 
@@ -223,6 +224,25 @@ bool QtUiApplication::applySettingsMigration(QtUiSettings settings, const uint n
     // saved.  Exceptions will be noted below.
     // NOTE:  If you add new upgrade logic here, you MUST ALSO increase VERSION_MINOR_CURRENT in
     // migrateSettings()!  Otherwise, your upgrade logic won't ever be called.
+    case 9:
+    {
+        // New default changes: show highest sender prefix mode, if available
+
+        // --------
+        // ChatView settings
+        ChatViewSettings chatViewSettings;
+        const QString senderPrefixModeId = "SenderPrefixMode";
+        if (!chatViewSettings.valueExists(senderPrefixModeId)) {
+            // New default is HighestMode, preserve previous behavior by setting to NoModes
+            chatViewSettings.setValue(senderPrefixModeId,
+                                      static_cast<int>(UiStyle::SenderPrefixMode::NoModes));
+        }
+        // --------
+
+        // Migration complete!
+        return true;
+    }
+
     case 8:
     {
         // New default changes: RegEx checkbox now toggles Channel regular expressions, too

--- a/src/qtui/qtuistyle.cpp
+++ b/src/qtui/qtuistyle.cpp
@@ -32,8 +32,8 @@ QtUiStyle::QtUiStyle(QObject *parent) : UiStyle(parent)
     updateUseCustomTimestampFormat();
     s.notify("TimestampFormat", this, SLOT(updateTimestampFormatString()));
     updateTimestampFormatString();
-    s.notify("ShowSenderPrefixes", this, SLOT(updateShowSenderPrefixes()));
-    updateShowSenderPrefixes();
+    s.notify("SenderPrefixMode", this, SLOT(updateSenderPrefixDisplay()));
+    updateSenderPrefixDisplay();
     s.notify("ShowSenderBrackets", this, SLOT(updateShowSenderBrackets()));
     updateShowSenderBrackets();
 
@@ -56,10 +56,10 @@ void QtUiStyle::updateTimestampFormatString()
     setTimestampFormatString(s.timestampFormatString());
 }
 
-void QtUiStyle::updateShowSenderPrefixes()
+void QtUiStyle::updateSenderPrefixDisplay()
 {
     ChatViewSettings s;
-    enableSenderPrefixes(s.showSenderPrefixes());
+    setSenderPrefixDisplay(s.SenderPrefixDisplay());
 }
 
 void QtUiStyle::updateShowSenderBrackets()

--- a/src/qtui/qtuistyle.h
+++ b/src/qtui/qtuistyle.h
@@ -61,9 +61,9 @@ private slots:
     void updateTimestampFormatString();
     
     /**
-     * Updates knowledge of whether or not to show sender prefixmodes
+     * Updates knowledge of how to display sender prefix modes
      */
-    void updateShowSenderPrefixes();
+    void updateSenderPrefixDisplay();
 
     /**
      * Updates knowledge of whether or not to show sender brackets

--- a/src/qtui/settingspages/chatviewsettingspage.cpp
+++ b/src/qtui/settingspages/chatviewsettingspage.cpp
@@ -19,9 +19,11 @@
  ***************************************************************************/
 
 #include "chatviewsettingspage.h"
+#include "chatviewsettings.h"
 #include "client.h"
 #include "qtui.h"
 #include "qtuistyle.h"
+#include "uistyle.h"
 
 ChatViewSettingsPage::ChatViewSettingsPage(QWidget *parent)
     : SettingsPage(tr("Interface"), tr("Chat View"), parent)
@@ -33,18 +35,42 @@ ChatViewSettingsPage::ChatViewSettingsPage(QWidget *parent)
     ui.showWebPreview->setEnabled(false);
 #endif
 
+    // Handle UI dependent on core feature flags here
     // FIXME remove with protocol v11
     if (!Client::isCoreFeatureEnabled(Quassel::Feature::SynchronizedMarkerLine)) {
         ui.autoMarkerLine->setEnabled(false);
         ui.autoMarkerLine->setChecked(true);
         ui.autoMarkerLine->setToolTip(tr("You need at least version 0.6 of Quassel Core to use this feature"));
     }
-    if (!Client::isCoreFeatureEnabled(Quassel::Feature::CoreSideHighlights)) {
-        ui.showSenderPrefixes->setEnabled(false);
-        ui.showSenderPrefixes->setToolTip(tr("You need at least version 0.13 of Quassel Core to use this feature"));
+    if (!Client::isCoreFeatureEnabled(Quassel::Feature::SenderPrefixes)) {
+        // Sender prefixes are not supported, disallow toggling
+        ui.senderPrefixComboBox->setEnabled(false);
+        // Split up the message to allow re-using translations:
+        // [Original tool-tip]
+        // [Bold 'does not support feature' message]
+        // [Specific version needed and feature details]
+        ui.senderPrefixComboBox->setToolTip(
+                    QString("<b>%2</b><br/>%3").arg(
+                        tr("Your Quassel core does not support this feature"),
+                        tr("You need a Quassel core v0.13.0 or newer in order to show sender "
+                           "modes before nicknames.")));
     }
-
     initAutoWidgets();
+    initSenderPrefixComboBox();
+}
+
+
+void ChatViewSettingsPage::initSenderPrefixComboBox()
+{
+    // Fill combobox with sender prefix modes
+    // Do not change ComboBox ordering without also adjusting chatviewsettingspage.ui "defaultValue"
+    // and UiStyle::SenderPrefixMode
+    ui.senderPrefixComboBox->addItem(tr("No modes"),
+                                     static_cast<int>(UiStyle::SenderPrefixMode::NoModes));
+    ui.senderPrefixComboBox->addItem(tr("Highest mode"),
+                                     static_cast<int>(UiStyle::SenderPrefixMode::HighestMode));
+    ui.senderPrefixComboBox->addItem(tr("All modes"),
+                                     static_cast<int>(UiStyle::SenderPrefixMode::AllModes));
 }
 
 

--- a/src/qtui/settingspages/chatviewsettingspage.cpp
+++ b/src/qtui/settingspages/chatviewsettingspage.cpp
@@ -76,9 +76,15 @@ void ChatViewSettingsPage::initSenderPrefixComboBox()
 
 void ChatViewSettingsPage::save()
 {
+    bool needsStyleReload = SettingsPage::hasChanged(ui.customChatViewFont)
+            || SettingsPage::hasChanged(ui.chatViewFont);
+
     // Save the general settings
     SettingsPage::save();
-    // Update the stylesheet in case fonts are changed
-    QtUi::style()->generateSettingsQss();
-    QtUi::style()->reload();
+
+    // Update the stylesheet if fonts are changed
+    if (needsStyleReload) {
+        QtUi::style()->generateSettingsQss();
+        QtUi::style()->reload();
+    }
 }

--- a/src/qtui/settingspages/chatviewsettingspage.h
+++ b/src/qtui/settingspages/chatviewsettingspage.h
@@ -41,6 +41,11 @@ public slots:
 private:
     Ui::ChatViewSettingsPage ui;
 
+    /**
+     * Initialize the available options for sender prefixes
+     */
+    void initSenderPrefixComboBox();
+
     inline QString settingsKey() const { return QString("QtUi/ChatView/__default__"); }
 };
 

--- a/src/qtui/settingspages/chatviewsettingspage.ui
+++ b/src/qtui/settingspages/chatviewsettingspage.ui
@@ -93,23 +93,49 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="showSenderPrefixes">
-     <property name="toolTip">
-      <string>Shows the modes of senders before their name (e.g. @, +)</string>
-     </property>
-     <property name="text">
-      <string>Show sendermodes in front of nicknames</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-     <property name="defaultValue" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="settingsKey" stdset="0">
-      <string notr="true">ShowSenderPrefixes</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Show sender modes before nicknames:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="senderPrefixComboBox">
+       <property name="toolTip">
+        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot;font-weight:400; font-style:normal;&quot;&gt;
+&lt;p&gt;&lt;span style=&quot;font-weight:600;&quot;&gt;Sender modes:&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span style=&quot;text-decoration: underline;&quot;&gt;No modes:&lt;/span&gt; Don't show any modes&lt;br/&gt;&lt;span style=&quot;font-style: italic;&quot;&gt;Example:&lt;/span&gt; &amp;lt;nickname&amp;gt;&lt;/p&gt;
+&lt;p&gt;&lt;span style=&quot;text-decoration: underline;&quot;&gt;Highest mode:&lt;/span&gt; Show only the highest active mode&lt;br/&gt;&lt;span style=&quot;font-style: italic;&quot;&gt;Example:&lt;/span&gt; &amp;lt;@nickname&amp;gt;&lt;/p&gt;
+&lt;p&gt;&lt;span style=&quot;text-decoration: underline;&quot;&gt;All modes:&lt;/span&gt; Show all active modes&lt;br/&gt;&lt;span style=&quot;font-style: italic;&quot;&gt;Example:&lt;/span&gt; &amp;lt;@+nickname&amp;gt;&lt;/p&gt;
+&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="defaultValue" stdset="0">
+        <bool>1</bool>
+       </property>
+       <property name="settingsKey" stdset="0">
+        <string notr="true">SenderPrefixMode</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -254,6 +280,7 @@
   <tabstop>customTimestampFormat</tabstop>
   <tabstop>timestampFormat</tabstop>
   <tabstop>showSenderBrackets</tabstop>
+  <tabstop>senderPrefixComboBox</tabstop>
   <tabstop>customChatViewFont</tabstop>
   <tabstop>showWebPreview</tabstop>
   <tabstop>autoMarkerLine</tabstop>

--- a/src/qtui/settingspages/chatviewsettingspage.ui
+++ b/src/qtui/settingspages/chatviewsettingspage.ui
@@ -104,18 +104,15 @@
      <item>
       <widget class="QComboBox" name="senderPrefixComboBox">
        <property name="toolTip">
-        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot;font-weight:400; font-style:normal;&quot;&gt;
-&lt;p&gt;&lt;span style=&quot;font-weight:600;&quot;&gt;Sender modes:&lt;/span&gt;&lt;/p&gt;
-&lt;p&gt;&lt;span style=&quot;text-decoration: underline;&quot;&gt;No modes:&lt;/span&gt; Don't show any modes&lt;br/&gt;&lt;span style=&quot;font-style: italic;&quot;&gt;Example:&lt;/span&gt; &amp;lt;nickname&amp;gt;&lt;/p&gt;
-&lt;p&gt;&lt;span style=&quot;text-decoration: underline;&quot;&gt;Highest mode:&lt;/span&gt; Show only the highest active mode&lt;br/&gt;&lt;span style=&quot;font-style: italic;&quot;&gt;Example:&lt;/span&gt; &amp;lt;@nickname&amp;gt;&lt;/p&gt;
-&lt;p&gt;&lt;span style=&quot;text-decoration: underline;&quot;&gt;All modes:&lt;/span&gt; Show all active modes&lt;br/&gt;&lt;span style=&quot;font-style: italic;&quot;&gt;Example:&lt;/span&gt; &amp;lt;@+nickname&amp;gt;&lt;/p&gt;
-&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;qt&gt;&lt;style&gt;.bold { font-weight: bold; } .italic { font-style: italic; } .underline { text-decoration: underline; }&lt;/style&gt;
+&lt;p&gt;&lt;span class=&quot;bold&quot;&gt;Sender modes:&lt;/span&gt;&lt;/p&gt;
+&lt;p&gt;&lt;span class=&quot;underline&quot;&gt;No modes:&lt;/span&gt; Don't show any modes&lt;br/&gt;&lt;span class=&quot;italic&quot;&gt;Example:&lt;/span&gt; &amp;lt;nickname&amp;gt;&lt;/p&gt;
+&lt;p&gt;&lt;span class=&quot;underline&quot;&gt;Highest mode:&lt;/span&gt; Show only the highest active mode&lt;br/&gt;&lt;span class=&quot;italic&quot;&gt;Example:&lt;/span&gt; &amp;lt;@nickname&amp;gt;&lt;/p&gt;
+&lt;p&gt;&lt;span class=&quot;underline&quot;&gt;All modes:&lt;/span&gt; Show all active modes&lt;br/&gt;&lt;span class=&quot;italic&quot;&gt;Example:&lt;/span&gt; &amp;lt;@+nickname&amp;gt;&lt;/p&gt;
+&lt;/qt&gt;</string>
        </property>
        <property name="defaultValue" stdset="0">
-        <bool>1</bool>
+        <number>1</number>
        </property>
        <property name="settingsKey" stdset="0">
         <string notr="true">SenderPrefixMode</string>

--- a/src/qtui/settingspages/corehighlightsettingspage.ui
+++ b/src/qtui/settingspages/corehighlightsettingspage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>438</width>
+    <width>541</width>
     <height>404</height>
    </rect>
   </property>
@@ -71,7 +71,7 @@
    <item>
     <widget class="QWidget" name="highlightsConfigWidget" native="true">
      <layout class="QVBoxLayout" name="highlightConfigLayout">
-     <property name="leftMargin">
+      <property name="leftMargin">
        <number>0</number>
       </property>
       <property name="topMargin">
@@ -231,10 +231,10 @@
                <item>
                 <widget class="QPushButton" name="highlightImport">
                  <property name="toolTip">
-                  <string>Import highlight rules configured in &lt;i&gt;Local Highlights&lt;/i&gt;</string>
+                  <string notr="true">Import highlight rules configured in ${source}</string>
                  </property>
                  <property name="text">
-                  <string>Import Local</string>
+                  <string notr="true">Import ${source}</string>
                  </property>
                 </widget>
                </item>

--- a/src/uisupport/settingspage.cpp
+++ b/src/uisupport/settingspage.cpp
@@ -50,40 +50,41 @@ void SettingsPage::setChangedState(bool hasChanged_)
 
 void SettingsPage::load(QCheckBox *box, bool checked)
 {
-    box->setProperty("StoredValue", checked);
+    box->setProperty("storedValue", checked);
     box->setChecked(checked);
 }
 
 
 bool SettingsPage::hasChanged(QCheckBox *box)
 {
-    return box->property("StoredValue").toBool() != box->isChecked();
+    return box->property("storedValue").toBool() != box->isChecked();
 }
 
 
 void SettingsPage::load(QComboBox *box, int index)
 {
-    box->setProperty("StoredValue", index);
+    box->setProperty("storedValue", index);
     box->setCurrentIndex(index);
 }
 
 
 bool SettingsPage::hasChanged(QComboBox *box)
 {
-    return box->property("StoredValue").toInt() != box->currentIndex();
+    return box->property("storedValue").toInt() != box->currentIndex();
 }
 
 
 void SettingsPage::load(QSpinBox *box, int value)
 {
-    box->setProperty("StoredValue", value);
+    box->setProperty("storedValue", value);
     box->setValue(value);
 }
 
 
 bool SettingsPage::hasChanged(QSpinBox *box)
 {
-    return box->property("StoredValue").toInt() != box->value();
+    return box->property("storedValue").toInt() != box->value();
+}
 }
 
 

--- a/src/uisupport/settingspage.cpp
+++ b/src/uisupport/settingspage.cpp
@@ -25,6 +25,8 @@
 #include <QSpinBox>
 #include <QVariant>
 
+#include "fontselector.h"
+
 #include "uisettings.h"
 
 SettingsPage::SettingsPage(const QString &category, const QString &title, QWidget *parent)
@@ -85,6 +87,18 @@ bool SettingsPage::hasChanged(QSpinBox *box)
 {
     return box->property("storedValue").toInt() != box->value();
 }
+
+
+void SettingsPage::load(FontSelector *box, QFont value)
+{
+    box->setProperty("storedValue", value);
+    box->setSelectedFont(value);
+}
+
+
+bool SettingsPage::hasChanged(FontSelector *box)
+{
+    return box->property("storedValue").value<QFont>() != box->selectedFont();
 }
 
 

--- a/src/uisupport/settingspage.h
+++ b/src/uisupport/settingspage.h
@@ -26,6 +26,7 @@
 class QCheckBox;
 class QComboBox;
 class QSpinBox;
+class FontSelector;
 
 //! A SettingsPage is a page in the settings dialog.
 /** The SettingsDlg provides suitable standard buttons, such as Ok, Apply, Cancel, Restore Defaults and Reset.
@@ -115,6 +116,8 @@ public:
     static bool hasChanged(QComboBox *box);
     static void load(QSpinBox *box, int value);
     static bool hasChanged(QSpinBox *box);
+    static void load(FontSelector *box, QFont value);
+    static bool hasChanged(FontSelector *box);
 
 public slots:
     //! Save settings to permanent storage.

--- a/src/uisupport/uistyle.cpp
+++ b/src/uisupport/uistyle.cpp
@@ -36,7 +36,7 @@ QHash<QString, UiStyle::FormatType> UiStyle::_formatCodes;
 bool UiStyle::_useCustomTimestampFormat;       /// If true, use the custom timestamp format
 QString UiStyle::_timestampFormatString;       /// Timestamp format
 QString UiStyle::_systemTimestampFormatString; /// Cached copy of system locale timestamp format
-bool UiStyle::_showSenderPrefixes;             /// If true, show prefixmodes before sender names
+UiStyle::SenderPrefixMode UiStyle::_senderPrefixDisplay; /// Display of prefix modes before sender
 bool UiStyle::_showSenderBrackets;             /// If true, show brackets around sender names
 
 namespace {
@@ -100,8 +100,8 @@ UiStyle::UiStyle(QObject *parent)
     // in there.
     setUseCustomTimestampFormat(false);
     setTimestampFormatString(" hh:mm:ss");
-    enableSenderPrefixes(false);
-    enableSenderBrackets(true);
+    setSenderPrefixDisplay(UiStyle::SenderPrefixMode::HighestMode);
+    enableSenderBrackets(false);
 
     // BufferView / NickView settings
     UiStyleSettings s;
@@ -251,10 +251,10 @@ void UiStyle::setTimestampFormatString(const QString &format)
     }
 }
 
-void UiStyle::enableSenderPrefixes(bool enabled)
+void UiStyle::setSenderPrefixDisplay(UiStyle::SenderPrefixMode mode)
 {
-    if (_showSenderPrefixes != enabled) {
-        _showSenderPrefixes = enabled;
+    if (_senderPrefixDisplay != mode) {
+        _senderPrefixDisplay = mode;
     }
 }
 
@@ -1058,8 +1058,18 @@ QString UiStyle::StyledMessage::plainSender() const
 QString UiStyle::StyledMessage::decoratedSender() const
 {
     QString _senderPrefixes;
-    if (_showSenderPrefixes) {
+    switch (_senderPrefixDisplay) {
+    case UiStyle::SenderPrefixMode::AllModes:
+        // Show every available mode
         _senderPrefixes = senderPrefixes();
+        break;
+    case UiStyle::SenderPrefixMode::HighestMode:
+        // Show the highest available mode (left-most)
+        _senderPrefixes = senderPrefixes().left(1);
+        break;
+    case UiStyle::SenderPrefixMode::NoModes:
+        // Don't show any mode (already empty by default)
+        break;
     }
 
     switch (type()) {

--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -41,6 +41,7 @@
 class UiStyle : public QObject
 {
     Q_OBJECT
+    Q_ENUMS(SenderPrefixModes)
 
 public:
     UiStyle(QObject *parent = 0);
@@ -161,6 +162,15 @@ public:
         SenderColor0f,
         NumRoles // must be last!
     };
+
+    /// Display of sender prefix modes
+    enum class SenderPrefixMode {
+        NoModes = 0,      ///< Hide sender modes
+        HighestMode = 1,  ///< Show the highest active sender mode
+        AllModes = 2      ///< Show all active sender modes
+    };
+    // Do not change SenderPrefixMode numbering without also adjusting
+    // ChatViewSettingsPage::initSenderPrefixComboBox() and chatviewsettingspage.ui "defaultValue"
 
     struct Format {
         FormatType type;
@@ -305,11 +315,11 @@ protected:
      */
     static void setTimestampFormatString(const QString &format);
     /**
-     * Updates the local setting cache of whether or not to show sender prefixmodes
+     * Updates the local setting cache of how to display sender prefix modes
      *
-     * @param[in] enabled  If true, sender prefixmodes are enabled, otherwise false.
+     * @param[in] mode  Display format for sender prefix modes
      */
-    static void enableSenderPrefixes(bool enabled);
+    static void setSenderPrefixDisplay(UiStyle::SenderPrefixMode mode);
 
     /**
      * Updates the local setting cache of whether or not to show sender brackets
@@ -335,7 +345,7 @@ private:
     static bool _useCustomTimestampFormat;        /// If true, use the custom timestamp format
     static QString _systemTimestampFormatString;  /// Cached copy of system locale timestamp format
     static QString _timestampFormatString;        /// Timestamp format string
-    static bool _showSenderPrefixes;              /// If true, show prefixmodes before sender names
+    static UiStyle::SenderPrefixMode _senderPrefixDisplay; /// Display of prefix modes before sender
     static bool _showSenderBrackets;              /// If true, show brackets around sender names
 
     QIcon _channelJoinedIcon;
@@ -413,3 +423,4 @@ QDataStream &operator>>(QDataStream &in, UiStyle::FormatList &formatList);
 
 Q_DECLARE_METATYPE(UiStyle::FormatList)
 Q_DECLARE_METATYPE(UiStyle::MessageLabel)
+Q_DECLARE_METATYPE(UiStyle::SenderPrefixMode)

--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -164,13 +164,14 @@ public:
     };
 
     /// Display of sender prefix modes
-    enum class SenderPrefixMode {
+    enum SenderPrefixMode {
         NoModes = 0,      ///< Hide sender modes
         HighestMode = 1,  ///< Show the highest active sender mode
         AllModes = 2      ///< Show all active sender modes
     };
     // Do not change SenderPrefixMode numbering without also adjusting
     // ChatViewSettingsPage::initSenderPrefixComboBox() and chatviewsettingspage.ui "defaultValue"
+    // TODO Qt5: Switch to "enum class"
 
     struct Format {
         FormatType type;
@@ -197,22 +198,22 @@ public:
      * @see UiStyle::ColorRole
      */
     const QList<QColor> defaultSenderColors = QList<QColor> {
-        QColor(204,   0,   0),  /// Sender00
-        QColor(  0, 108, 173),  /// Sender01
-        QColor( 77, 153,   0),  /// Sender02
-        QColor(102,   0, 204),  /// Sender03
-        QColor(166, 125,   0),  /// Sender04
-        QColor(  0, 153,  39),  /// Sender05
-        QColor(  0,  48, 192),  /// Sender06
-        QColor(204,   0, 154),  /// Sender07
-        QColor(185,  70,   0),  /// Sender08
-        QColor(134, 153,   0),  /// Sender09
-        QColor( 20, 153,   0),  /// Sender10
-        QColor(  0, 153,  96),  /// Sender11
-        QColor(  0, 108, 173),  /// Sender12
-        QColor(  0, 153, 204),  /// Sender13
-        QColor(179,   0, 204),  /// Sender14
-        QColor(204,   0,  77),  /// Sender15
+        QColor(204,   0,   0),  ///< Sender00
+        QColor(  0, 108, 173),  ///< Sender01
+        QColor( 77, 153,   0),  ///< Sender02
+        QColor(102,   0, 204),  ///< Sender03
+        QColor(166, 125,   0),  ///< Sender04
+        QColor(  0, 153,  39),  ///< Sender05
+        QColor(  0,  48, 192),  ///< Sender06
+        QColor(204,   0, 154),  ///< Sender07
+        QColor(185,  70,   0),  ///< Sender08
+        QColor(134, 153,   0),  ///< Sender09
+        QColor( 20, 153,   0),  ///< Sender10
+        QColor(  0, 153,  96),  ///< Sender11
+        QColor(  0, 108, 173),  ///< Sender12
+        QColor(  0, 153, 204),  ///< Sender13
+        QColor(179,   0, 204),  ///< Sender14
+        QColor(204,   0,  77),  ///< Sender15
     };
     // Explicitly declare QList<QColor> type for defaultSenderColors, otherwise error C2797
     // "list initialization inside member initializer list" will occur in Windows builds with Visual
@@ -342,11 +343,11 @@ private:
     mutable QHash<quint64, QFontMetricsF *> _metricsCache;
     QHash<UiStyle::ItemFormatType, QTextCharFormat> _listItemFormats;
     static QHash<QString, FormatType> _formatCodes;
-    static bool _useCustomTimestampFormat;        /// If true, use the custom timestamp format
-    static QString _systemTimestampFormatString;  /// Cached copy of system locale timestamp format
-    static QString _timestampFormatString;        /// Timestamp format string
-    static UiStyle::SenderPrefixMode _senderPrefixDisplay; /// Display of prefix modes before sender
-    static bool _showSenderBrackets;              /// If true, show brackets around sender names
+    static bool _useCustomTimestampFormat;        ///< If true, use the custom timestamp format
+    static QString _systemTimestampFormatString;  ///< Cached copy of system locale timestamp format
+    static QString _timestampFormatString;        ///< Timestamp format string
+    static UiStyle::SenderPrefixMode _senderPrefixDisplay; ///< Prefix mode display before sender
+    static bool _showSenderBrackets;              ///< If true, show brackets around sender names
 
     QIcon _channelJoinedIcon;
     QIcon _channelPartedIcon;


### PR DESCRIPTION
## In short

* Optionally show only the highest sender mode prefix
  * `All modes`, `Highest mode` (**new default**), `No modes` (**migrated default**)
  * Keep existing users on no modes to match old behavior
  * Use highest mode for new configuration to match other clients
  * *`0.13-master` users will need to re-enable sender prefixes after this*
* Clean up and improve settings page handling
  * Fix `SettingsPage::hasChanged()` widget-specific handling, support `FontSelector`
  * `ChatViewSettings` check if needing to reload stylesheet before doing it
  * Fix settings migration unintentional fallthrough

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing requested feature, fixes bugs
Risk | ★★☆ *2/3* | More options to manage, possible settings regressions
Intrusiveness | ★★☆ *2/3* | UI, string changes, may interfere with other PRs

## Rationale
Quassel now properly handles multiple prefixes at any given time.  However, in most cases, one only needs to know the highest mode of any given user - if someone is an operator, it stands to reason they may have voice, too.

Thus, Quassel should offer a way to only show the highest sender mode, reducing clutter, while still giving the option to see all modes should someone need it, as well as turn off sender modes for those who find them unncessary.

## Examples
### Sender prefix display modes
**Setup**
1.  Join an empty channel on a `multi-prefix` capable server, e.g. Freenode
2.  `/mode +v your_nick`, so you have `@` operator and `+` voice
3.  Send a message

**No modes**
*This is the default for people upgrading existing Quassel setups.*
![Chat view showing a test message from nick `dcircuit_dev` with no prefix](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-sender-mode-highest/Chat%20-%20sender%20mode%20none.png#v1 )

```
<dcircuit_dev> test
<dcircuit_dev> This is a test message.  Test successful.
```

**Highest mode**
*This is the default for new installations of Quassel.*
![Chat view showing a test message from nick `dcircuit_dev` with '@' prefix](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-sender-mode-highest/Chat%20-%20sender%20mode%20highest.png#v1 )

```
<@dcircuit_dev> test
<@dcircuit_dev> This is a test message.  Test successful.
```

**All modes**
![Chat view showing a test message from nick `dcircuit_dev` with `@+` prefixes](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-sender-mode-highest/Chat%20-%20sender%20mode%20all.png#v1 )

```
<@+dcircuit_dev> test
<@+dcircuit_dev> This is a test message.  Test successful.
```

### Chat View settings for sender modes
*In Settings → Interface → Chat View*
![Chat View settings dialog showing the configuration dropdown for sender modes](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-sender-mode-highest/Settings%20-%20Chat%20View%20-%20show%20sender%20modes%20combobox.png#v1 )

*Content*
> Show sender modes before nicknames: \[dropdown box here\]

*Tooltip*
> **Sender modes:**
> 
> *No modes:* Don't show any modes.
> *Example:* \<nickname\>
> 
> *Highest mode:* Show only the highest active mode.
> *Example:* \<@ nickname\> \[space added to disable GitHub auto-link\]
> 
> *All modes:* Show all active modes.
> *Example:* \<\@+nickname\>

### Sender prefixes not supported by core
*In Settings → Interface → Chat View*
![Chat View settings dialog showing the out of date core tooltip](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-sender-mode-highest/Settings%20-%20Chat%20View%20-%20show%20sender%20modes%20unavailable.png#v1 )

*Tooltip*
> **Your Quassel core does not support this feature**
> 
> You need a Quassel core v0.13.0 or newer in order to show sender modes before nicknames.