### PR TITLE
core: Fix oidentd signal connection, cleanup

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -100,13 +100,17 @@ CoreNetwork::CoreNetwork(const NetworkId &networkid, CoreSession *session)
     connect(this, SIGNAL(capRemoved(QString)), this, SLOT(serverCapRemoved(QString)));
 
     if (Quassel::isOptionSet("oidentd")) {
-        connect(this, SIGNAL(socketInitialized(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(addSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Qt::BlockingQueuedConnection);
-        connect(this, SIGNAL(socketDisconnected(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)), Core::instance()->oidentdConfigGenerator(), SLOT(removeSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16)));
+        connect(this, SIGNAL(socketInitialized(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16, qint64)),
+                Core::instance()->oidentdConfigGenerator(), SLOT(addSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16, qint64)), Qt::BlockingQueuedConnection);
+        connect(this, SIGNAL(socketDisconnected(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16, qint64)),
+                Core::instance()->oidentdConfigGenerator(), SLOT(removeSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16, qint64)));
     }
 
     if (Quassel::isOptionSet("ident-daemon")) {
-        connect(this, SIGNAL(socketInitialized(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16, qint64)), Core::instance()->identServer(), SLOT(addSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16, qint64)), Qt::BlockingQueuedConnection);
-        connect(this, SIGNAL(socketDisconnected(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16, qint64)), Core::instance()->identServer(), SLOT(removeSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16, qint64)));
+        connect(this, SIGNAL(socketInitialized(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16, qint64)),
+                Core::instance()->identServer(), SLOT(addSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16, qint64)), Qt::BlockingQueuedConnection);
+        connect(this, SIGNAL(socketDisconnected(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16, qint64)),
+                Core::instance()->identServer(), SLOT(removeSocket(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16, qint64)));
     }
 }
 

--- a/src/core/oidentdconfiggenerator.cpp
+++ b/src/core/oidentdconfiggenerator.cpp
@@ -76,9 +76,16 @@ QString OidentdConfigGenerator::sysIdentForIdentity(const CoreIdentity *identity
 }
 
 
-bool OidentdConfigGenerator::addSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort)
+bool OidentdConfigGenerator::addSocket(const CoreIdentity *identity,
+                                       const QHostAddress &localAddress, quint16 localPort,
+                                       const QHostAddress &peerAddress, quint16 peerPort,
+                                       qint64 socketId)
 {
-    Q_UNUSED(localAddress) Q_UNUSED(peerAddress) Q_UNUSED(peerPort)
+    Q_UNUSED(localAddress)
+    Q_UNUSED(peerAddress)
+    Q_UNUSED(peerPort)
+    Q_UNUSED(socketId)
+
     const QString ident = sysIdentForIdentity(identity);
 
     _quasselConfig.append(_quasselStanzaTemplate.arg(localPort).arg(ident).arg(_configTag).toLatin1());
@@ -90,9 +97,18 @@ bool OidentdConfigGenerator::addSocket(const CoreIdentity *identity, const QHost
 
 
 //! not yet implemented
-bool OidentdConfigGenerator::removeSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort)
+bool OidentdConfigGenerator::removeSocket(const CoreIdentity *identity,
+                                          const QHostAddress &localAddress, quint16 localPort,
+                                          const QHostAddress &peerAddress, quint16 peerPort,
+                                          qint64 socketId)
 {
-    Q_UNUSED(identity) Q_UNUSED(localAddress) Q_UNUSED(localPort) Q_UNUSED(peerAddress) Q_UNUSED(peerPort)
+    Q_UNUSED(identity)
+    Q_UNUSED(localAddress)
+    Q_UNUSED(localPort)
+    Q_UNUSED(peerAddress)
+    Q_UNUSED(peerPort)
+    Q_UNUSED(socketId)
+
     return true;
 }
 

--- a/src/core/oidentdconfiggenerator.h
+++ b/src/core/oidentdconfiggenerator.h
@@ -63,8 +63,12 @@ public:
     ~OidentdConfigGenerator();
 
 public slots:
-    bool addSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
-    bool removeSocket(const CoreIdentity *identity, const QHostAddress &localAddress, quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort);
+    bool addSocket(const CoreIdentity *identity, const QHostAddress &localAddress,
+                   quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort,
+                   qint64 socketId);
+    bool removeSocket(const CoreIdentity *identity, const QHostAddress &localAddress,
+                      quint16 localPort, const QHostAddress &peerAddress, quint16 peerPort,
+                      qint64 socketId);
 
 private:
     QString sysIdentForIdentity(const CoreIdentity *identity) const;


### PR DESCRIPTION
## In short

* Update `OidentdConfigGenerator` signal connections, adding missing `socketId`
  * Added [in integrated `identd` commit, 41b9d68](https://github.com/quassel/quassel/commit/41b9d689945e784b160a25d12076600ff4b7ae90 )
  * Fixes `oidentd` breakage, warning about signals/slots not matching up
* Clean up line length and spacing

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | Fix `oidentd` signal/slot issues, avoid lengthy warning messages
Risk | ★☆☆ *1/3* | Signal/slot usage might be incorrect
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

*Thanks to @genius3000 for finding this issue!*

## Examples
**Command used**
```
./run-profile.sh master core local --oidentd --oidentd-conffile /tmp/test
```

### Before
*Two pairs of warnings for each configured network*
```
2018-06-18 21:32:41 Warning: QObject::connect: No such signal CoreNetwork::socketInitialized(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16) in [...]quassel/src/core/corenetwork.cpp:103 
2018-06-18 21:32:41 Warning: QObject::connect:  (sender name:   '3') 
2018-06-18 21:32:41 Warning: QObject::connect: No such signal CoreNetwork::socketDisconnected(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16) in [...]quassel/src/core/corenetwork.cpp:104 
2018-06-18 21:32:41 Warning: QObject::connect:  (sender name:   '3') 
[...]
2018-06-18 21:32:41 Warning: QObject::connect: No such signal CoreNetwork::socketInitialized(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16) in [...]quassel/src/core/corenetwork.cpp:103 
2018-06-18 21:32:41 Warning: QObject::connect:  (sender name:   '10') 
2018-06-18 21:32:41 Warning: QObject::connect: No such signal CoreNetwork::socketDisconnected(const CoreIdentity*, QHostAddress, quint16, QHostAddress, quint16) in [...]quassel/src/core/corenetwork.cpp:104 
2018-06-18 21:32:41 Warning: QObject::connect:  (sender name:   '10')
```

### After
*No warnings in log file*