### PR TITLE
core: Handle single-param PONG replies, hide bad timestamps

### DIFF
--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -661,12 +661,46 @@ void CoreSessionEventProcessor::processIrcEventPong(IrcEvent *e)
     // Attempt to parse the timestamp
     QTime sendTime = QTime::fromString(timestamp, "hh:mm:ss.zzz");
     if (sendTime.isValid()) {
+        // Mark IRC server as sending valid ping replies
+        if (!coreNetwork(e)->isPongTimestampValid()) {
+            coreNetwork(e)->setPongTimestampValid(true);
+            // Add a message the first time it happens
+            qDebug().nospace() << "Received PONG with valid timestamp, marking pong replies on "
+                                  "network "
+                               << "\"" << qPrintable(e->network()->networkName()) << "\" (ID: "
+                               << qPrintable(QString::number(e->network()->networkId().toInt()))
+                               << ") as usable for latency measurement";
+        }
+        // Remove pending flag
+        coreNetwork(e)->resetPongReplyPending();
+
+        // Don't show this in the UI
+        e->setFlag(EventManager::Silent);
+        // TODO:  To allow for a user-sent /ping (without arguments, so default timestamp is used),
+        // this could track how many automated PINGs have been sent by the core and subtract one
+        // each time, only marking the PING as silent if there's pending automated pong replies.
+        // However, that's a behavior change which warrants further testing.  For now, take the
+        // simpler, previous approach that errs on the side of silencing too much.
+
         // Calculate latency from time difference, divided by 2 to account for round-trip time
         e->network()->setLatency(sendTime.msecsTo(QTime::currentTime()) / 2);
-    } else {
-        // Just in case it's a wonky server, log a debug message to make this easier to track down
-        qDebug() << "Received valid PONG with invalid timestamp, parameters are" << e->params();
+    } else if (coreNetwork(e)->isPongReplyPending() && !coreNetwork(e)->isPongTimestampValid()) {
+        // There's an auto-PING reply pending and we've not yet received a PONG reply with a valid
+        // timestamp.  It's possible this server will never respond with a valid timestamp, and thus
+        // any automated PINGs will result in unwanted spamming of the server buffer.
+
+        // Don't show this in the UI
+        e->setFlag(EventManager::Silent);
+        // Remove pending flag
+        coreNetwork(e)->resetPongReplyPending();
+
+        // Log a message
+        qDebug().nospace() << "Received PONG with invalid timestamp from network "
+                           << "\"" << qPrintable(e->network()->networkName()) << "\" (ID: "
+                           << qPrintable(QString::number(e->network()->networkId().toInt()))
+                           << "), silencing, parameters are " << e->params();
     }
+    // else: We're not expecting a PONG reply and timestamp is not valid, assume it's from the user
 }
 
 

--- a/src/core/eventstringifier.cpp
+++ b/src/core/eventstringifier.cpp
@@ -365,29 +365,11 @@ void EventStringifier::processIrcEventPart(IrcEvent *e)
 
 void EventStringifier::processIrcEventPong(IrcEvent *e)
 {
-    // Some IRC servers respond with only one parameter, others respond with two, with the latter
-    // being the text sent.  Handle both situations.
-    QString timestamp;
-    if (e->params().count() < 2) {
-        // Only one parameter received
-        // :localhost PONG 02:43:49.565
-        timestamp = e->params().at(0);
-    } else {
-        // Two parameters received, pick the second
-        // :localhost PONG localhost :02:43:49.565
-        timestamp = e->params().at(1);
-    }
+    // CoreSessionEventProcessor will flag automated PONG replies as EventManager::Silent.  There's
+    // no need to handle that specially here.
 
-    // Attempt to parse the timestamp
-    QTime sendTime = QTime::fromString(timestamp, "hh:mm:ss.zzz");
-    if (!sendTime.isValid()) {
-        // No valid timestamp found, this is most likely a user-specified PING message.
-        //
-        // Or the IRC server is returning whatever it feels like to PING messages, in which case..
-        // sorry.  Increase the ping timeout delay in Quassel to as high as possible, and go
-        // encourage your IRC server developer to fix their stuff.
-        displayMsg(e, Message::Server, "PONG " + e->params().join(" "), e->prefix());
-    }
+    // Format the PONG reply for display
+    displayMsg(e, Message::Server, "PONG " + e->params().join(" "), e->prefix());
 }
 
 


