### PR TITLE
docs: Simplify README.md, add help, downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-Quassel IRC [![Linux Build Status](https://travis-ci.org/quassel/quassel.svg?branch=master)](https://travis-ci.org/quassel/quassel) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/quassel/quassel?branch=master&svg=true)](https://ci.appveyor.com/project/quassel/quassel/branch/master)
+Quassel IRC
 ===============
+
+[![Linux Build Status][ci-linux-badge]][ci-linux-status-page] [![Windows Build Status][ci-win-badge]][ci-win-status-page]
 
 [Quassel IRC][web-home] is a modern, cross-platform, distributed IRC client,
 meaning that one (or multiple) client(s) can attach to and detach from a
-central core -- much like the popular combination of screen and a text-based
+central core – much like the popular combination of screen and a text-based
 IRC client such as WeeChat, but graphical.
 
 Not only do we aim to bring a pleasurable, comfortable chatting experience to
@@ -13,21 +15,30 @@ you are welcome to download and see for yourself!
 
 ## Release notes
 You can find the current release notes on the [Quassel IRC homepage][web-home],
-as well as in this repository's [```ChangeLog```][repo-changelog].
+as well as in this repository's [`ChangeLog`][repo-changelog].
+
+## Downloading
+Official, stable downloads are provided on the [Quassel IRC download page][web-download].
+
+Automated Windows builds are available via the [AppVeyor build history][ci-win-status-history].  Pick a build, then choose the *Artifacts* tab.
+
+Unofficial builds and testing versions are [contributed by several community members][docs-wiki-unofficial-build].
 
 ## Quick reference
+We recommend reading the [getting started guide on the wiki][docs-wiki-getstart],
+but in a pinch, these steps will do.
 
 On first run of the Quassel core, it will wait for a client to connect
-and present a first-run wizard that will allow you to create the database
-and one admin user for the core-side storage.
+and present a wizard that will allow you to create the database and one admin
+user for the core-side storage.
 
-* To add more users, run: ```quasselcore --add-user```
-* To change the password of an existing user: ```quasselcore --change-userpass=username```
+Once you've set up Quassel, you may:
+* Add more users: `quasselcore --add-user`
+* Change the password of an existing user: `quasselcore --change-userpass=username`
+* See all available options: `quasselcore --help`
 
-On some systems, you may need to specify ```--configdir```, e.g.
-```quasselcore --configdir=/var/lib/quassel [command]```.
-
-The ```manageusers.py``` script is deprecated and should no longer be used.
+On some systems, you may need to specify `--configdir`, e.g.
+`quasselcore --configdir=/var/lib/quassel [command]`.
 
 To learn more, see [the Quassel project wiki][docs-wiki] for in-depth
 documentation.
@@ -36,8 +47,8 @@ documentation.
 
 IRC is the preferred means of getting in touch with the developers.
 
-The Quassel IRC Team can be contacted on **```Freenode/#quassel```**
-(or **```#quassel.de```**).  If you have trouble getting Quassel to connect,
+The Quassel IRC Team can be contacted on **`Freenode/#quassel`**
+(or **`#quassel.de`**).  If you have trouble getting Quassel to connect,
 you can use [Freenode's webchat][help-freenode].
 
 We always welcome new users in our channels!
@@ -45,7 +56,7 @@ We always welcome new users in our channels!
 You can learn more and reach out to us in several ways:
 * [Visit our homepage][web-home]
 * [Submit and browse issues on the bugtracker][dev-bugs]
- * Github issues are not used, but [pull requests][dev-pr-new] are accepted!
+  * GitHub issues are not used, but [pull requests][dev-pr-new] are accepted!
 * [Email the dev team - devel@quassel-irc.org][dev-email]
 
 Thanks for reading,
@@ -53,9 +64,17 @@ Thanks for reading,
 ~ *The Quassel IRC Team*
 
 [web-home]: https://quassel-irc.org
+[web-download]: https://quassel-irc.org/downloads
 [dev-bugs]: https://bugs.quassel-irc.org
 [dev-email]: mailto:devel@quassel-irc.org
 [dev-pr-new]: https://github.com/quassel/quassel/pull/new/master
 [docs-wiki]: https://bugs.quassel-irc.org/projects/quassel-irc/wiki
+[docs-wiki-unofficial-build]: https://bugs.quassel-irc.org/projects/quassel-irc/wiki#Unofficial-builds
+[docs-wiki-getstart]: https://bugs.quassel-irc.org/projects/quassel-irc/wiki#Getting-started
 [help-freenode]: https://webchat.freenode.net?channels=%23quassel
 [repo-changelog]: ChangeLog
+[ci-linux-badge]: https://travis-ci.org/quassel/quassel.svg?branch=master
+[ci-linux-status-page]: https://travis-ci.org/quassel/quassel/branches
+[ci-win-badge]: https://ci.appveyor.com/api/projects/status/github/quassel/quassel?branch=master&svg=true&passingText=Windows:%20passing&pendingText=Windows:%20pending&failingText=Windows:%20failing
+[ci-win-status-page]: https://ci.appveyor.com/project/quassel/quassel/branch/master
+[ci-win-status-history]: https://ci.appveyor.com/project/quassel/quassel/history


### PR DESCRIPTION
## In brief
* Add more guidance
  * Document the use of `--help`
  * Add a section on official downloads, automated builds, and community-contributed builds
* Update and simplify README for visual and plain-text reading
  * Move status badges to a new line, clean up URLs
  * Add `Windows:` text [to AppVeyor badge](https://www.appveyor.com/docs/status-badges/ ) to distinguish (*[no option on Travis CI](https://docs.travis-ci.com/user/status-images/ )*)
  * Replace ` ```triple-backticks``` ` with ``` `single-backticks` ```, easier to read
  * Move CI status URLs out of the way using Markdown references
  * Remove outdated notice about `manageusers.py`
  * Fix bulleted list at the bottom

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Developer-facing polish, clarifications
Risk | ★☆☆ *1/3* | Possible bad rendering, confusion, easily reverted
Intrusiveness | ★☆☆ *1/3* | Only changes `README.md`, shouldn't interfere with other pull requests

*Note: Looking at [the branch directly](https://github.com/digitalcircuit/quassel/blob/ft-readme-tweaks/README.md ) may be easier than using GitHub's pull request difference view.*

## Example
### Before
![README in the old layout](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-readme-tweaks/README%20-%20old.png#v1 )
*Or view directly: [`README.md`](https://github.com/quassel/quassel/blob/41f7cd2411c6500bd6a07be63f3adb1c0eb890a7/README.md)*

### After
![README in the new layout](https://zorro.casa/go/db/Hosting/Utilities/Quassel/Development/pr/ft-readme-tweaks/README%20-%20new.png#v5 )
*Or view directly: [`README.md`](https://github.com/digitalcircuit/quassel/blob/ft-readme-tweaks/README.md)*