### PR TITLE
aboutdata: Rename QuasselDroid → Quasseldroid

### DIFF
--- a/src/uisupport/aboutdata.cpp
+++ b/src/uisupport/aboutdata.cpp
@@ -178,7 +178,7 @@ void AboutData::setQuasselPersons(AboutData *aboutData)
         { "Sebastian Goth", "seezer", tr("Many features, fixes and improvements") },
         { "Bas Pape", "Tucos", tr("Many fixes and improvements, bug and patch triaging, community support") },
         { "Shane Synan", "digitalcircuit", tr("IRCv3 support, documentation, many other improvements, testing, outstanding PRs") },
-        { "Janne Koschinski", "justJanne", tr("QuasselDroid, architecture, (mobile) performance, many other improvements and fixes, testing") },
+        { "Janne Koschinski", "justJanne", tr("Quasseldroid, architecture, (mobile) performance, many other improvements and fixes, testing") },
     });
 
     aboutData->addCredits({


### PR DESCRIPTION
## In brief
* Rename @justJanne 's `QuasselDroid` to `Quasseldroid`
  * Matches [upstream branding rename](https://git.kuschku.de/justJanne/QuasselDroid-ng/commit/5e08f048764171d550ce17127c4075709bf9c2cd ) (*to reduce risk of lawsuit over `Droid`*)
  * Other mention of `QuasselDroid` from `sandsmark` left alone, as that project's not renamed

*As this is a trivial change, I've skipped the usual breakdown and analysis.  Only risk should be incorrect about data - feel free to comment here or correct afterwards.*