### PR TITLE
/mode: Prepend current nickname if buffer has no name

### DIFF
--- a/src/core/coreuserinputhandler.cpp
+++ b/src/core/coreuserinputhandler.cpp
@@ -474,7 +474,6 @@ void CoreUserInputHandler::handleMode(const BufferInfo &bufferInfo, const QStrin
     Q_UNUSED(bufferInfo)
 
     QStringList params = msg.split(' ', QString::SkipEmptyParts);
-    // if the first argument is neither a channel nor us (user modes are only to oneself) the current buffer is assumed to be the target
     if (!params.isEmpty()) {
         if (params[0] == "-reset" && params.count() == 1) {
             network()->resetPersistentModes();
@@ -483,7 +482,11 @@ void CoreUserInputHandler::handleMode(const BufferInfo &bufferInfo, const QStrin
             return;
         }
         if (!network()->isChannelName(params[0]) && !network()->isMyNick(params[0]))
-            params.prepend(bufferInfo.bufferName());
+            // If the first argument is neither a channel nor us (user modes are only to oneself)
+            // the current buffer is assumed to be the target.
+            // If the current buffer returns no name (e.g. status buffer), assume target is us.
+            params.prepend(!bufferInfo.bufferName().isEmpty() ?
+                                bufferInfo.bufferName() : network()->myNick());
         if (network()->isMyNick(params[0]) && params.count() == 2)
             network()->updateIssuedModes(params[1]);
     }


### PR DESCRIPTION
Currently when running `/mode ...` without having a valid channel name or our current IRC nick as the first parameter, the current buffer name is prepended. This works great when running from a channel buffer or a user query (typically changing modes of other users will fail, but that's not a Quassel problem).  
When ran from the status buffer, the buffer name returned is an empty string, so we can check for this and prepend our current IRC nick to be able to shortcut (for example: `/mode +R`) from the status buffer. This does not effect the channel/user prepending as mentioned before.

### Testing
**Before:**
From channel: `/mode +R` ; Mode +R is set on the channel
From user query: `/mode +R` ; Server returns `Can't change mode for other users`
From server query: `/mode +R` ; Server returns `<server name>: No such nick/channel`
From status buffer: `/mode +R` ; Server returns `+R: No such nick/channel`

**After:**
From channel: `/mode +R` ; Mode +R is set on the channel
From user query: `/mode +R` ; Server returns `Can't change mode for other users`
From server query: `/mode +R` ; Server returns `<server name>: No such nick/channel`
From status buffer: `/mode +R` ; Mode +R is set on myself

Also tested this with `/m` aliased to both `/mode $0` and `/mode $channel $0` with the same results throughout.