### PR TITLE
client: Fix include typo, "icon.h" not "icon"

### DIFF
--- a/src/qtui/indicatornotificationbackend.cpp
+++ b/src/qtui/indicatornotificationbackend.cpp
@@ -28,7 +28,7 @@
 
 #include "client.h"
 #include "clientsettings.h"
-#include "icon"
+#include "icon.h"
 #include "mainwin.h"
 #include "networkmodel.h"
 #include "qtui.h"


### PR DESCRIPTION
## In brief

* Fix typo in `src/qtui/indicatornotificationbackend.cpp`
  * Use `#include "icon.h"`, not `#include "icon"`
  * Fixes one [build failure on Ubuntu 14.04](https://launchpadlibrarian.net/374946808/buildlog_ubuntu-trusty-amd64.quassel_0.13.0~alpha+201806172210-0ubuntu0~built201806180131~git5e4bfce~ubuntu14.04.1_BUILDING.txt.gz )

*Thanks to @mamarley for reporting this!*

*As this is a trivial change, I've skipped the usual breakdown and analysis.  Only risk should be still failing to compile.*