### PR TITLE
 client: Fix Remote Cores marked unsaved on load, cleanup

### DIFF
--- a/src/client/coreaccount.cpp
+++ b/src/client/coreaccount.cpp
@@ -169,7 +169,34 @@ void CoreAccount::fromVariantMap(const QVariantMap &v)
 }
 
 
-bool CoreAccount::operator==(const CoreAccount &o) const
+bool CoreAccount::operator==(const CoreAccount &other) const
 {
-    return toVariantMap(true) == o.toVariantMap(true);
+    return toVariantMap(true) == other.toVariantMap(true);
+}
+
+
+bool CoreAccount::operator!=(const CoreAccount &other) const
+{
+    return !(*this == other);
+}
+
+
+QDebug operator<<(QDebug dbg, const CoreAccount &acc)
+{
+    dbg.nospace() << qPrintable(QString("CoreAccount(AccountId:")) << acc.accountId()
+    << qPrintable(QString(", AccountName:")) << acc.accountName()
+    << qPrintable(QString(", Uuid:")) << acc.uuid()
+    << qPrintable(QString(", Internal:")) << acc.isInternal()
+    << qPrintable(QString(", User:")) << acc.user()
+    << qPrintable(QString(", Password:")) << acc.password()
+    << qPrintable(QString(", StorePassword:")) << acc.storePassword()
+    << qPrintable(QString(", HostName:")) << acc.hostName()
+    << qPrintable(QString(", Port:")) << acc.port()
+    << qPrintable(QString(", UseSSL:")) << acc.useSsl()
+    << qPrintable(QString(", ProxyType:")) << acc.proxyType()
+    << qPrintable(QString(", ProxyUser:")) << acc.proxyUser()
+    << qPrintable(QString(", ProxyPassword:")) << acc.proxyPassword()
+    << qPrintable(QString(", ProxyHostName:")) << acc.proxyHostName()
+    << qPrintable(QString(", ProxyPort:")) << acc.proxyPort();
+    return dbg.space();
 }

--- a/src/client/coreaccount.h
+++ b/src/client/coreaccount.h
@@ -22,6 +22,7 @@
 #define COREACCOUNT_H_
 
 #include <QCoreApplication>
+#include <QDebug>
 #include <QNetworkProxy>
 #include <QUuid>
 #include <QVariantMap>
@@ -78,6 +79,7 @@ public:
     virtual void fromVariantMap(const QVariantMap &);
 
     bool operator==(const CoreAccount &other) const;
+    bool operator!=(const CoreAccount &other) const;
 
 private:
     AccountId _accountId;
@@ -92,5 +94,6 @@ private:
     uint _proxyPort;
 };
 
+QDebug operator<<(QDebug dbg, const CoreAccount &msg);
 
 #endif

--- a/src/client/coreaccountmodel.cpp
+++ b/src/client/coreaccountmodel.cpp
@@ -155,6 +155,12 @@ bool CoreAccountModel::operator==(const CoreAccountModel &other) const
 }
 
 
+bool CoreAccountModel::operator!=(const CoreAccountModel &other) const
+{
+    return !(*this == other);
+}
+
+
 // TODO with Qt 4.6, use QAbstractItemModel move semantics to properly do this
 AccountId CoreAccountModel::createOrUpdateAccount(const CoreAccount &newAcc)
 {

--- a/src/client/coreaccountmodel.h
+++ b/src/client/coreaccountmodel.h
@@ -57,6 +57,7 @@ public:
     void update(const CoreAccountModel *other);
 
     bool operator==(const CoreAccountModel &other) const;
+    bool operator!=(const CoreAccountModel &other) const;
 
 public slots:
     void save();

--- a/src/qtui/settingspages/coreaccountsettingspage.cpp
+++ b/src/qtui/settingspages/coreaccountsettingspage.cpp
@@ -226,8 +226,9 @@ bool CoreAccountSettingsPage::testHasChanged()
 {
     if (ui.autoConnectAccount->currentIndex() != ui.autoConnectAccount->property("storedValue").toInt())
         return true;
-    if (!(*model() == *Client::coreAccountModel()))
+    if (*model() != *Client::coreAccountModel()) {
         return true;
+    }
 
     return false;
 }

--- a/src/qtui/settingspages/coreaccountsettingspage.cpp
+++ b/src/qtui/settingspages/coreaccountsettingspage.cpp
@@ -81,6 +81,8 @@ void CoreAccountSettingsPage::load()
     ui.autoConnectAccount->setCurrentIndex(idx.isValid() ? idx.row() : 0);
     ui.autoConnectAccount->setProperty("storedValue", ui.autoConnectAccount->currentIndex());
     setWidgetStates();
+    // Mark as no changes made, we just loaded settings
+    setChangedState(false);
 }
 
 
@@ -224,8 +226,10 @@ void CoreAccountSettingsPage::widgetHasChanged()
 
 bool CoreAccountSettingsPage::testHasChanged()
 {
-    if (ui.autoConnectAccount->currentIndex() != ui.autoConnectAccount->property("storedValue").toInt())
+    if (ui.autoConnectAccount->currentIndex() !=
+            ui.autoConnectAccount->property("storedValue").toInt()) {
         return true;
+    }
     if (*model() != *Client::coreAccountModel()) {
         return true;
     }


### PR DESCRIPTION
## In short
* Fix Remote Cores wrongly being marked as unsaved on load
  * Happens if default core account was chosen and index in `QComboBox` was not `0`
* Clean up `CoreAccount`/`CoreAccountModel`, add `qDebug` support
  * Not needed, but since it was added while debugging this, worthwhile keeping
  * Add inequality `!=` operator to simplify comparisons elsewhere

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing fix for misleading configuration prompt
Risk | ★☆☆ *1/3* | Might not correctly detect core account changes
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other PRs

## Testing
### Steps
1.  Start with blank client configuration
2.  Add two accounts, `A` and `B`, with any data
3.  Pick `B` as default account
4.  Save, close configuration dialog, re-open
5.  Select `Remote Cores`

### Before
`Remote Cores` acts as if unsaved changes exist.

### After
`Remote Cores` only shows changes if changes were made, avoiding needlessly prompting the user.