### PR TITLE
Fix default port for integrated ident daemon

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -192,7 +192,7 @@ int main(int argc, char **argv)
     cliParser->addOption("oidentd-conffile", 0, "Set path to oidentd configuration file", "file");
     cliParser->addSwitch("strict-ident", 0, "Use users' quasselcore username as ident reply. Ignores each user's configured ident setting.");
     cliParser->addSwitch("ident-daemon", 0, "Enable internal ident daemon");
-    cliParser->addOption("ident-port", 0, "The port quasselcore will listen at for ident requests. Only meaningful with --ident-daemon", "10113");
+    cliParser->addOption("ident-port", 0, "The port quasselcore will listen at for ident requests. Only meaningful with --ident-daemon", "port", "10113");
 #ifdef HAVE_SSL
     cliParser->addSwitch("require-ssl", 0, "Require SSL for remote (non-loopback) client connections");
     cliParser->addOption("ssl-cert", 0, "Specify the path to the SSL Certificate", "path", "configdir/quasselCert.pem");


### PR DESCRIPTION
The value for the option identifier was missing, causing what was
intended to be the default value to actually become the identifier
and the default value to be undefined.  This resulted in random
ports being chosen.