### PR TITLE
client: Fix text format shortcuts edge case

### DIFF
--- a/src/qtui/inputwidget.cpp
+++ b/src/qtui/inputwidget.cpp
@@ -554,16 +554,16 @@ void InputWidget::changeNick(const QString &newNick) const
 void InputWidget::onTextEntered(const QString &text)
 {
     Client::userInput(currentBufferInfo(), text);
-    ui.boldButton->setChecked(false);
-    ui.underlineButton->setChecked(false);
-    ui.italicButton->setChecked(false);
 
+    // Remove formatting from entered text
+    // TODO: Offer a way to convert pasted text to mIRC formatting codes
     setFormatClear(true);
 }
 
 
 void InputWidget::setFormatClear(const bool global)
 {
+    // Apply formatting
     QTextCharFormat fmt;
     fmt.setFontWeight(QFont::Normal);
     fmt.setFontUnderline(false);
@@ -575,30 +575,44 @@ void InputWidget::setFormatClear(const bool global)
     } else {
         setFormatOnSelection(fmt);
     }
+
+    // Make sure UI state follows
+    ui.boldButton->setChecked(false);
+    ui.italicButton->setChecked(false);
+    ui.underlineButton->setChecked(false);
 }
 
 
 void InputWidget::setFormatBold(const bool bold)
 {
+    // Apply formatting
     QTextCharFormat fmt;
     fmt.setFontWeight(bold ? QFont::Bold : QFont::Normal);
     mergeFormatOnSelection(fmt);
+    // Make sure UI state follows
+    ui.boldButton->setChecked(bold);
 }
 
 
 void InputWidget::setFormatItalic(const bool italic)
 {
+    // Apply formatting
     QTextCharFormat fmt;
     fmt.setFontItalic(italic);
     mergeFormatOnSelection(fmt);
+    // Make sure UI state follows
+    ui.italicButton->setChecked(italic);
 }
 
 
 void InputWidget::setFormatUnderline(const bool underline)
 {
+    // Apply formatting
     QTextCharFormat fmt;
     fmt.setFontUnderline(underline);
     mergeFormatOnSelection(fmt);
+    // Make sure UI state follows
+    ui.underlineButton->setChecked(underline);
 }
 
 


### PR DESCRIPTION
## In brief
* Fix issue where sometimes text shortcuts could not change formatting
  * When toggling text formatting via keyboard, always update button state
  * Fixes issue where formatting could not be removed by shortcut, only by button

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing edge case where keyboard shortcuts break
Risk | ★☆☆ *1/3* | Possible mismatch between format state and actual text
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other pull requests

*Note: I originally avoided doing this out of concern it'd create a loop with the `clicked()` signal firing when setting check state.  Thankfully that's not the case.*

## Testing
### Steps

1.  Type `test message here`
2.  Select `message`, mark as italic (*button or shortcut*)
3.  Move cursor to end of message, so italic button becomes unpressed
4.  Click at the end of the word `message` (*after the `e`*), and drag-select/<kbd>Shift+Arrow</kbd> select up to the beginning of the message (*before the `m`*).
5.  Use shortcut to toggle italic, several times
6.  Use button to toggle italic, several times

### Before
The italic shortcut would not toggle on then off, clearing the format.

### After
The italic shortcut works after toggling twice, just like the button.

*Having to toggle twice in this situation is a bug that existed before the formatting shortcut changes.*