### PR DESCRIPTION
## In short

* Accept both 1 and 2 parameter `PONG` replies
  * Take the last parameter of either for timestamp calculation
  * Handles both `:localhost PONG 02:43:49.565` and `:localhost PONG localhost :02:43:49.565`
* Silence `PING` replies for invalid timestamps on servers that don't quote for `PONG`
  * Track if server sends valid timestamps; if not, hide next `PONG` after automated `PING`
  * Avoids spamming the server window with unwanted timestamps
  * Helps with [`irc.gitter.im`](https://irc.gitter.im), among others

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing `PING` improvements, fix single-parameter server
Risk | ★★☆ *2/3* | `PONG` replies may be hidden or shown at the wrong time
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

# Examples
## Single-parameter pong
*Tested using the [Oragono IRC server](https://oragono.io/), which currently sends single-parameter `PONG` replies.*

### Before
```
2018-06-17 20:27:36 Warning: IrcEventPong requires 2 params, got: ("20:27:36.708")
```

### After
**After, valid `PONG` with valid timestamp**
*No error message shown, lag correctly calculated*

## Invalid timestamp handling
### Before
*Quassel UI would show any `PONG` replies that did not conform to the timestamp of automated `PING` commands.*

**[Gitter](https://irc.gitter.im), invalid timestamp**
```
2018-06-18 11:28:00 Warning: IrcEventPong requires 2 params, got: ("irc.gitter.im")
2018-06-18 11:28:30 Warning: IrcEventPong requires 2 params, got: ("irc.gitter.im")
2018-06-18 11:29:00 Warning: IrcEventPong requires 2 params, got: ("irc.gitter.im")
[...]
```

### After
**Core-side**
*Quassel hides the next (and only the next) `PONG` reply following an automated `PING` until the network proves it will reply with a valid timestamp.*

```
2018-06-18 11:19:32 Debug: Received PONG with invalid timestamp from network "Gitter" (ID: 11), silencing, parameters are ("irc.gitter.im") 
2018-06-18 11:20:02 Debug: Received PONG with invalid timestamp from network "Gitter" (ID: 11), silencing, parameters are ("irc.gitter.im") 
2018-06-18 11:20:32 Debug: Received PONG with invalid timestamp from network "Gitter" (ID: 11), silencing, parameters are ("irc.gitter.im") 
2018-06-18 11:20:54 Debug: Received PONG with valid timestamp, marking pong replies on network "Freenode" (ID: 2) as usable for latency measurement 
2018-06-18 11:21:02 Debug: Received PONG with invalid timestamp from network "Gitter" (ID: 11), silencing, parameters are ("irc.gitter.im")
```

*Manual /ping commands still work unless sent immediately after an automated `PING` if the server replies to the manual `PING` before the automated `PING`.*

**Freenode, marked as valid timestamp**
```
[automated PING]
2018-06-18 11:20:54 Debug: Received PONG with valid timestamp, marking pong replies on network "Freenode" (ID: 2) as usable for latency measurement 
/ping Test
[11:23:43 am] * PONG adams.freenode.net Test
[further automated PINGs don't result in debug messages]
```

**[Gitter](https://irc.gitter.im), invalid timestamp**
```
[automated PING]
2018-06-18 11:19:32 Debug: Received PONG with invalid timestamp from network "Gitter" (ID: 11), silencing, parameters are ("irc.gitter.im") 
2018-06-18 11:20:02 Debug: Received PONG with invalid timestamp from network "Gitter" (ID: 11), silencing, parameters are ("irc.gitter.im") 
/ping Test
[11:20:02 am] * PONG irc.gitter.im
/ping Test
[11:20:07 am] * PONG irc.gitter.im
[manual pings show, further automated PINGs result in debug messages]
2018-06-18 11:20:32 Debug: Received PONG with invalid timestamp from network "Gitter" (ID: 11), silencing, parameters are ("irc.gitter.im") 
[...]
```