### PR TITLE
common: Use UTF-8 server encoding by default

### DIFF
--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -104,7 +104,7 @@ bool Quassel::init()
     instance()->setupEnvironment();
     instance()->registerMetaTypes();
 
-    Network::setDefaultCodecForServer("ISO-8859-1");
+    Network::setDefaultCodecForServer("UTF-8");
     Network::setDefaultCodecForEncoding("UTF-8");
     Network::setDefaultCodecForDecoding("ISO-8859-15");
 

--- a/src/qtui/settingspages/networkssettingspage.ui
+++ b/src/qtui/settingspages/networkssettingspage.ui
@@ -971,8 +971,7 @@ This setting defines the encoding for messages that are not UTF-8.</string>
                <item row="2" column="0">
                 <widget class="QLabel" name="label_9">
                  <property name="toolTip">
-                  <string>This specifies how control messages, nicks and servernames are encoded.
-Unless you *really* know what you do, leave this as ISO-8859-1!</string>
+                  <string>&lt;qt&gt;&lt;p&gt;This specifies how control messages, nicks and servernames are encoded.&lt;/p&gt;&lt;p&gt;&lt;b&gt;UTF-8&lt;/b&gt; should be fine for modern networks.  On other networks, you may need to use &lt;b&gt;ISO-8859-1&lt;/b&gt; to avoid errors with illegal characters and invalid encoding.&lt;/p&gt;&lt;/qt&gt;</string>
                  </property>
                  <property name="text">
                   <string>Server encoding:</string>
@@ -985,8 +984,7 @@ Unless you *really* know what you do, leave this as ISO-8859-1!</string>
                   <bool>true</bool>
                  </property>
                  <property name="toolTip">
-                  <string>This specifies how control messages, nicks and servernames are encoded.
-Unless you *really* know what you do, leave this as ISO-8859-1!</string>
+                  <string>&lt;qt&gt;&lt;p&gt;This specifies how control messages, nicks and servernames are encoded.&lt;/p&gt;&lt;p&gt;&lt;b&gt;UTF-8&lt;/b&gt; should be fine for modern networks.  On other networks, you may need to use &lt;b&gt;ISO-8859-1&lt;/b&gt; to avoid errors with illegal characters and invalid encoding.&lt;/p&gt;&lt;/qt&gt;</string>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
## In short

* Switch to `UTF-8` as default codec for server
  * Fixes non-ASCII characters in `/away`/etc silently being converted to `???` marks
  * Don't modify default decoding codec, `UTF-8` is handled already
  * New client/old core will show wrong default encoding, specifying `ISO-8859-1` still works
  * Affects all networks without custom encoding, migration would be complex
* Update tooltips to offer guidance on restoring server encoding

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing, fixes silent failure of `UTF-8` in `/away`, channel names, etc
Risk | ★★★ *3/3* | Changes server to `UTF-8` for networks without custom encoding
Intrusiveness | ★☆☆ *1/3* | Tooltip/defaults changes, shouldn't interfere with other pull requests

*Thanks to @disconsented for bringing this issue to attention again.*

## Rationale
IRC is used in many languages other than English, and when possible, Quassel should accomodate this.  Thankfully, Quassel handles Unicode pretty much everywhere, but configuring Quassel to do so can be somewhat non-intuitive.

Quassel should instead default to `UTF-8` for server encoding, relying on IRC servers to provide error messages when they cannot accept characters to inform users to change, rather than assuming the worst-case and silently discarding special characters.

This is a matter of trade-offs.  Invalid encoding can result in error messages or server disconnecting, confusing but noisy.  However, too limited of an encoding simply silently converts characters to question marks, in e.g. `/away` messages or nicks.  No warnings are printed.

Is the IRC world ready for `UTF-8` by default as a server encoding?

Well.. that's hard to say.  This can be overridden per-network (*even with an old client!*), and this commit is also easily reverted.  It's probably worthwhile trying in beta, reverting before release if too many things break.  IRC servers should at least provide error messages.

(*I personally think it's time to switch.  Partially since it took me 1-2 years before finding out this is why I couldn't join `UTF-8` channels on a certain network.  And it's still confusing people today with e.g. non-ASCII in `/away` messages.*)

### Breaking changes
* Network server codec is now `UTF-8` by default when not customized
  * Can be reverted to `ISO-8859-1` in `Network` `Encodings` settings, even with older clients
* Mismatching client/core versions will display wrong defaults in UI
  * Visual error, picking a custom encoding still works

## Examples
*Using Freenode as an example of a partially `UTF-8` server network*

### Before
**Server encoding of `ISO-8859-1` is used by default**

```
/join ##test♪
[8:18:31 pm] --> digitalcircuit (...) has joined ##test?
/nick digitalcircuit♪
[8:19:06 pm] * No free and valid nicks in nicklist found. use: /nick <othernick> to continue
[8:19:06 pm] * Nick digitalcircuit? contains illegal characters
/away Now playing ♪ Songs to Test
[8:21:11 pm] * You have been marked as being away
/whois digitalcircuit
[...]
[8:21:18 pm] * [Whois] digitalcircuit is away: "Now playing ? Songs to Test"
```

### After
**Server encoding of `UTF-8` is used by default**

*Notice how Freenode accepts `UTF-8` in `/away` messages despite disallowing it in channel and nicknames.  Freenode also provides appropriate error messages.*

```
/join ##test♪
[8:16:57 pm] * 479 ##test♪ Illegal channel name
/nick digitalcircuit♪
[8:17:39 pm] * No free and valid nicks in nicklist found. use: /nick <othernick> to continue
[8:17:39 pm] * Nick digitalcircuit�� contains illegal characters
/away Now playing ♪ Songs to Test
[8:21:46 pm] * You have been marked as being away
/whois digitalcircuit
[...]
[8:22:12 pm] * [Whois] digitalcircuit is away: "Now playing ♪ Songs to Test"
```

### Tooltip guidance
*In `Settings` → `IRC` → `Networks` → pick a network → `Encodings`, tooltip for `Server encoding:`*
![Settings - IRC - Networks - network chosen - Encodings - Server encoding tooltip](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-update-encode-defaults/Network%20Encodings%20tooltip.png#v1 )

*Tooltip*
> This specifies how control messages, nicks, and servernames are encoded.
> 
> **UTF-8** should be fine for modern networks.  On other networks, you may need to use **ISO-8859-1** to avoid errors with illegal characters and invalid encoding.