### PR TITLE
client: Use QT_VERSION for 'enum class' fallback

### DIFF
--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -164,14 +164,17 @@ public:
     };
 
     /// Display of sender prefix modes
+#if QT_VERSION >= 0x050000
+    enum class SenderPrefixMode {
+#else
     enum SenderPrefixMode {
+#endif
         NoModes = 0,      ///< Hide sender modes
         HighestMode = 1,  ///< Show the highest active sender mode
         AllModes = 2      ///< Show all active sender modes
     };
     // Do not change SenderPrefixMode numbering without also adjusting
     // ChatViewSettingsPage::initSenderPrefixComboBox() and chatviewsettingspage.ui "defaultValue"
-    // TODO Qt5: Switch to "enum class"
 
     struct Format {
         FormatType type;


### PR DESCRIPTION
## In brief
* Use `QT_VERSION` macro for `UiStyle` `enum class` fallback
  * Makes it simpler to clean up Qt4 code once the migration happens
  * Mimics how it's done in `quassel.h` for the `Feature` enum

_As this is a trivial change, I've skipped the usual breakdown and analysis.  Only risk should be differences in Qt5 and Qt4 handling._