### PR TITLE
client: Handle legacy CoreInfo, fix sync, disconnect

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -149,6 +149,17 @@ public:
     static void mergeBuffersPermanently(BufferId bufferId1, BufferId bufferId2);
     static void purgeKnownBufferIds();
 
+    /**
+     * Requests client to resynchronize the CoreInfo object for legacy (pre-0.13) cores
+     *
+     * This provides compatibility with updating core information for legacy cores, and can be
+     * removed after protocol break.
+     *
+     * NOTE: On legacy (pre-0.13) cores, any existing connected signals will be destroyed and must
+     * be re-added after calling this, in addition to checking for existing data in coreInfo().
+     */
+    static void refreshLegacyCoreInfo();
+
     static void changePassword(const QString &oldPassword, const QString &newPassword);
     static void kickClient(int peerId);
 
@@ -177,6 +188,17 @@ signals:
     void connected();
     void disconnected();
     void coreConnectionStateChanged(bool);
+
+    /**
+     * Signals that core information has been resynchronized, removing existing signal handlers
+     *
+     * Whenever this is emitted, one should re-add any handlers for CoreInfo::coreDataChanged() and
+     * apply any existing information in the coreInfo() object.
+     *
+     * Only emitted on legacy (pre-0.13) cores.  Generally, one should use the
+     * CoreInfo::coreDataChanged() signal too.
+     */
+    void coreInfoResynchronized();
 
     //! The identity with the given ID has been newly created in core and client.
     /** \param id The ID of the newly created identity.
@@ -257,6 +279,17 @@ private:
     void init();
 
     void requestInitialBacklog();
+
+    /**
+     * Deletes and resynchronizes the CoreInfo object for legacy (pre-0.13) cores
+     *
+     * This provides compatibility with updating core information for legacy cores, and can be
+     * removed after protocol break.
+     *
+     * NOTE: On legacy (pre-0.13) cores, any existing connected signals will be destroyed and must
+     * be re-added after calling this, in addition to checking for existing data in coreInfo().
+     */
+    void requestLegacyCoreInfo();
 
     static void addNetwork(Network *);
 

--- a/src/common/coreinfo.cpp
+++ b/src/common/coreinfo.cpp
@@ -41,3 +41,11 @@ void CoreInfo::setConnectedClientData(const int peerCount, const QVariantList pe
     _coreData["sessionConnectedClientData"] = peerData;
     setCoreData(_coreData);
 }
+
+void CoreInfo::reset()
+{
+    // Clear any stored data
+    _coreData.clear();
+    // Propagate changes to listeners
+    emit coreDataChanged(_coreData);
+}

--- a/src/common/coreinfo.h
+++ b/src/common/coreinfo.h
@@ -39,7 +39,15 @@ public:
 
     void setConnectedClientData(int, QVariantList);
 
+    /**
+     * Reset the core info state, clearing anything saved
+     */
+    void reset();
+
 signals:
+    /**
+     * Signals that core information has changed
+     */
     void coreDataChanged(QVariantMap);
 
 public slots:

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -138,6 +138,7 @@ public:
         EcdsaCertfpKeys,          ///< ECDSA keys for CertFP in identities
 #endif
         LongMessageId,            ///< 64-bit IDs for messages
+        SyncedCoreInfo,           ///< CoreInfo dynamically updated using signals
     };
     Q_ENUMS(Feature)
 

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -35,7 +35,7 @@ CoreInfoDlg::CoreInfoDlg(QWidget *parent) : QDialog(parent) {
 
     // Update legacy core info for Quassel cores earlier than 0.13.  This does nothing on modern
     // cores.
-    Client::refreshLegacyCoreInfo();
+    refreshLegacyCoreInfo();
 
     // Display existing core info, set up signal handlers
     coreInfoResynchronized();
@@ -45,6 +45,21 @@ CoreInfoDlg::CoreInfoDlg(QWidget *parent) : QDialog(parent) {
 
     updateUptime();
     startTimer(1000);
+}
+
+
+void CoreInfoDlg::refreshLegacyCoreInfo() {
+    if (!Client::isConnected() || Client::isCoreFeatureEnabled(Quassel::Feature::SyncedCoreInfo)) {
+        // If we're not connected, or the core supports SyncedCoreInfo (0.13+), bail out
+        return;
+    }
+
+    // Request legacy (pre-0.13) CoreInfo object to be resynchronized (does nothing on modern cores)
+    Client::refreshLegacyCoreInfo();
+
+    // On legacy cores, CoreInfo data does not send signals.  Periodically poll for information.
+    // 15 seconds seems like a reasonable trade-off as this only happens while the dialog is open.
+    QTimer::singleShot(15 * 1000, this, SLOT(refreshLegacyCoreInfo()));
 }
 
 

--- a/src/qtui/coreinfodlg.h
+++ b/src/qtui/coreinfodlg.h
@@ -40,6 +40,14 @@ protected:
 
 private slots:
     /**
+     * Requests resynchronization of CoreInfo object for legacy (pre-0.13) cores
+     *
+     * This provides compatibility with updating core information for legacy cores, and can be
+     * removed after protocol break.
+     */
+    void refreshLegacyCoreInfo();
+
+    /**
      * Handler for recreation of CoreInfo object, including first-time setup
      *
      * Applies existing CoreInfo information to the dialog, too.

--- a/src/qtui/coreinfodlg.h
+++ b/src/qtui/coreinfodlg.h
@@ -39,6 +39,13 @@ protected:
     void timerEvent(QTimerEvent *) override { updateUptime(); }
 
 private slots:
+    /**
+     * Handler for recreation of CoreInfo object, including first-time setup
+     *
+     * Applies existing CoreInfo information to the dialog, too.
+     */
+    void coreInfoResynchronized();
+
     void on_closeButton_clicked() { reject(); }
     void updateUptime();
     void disconnectClicked(int peerId);


### PR DESCRIPTION
## In short

* Synchronize core info before first connect
  * Removes warning about missing receiver for core info signal
* Refresh legacy core info whenever opening Core Info dialog
  * On legacy cores, fetch core information by recreating `CoreInfo` object
  * Add feature flag `SyncedCoreInfo`, don't poll on modern cores
  * Fixes information only refreshing once when connecting
* Indicate in core info dialog when disconnected
  * Reduces confusion about state of the core
  * Before, core info dialog would simply stop updating

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing polish, better client experience for old cores
Risk | ★★☆ *2/3* | Core Info might stop being refreshed, become corrupted
Intrusiveness | ★★☆ *2/3* | Protocol changes, could interfere with other PRs

## Examples
### Disconnected from core
*In File → Core Info…*
*Happens if you disconnect the current session, or if the current session gets disconnected, either remotely or due to server outage.*

**Before**
![File - Core Info, showing state after remote disconnect on previous version](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-coreinfo-legacy-warning/Core%20Info%20disconnected%20-%20old.png#v2 )
*The Core Information dialog stops updating, with `Ending session...` stuck on the button and nothing else working.*

**After**
![File - Core Info, showing state after remote disconnect](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-coreinfo-legacy-warning/Core%20Info%20disconnected%20-%20new.png#v1 )

> Item | Contents
> -----|---------
> Version: | Disconnected from core
> Version Date: | Not available
> Uptime: | Not available
> Connected Clients: | 0

### Sync warning
Connect to modern core.
**Before**
```
2018-06-17 22:12:48 Warning: "no registered receiver for sync call: CoreInfo::setCoreData (objectName=\"\"). Params are:" (QVariant(QVariantMap, QMap(("quasselBuildDate", QVariant(QString, "Sun Jun 17 17:10:58 2018"))("quasselVersion", QVariant(QString, "v0.13-pre (0.12.0+660 git-<a href=\"https://github.com/quassel/quassel/commit/5e4bfcea8cf62cded326d385acd47528c1974b09\">5e4bfce</a>)"))[...]("sessionConnectedClients", QVariant(int, 1))("startTime", QVariant(QDateTime, QDateTime(2018-06-18 03:12:43.229 UTC Qt::TimeSpec(UTC)))))))
```

**After**
*No warnings printed*

### Legacy cores
1.  Connect to legacy core
2.  Open Core Info dialog
3.  Connect other client to legacy core
4.  Close and re-open Core Info dialog in the first client

**Before**
Connected Clients would not update.

**After**
Connected Clients shows the correct value.