### PR TITLE
client: Convert /list #chan to advanced search, auto-search, polish

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -172,12 +172,14 @@ public:
      *
      * @see Client::showChannelList()
      *
-     * @param networkId       Network ID for associated network
-     * @param channelFilters  Partial channel name to search for, or empty to show all
+     * @param networkId        Network ID for associated network
+     * @param channelFilters   Partial channel name to search for, or empty to show all
+     * @param listImmediately  If true, immediately list channels, otherwise just show dialog
      */
-    void displayChannelList(NetworkId networkId, const QString &channelFilters = {})
+    void displayChannelList(NetworkId networkId, const QString &channelFilters = {},
+                            bool listImmediately = false)
     {
-        emit showChannelList(networkId, channelFilters);
+        emit showChannelList(networkId, channelFilters, listImmediately);
     }
 
 signals:
@@ -190,10 +192,13 @@ signals:
      *
      * @see MainWin::showChannelList()
      *
-     * @param networkId       Network ID for associated network
-     * @param channelFilters  Partial channel name to search for, or empty to show all
+     * @param networkId        Network ID for associated network
+     * @param channelFilters   Partial channel name to search for, or empty to show all
+     * @param listImmediately  If true, immediately list channels, otherwise just show dialog
      */
-    void showChannelList(NetworkId networkId, const QString &channelFilters = {});
+    void showChannelList(NetworkId networkId, const QString &channelFilters = {},
+                         bool listImmediately = false);
+
     void showIgnoreList(QString ignoreRule);
 
     void connected();

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -167,15 +167,33 @@ public:
         emit showIgnoreList(ignoreRule);
     }
 
-    void displayChannelList(NetworkId networkId) {
-        emit showChannelList(networkId);
+    /**
+     * Request to show the channel list dialog for the network, optionally searching by channel name
+     *
+     * @see Client::showChannelList()
+     *
+     * @param networkId       Network ID for associated network
+     * @param channelFilters  Partial channel name to search for, or empty to show all
+     */
+    void displayChannelList(NetworkId networkId, const QString &channelFilters = {})
+    {
+        emit showChannelList(networkId, channelFilters);
     }
 
 signals:
     void requestNetworkStates();
 
     void showConfigWizard(const QVariantMap &coredata);
-    void showChannelList(NetworkId networkId);
+
+    /**
+     * Request to show the channel list dialog for the network, optionally searching by channel name
+     *
+     * @see MainWin::showChannelList()
+     *
+     * @param networkId       Network ID for associated network
+     * @param channelFilters  Partial channel name to search for, or empty to show all
+     */
+    void showChannelList(NetworkId networkId, const QString &channelFilters = {});
     void showIgnoreList(QString ignoreRule);
 
     void connected();

--- a/src/client/clientuserinputhandler.cpp
+++ b/src/client/clientuserinputhandler.cpp
@@ -142,8 +142,8 @@ void ClientUserInputHandler::handleIgnore(const BufferInfo &bufferInfo, const QS
 
 void ClientUserInputHandler::handleList(const BufferInfo &bufferInfo, const QString &text)
 {
-    Q_UNUSED(text)
-    Client::instance()->displayChannelList(bufferInfo.networkId());
+    // Pass along any potential search parameters
+    Client::instance()->displayChannelList(bufferInfo.networkId(), text);
 }
 
 

--- a/src/client/clientuserinputhandler.cpp
+++ b/src/client/clientuserinputhandler.cpp
@@ -142,8 +142,8 @@ void ClientUserInputHandler::handleIgnore(const BufferInfo &bufferInfo, const QS
 
 void ClientUserInputHandler::handleList(const BufferInfo &bufferInfo, const QString &text)
 {
-    // Pass along any potential search parameters
-    Client::instance()->displayChannelList(bufferInfo.networkId(), text);
+    // Pass along any potential search parameters, list channels immediately
+    Client::instance()->displayChannelList(bufferInfo.networkId(), text, true);
 }
 
 

--- a/src/qtui/channellistdlg.cpp
+++ b/src/qtui/channellistdlg.cpp
@@ -84,6 +84,15 @@ void ChannelListDlg::setNetwork(NetworkId netId)
 }
 
 
+void ChannelListDlg::setChannelFilters(const QString &channelFilters)
+{
+    // Enable advanced mode if searching
+    setAdvancedMode(!channelFilters.isEmpty());
+    // Set channel search text after setting advanced mode so it's not cleared
+    ui.channelNameLineEdit->setText(channelFilters.trimmed());
+}
+
+
 void ChannelListDlg::requestSearch()
 {
     _listFinished = false;

--- a/src/qtui/channellistdlg.cpp
+++ b/src/qtui/channellistdlg.cpp
@@ -100,6 +100,11 @@ void ChannelListDlg::setChannelFilters(const QString &channelFilters)
 
 void ChannelListDlg::requestSearch()
 {
+    if (!_netId.isValid()) {
+        // No valid network set yet
+        return;
+    }
+
     _listFinished = false;
     enableQuery(false);
     showErrors(false);

--- a/src/qtui/channellistdlg.cpp
+++ b/src/qtui/channellistdlg.cpp
@@ -49,6 +49,8 @@ ChannelListDlg::ChannelListDlg(QWidget *parent)
     ui.channelListView->setTabKeyNavigation(false);
     ui.channelListView->setModel(&_sortFilter);
     ui.channelListView->setSortingEnabled(true);
+    // Sort A-Z by default
+    ui.channelListView->sortByColumn(0, Qt::AscendingOrder);
     ui.channelListView->verticalHeader()->hide();
     ui.channelListView->horizontalHeader()->setStretchLastSection(true);
 
@@ -70,6 +72,9 @@ ChannelListDlg::ChannelListDlg(QWidget *parent)
     enableQuery(true);
     showFilterLine(false);
     showErrors(false);
+
+    // Set initial input focus
+    updateInputFocus();
 }
 
 
@@ -113,6 +118,8 @@ void ChannelListDlg::receiveChannelList(const NetworkId &netId, const QStringLis
     showFilterLine(!channelList.isEmpty());
     _ircListModel.setChannelList(channelList);
     enableQuery(_listFinished);
+    // Reset input focus since UI changed
+    updateInputFocus();
 }
 
 
@@ -154,6 +161,18 @@ void ChannelListDlg::setAdvancedMode(bool advanced)
     ui.channelNameLineEdit->clear();
     ui.channelNameLineEdit->setVisible(advanced);
     ui.searchPatternLabel->setVisible(advanced);
+}
+
+
+void ChannelListDlg::updateInputFocus()
+{
+    // Update keyboard focus to match what options are available.  Prioritize the channel name
+    // editor as one likely won't need to filter when already limiting the list.
+    if (ui.channelNameLineEdit->isVisible()) {
+        ui.channelNameLineEdit->setFocus();
+    } else if (ui.filterLineEdit->isVisible()) {
+        ui.filterLineEdit->setFocus();
+    }
 }
 
 

--- a/src/qtui/channellistdlg.h
+++ b/src/qtui/channellistdlg.h
@@ -66,6 +66,11 @@ private:
     void enableQuery(bool enable);
     void setAdvancedMode(bool advanced);
 
+    /**
+     * Update the focus of input widgets according to dialog state
+     */
+    void updateInputFocus();
+
     Ui::ChannelListDlg ui;
 
     bool _listFinished;

--- a/src/qtui/channellistdlg.h
+++ b/src/qtui/channellistdlg.h
@@ -50,8 +50,13 @@ public:
      */
     void setChannelFilters(const QString &channelFilters);
 
-protected slots:
+public slots:
+    /**
+     * Request a channel listing using any parameters set in the UI
+     */
     void requestSearch();
+
+protected slots:
     void receiveChannelList(const NetworkId &netId, const QStringList &channelFilters, const QList<IrcListHelper::ChannelDescription> &channelList);
     void reportFinishedList();
     void joinChannel(const QModelIndex &);

--- a/src/qtui/channellistdlg.h
+++ b/src/qtui/channellistdlg.h
@@ -40,6 +40,16 @@ public:
 
     void setNetwork(NetworkId netId);
 
+    /**
+     * Set the channel search string, enabling advanced mode if needed
+     *
+     * Sets the channel name search text to the specified string, enabling advanced mode.  If search
+     * string is empty, advanced mode will be automatically hidden.
+     *
+     * @param channelFilters Partial channel name to search for, or empty to not filter by name
+     */
+    void setChannelFilters(const QString &channelFilters);
+
 protected slots:
     void requestSearch();
     void receiveChannelList(const NetworkId &netId, const QStringList &channelFilters, const QList<IrcListHelper::ChannelDescription> &channelList);

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -207,11 +207,11 @@ void MainWin::init()
     connect(Client::messageModel(), SIGNAL(rowsInserted(const QModelIndex &, int, int)),
         SLOT(messagesInserted(const QModelIndex &, int, int)));
     connect(GraphicalUi::contextMenuActionProvider(),
-            SIGNAL(showChannelList(NetworkId, const QString &)),
-            SLOT(showChannelList(NetworkId, const QString &)));
+            SIGNAL(showChannelList(NetworkId,QString,bool)),
+            SLOT(showChannelList(NetworkId,QString,bool)));
     connect(Client::instance(),
-            SIGNAL(showChannelList(NetworkId, const QString &)),
-            SLOT(showChannelList(NetworkId, const QString &)));
+            SIGNAL(showChannelList(NetworkId,QString,bool)),
+            SLOT(showChannelList(NetworkId,QString,bool)));
     connect(GraphicalUi::contextMenuActionProvider(), SIGNAL(showNetworkConfig(NetworkId)), SLOT(showNetworkConfig(NetworkId)));
     connect(GraphicalUi::contextMenuActionProvider(), SIGNAL(showIgnoreList(QString)), SLOT(showIgnoreList(QString)));
     connect(Client::instance(), SIGNAL(showIgnoreList(QString)), SLOT(showIgnoreList(QString)));
@@ -1473,7 +1473,7 @@ void MainWin::showCoreConfigWizard(const QVariantList &backends, const QVariantL
 }
 
 
-void MainWin::showChannelList(NetworkId netId, const QString &channelFilters)
+void MainWin::showChannelList(NetworkId netId, const QString &channelFilters, bool listImmediately)
 {
     ChannelListDlg *channelListDlg = new ChannelListDlg();
 
@@ -1498,6 +1498,9 @@ void MainWin::showChannelList(NetworkId netId, const QString &channelFilters)
     channelListDlg->setNetwork(netId);
     if (!channelFilters.isEmpty()) {
         channelListDlg->setChannelFilters(channelFilters);
+    }
+    if (listImmediately) {
+        channelListDlg->requestSearch();
     }
     channelListDlg->show();
 }

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -125,10 +125,13 @@ private slots:
     /**
      * Show the channel list dialog for the network, optionally searching by channel name
      *
-     * @param networkId       Network ID for associated network
-     * @param channelFilters  Partial channel name to search for, or empty to show all
+     * @param networkId        Network ID for associated network
+     * @param channelFilters   Partial channel name to search for, or empty to show all
+     * @param listImmediately  If true, immediately list channels, otherwise just show dialog
      */
-    void showChannelList(NetworkId netId = {}, const QString &channelFilters = {});
+    void showChannelList(NetworkId netId = {}, const QString &channelFilters = {},
+                         bool listImmediately = false);
+
     void showNetworkConfig(NetworkId netId = NetworkId());
     void showCoreConnectionDlg();
     void showCoreConfigWizard(const QVariantList &, const QVariantList &);

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -121,7 +121,14 @@ private slots:
     void currentBufferChanged(BufferId);
     void messagesInserted(const QModelIndex &parent, int start, int end);
     void showAboutDlg();
-    void showChannelList(NetworkId netId = NetworkId());
+
+    /**
+     * Show the channel list dialog for the network, optionally searching by channel name
+     *
+     * @param networkId       Network ID for associated network
+     * @param channelFilters  Partial channel name to search for, or empty to show all
+     */
+    void showChannelList(NetworkId netId = {}, const QString &channelFilters = {});
     void showNetworkConfig(NetworkId netId = NetworkId());
     void showCoreConnectionDlg();
     void showCoreConfigWizard(const QVariantList &, const QVariantList &);

--- a/src/uisupport/networkmodelcontroller.cpp
+++ b/src/uisupport/networkmodelcontroller.cpp
@@ -412,8 +412,10 @@ void NetworkModelController::handleGeneralAction(ActionType type, QAction *actio
         break;
     }
     case ShowChannelList:
-        if (networkId.isValid())
-            emit showChannelList(networkId, {});
+        if (networkId.isValid()) {
+            // Don't immediately list channels, allowing customization of filter first
+            emit showChannelList(networkId, {}, false);
+        }
         break;
     case ShowNetworkConfig:
         if (networkId.isValid())

--- a/src/uisupport/networkmodelcontroller.cpp
+++ b/src/uisupport/networkmodelcontroller.cpp
@@ -413,7 +413,7 @@ void NetworkModelController::handleGeneralAction(ActionType type, QAction *actio
     }
     case ShowChannelList:
         if (networkId.isValid())
-            emit showChannelList(networkId);
+            emit showChannelList(networkId, {});
         break;
     case ShowNetworkConfig:
         if (networkId.isValid())

--- a/src/uisupport/networkmodelcontroller.h
+++ b/src/uisupport/networkmodelcontroller.h
@@ -159,10 +159,11 @@ signals:
      *
      * @see MainWin::showChannelList()
      *
-     * @param networkId       Network ID for associated network
-     * @param channelFilters  Partial channel name to search for, or empty to show all
+     * @param networkId        Network ID for associated network
+     * @param channelFilters   Partial channel name to search for, or empty to show all
+     * @param listImmediately  If true, immediately list channels, otherwise just show dialog
      */
-    void showChannelList(NetworkId, const QString &);
+    void showChannelList(NetworkId, const QString &, bool);
     void showNetworkConfig(NetworkId);
     void showIgnoreList(QString);
 

--- a/src/uisupport/networkmodelcontroller.h
+++ b/src/uisupport/networkmodelcontroller.h
@@ -154,7 +154,15 @@ protected slots:
     virtual void actionTriggered(QAction *);
 
 signals:
-    void showChannelList(NetworkId);
+    /**
+     * Request to show the channel list dialog for the network, optionally searching by channel name
+     *
+     * @see MainWin::showChannelList()
+     *
+     * @param networkId       Network ID for associated network
+     * @param channelFilters  Partial channel name to search for, or empty to show all
+     */
+    void showChannelList(NetworkId, const QString &);
     void showNetworkConfig(NetworkId);
     void showIgnoreList(QString);
 


### PR DESCRIPTION
## In short

* Pass `/list <params>` to channel list dialog when opening
  * Allows for `/list #channel` to search
  * Restores behavior similar to current stable release
* Immediately search when called via `/list` and `/list <params>`
  * Mimics behavior of non-UI `/quote list`
* Polish up the experience
  * Add more keyboard friendliness with input focus
  * Sort channels in ascending order by default
* Prompt when `/list` called without valid network selected
  * Fixes `/list` before any network selected resulting in useless channel list dialog
  * Happens when `/list` after connecting to core without any connected networks

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing regression fix, UI polish/keyboard readiness
Risk | ★☆☆ *1/3* | Channel list may not show at correct times
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other PRs

## Examples
**CAUTION: If testing, do not use `Freenode`.  Use a network that has a smaller channel list.**

### Before
*`/list` and `/list #test` behave the same way*
![Dialog shown when running '/list' on previous client, no channel results shown, 'Show Channels' must be clicked, sorting in descending channel name](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-list-cmd-ui-chanfilter/List%20command%20run%20-%20before.png#v1 )
*No content is shown, same as right-click network → `Show Channel List`, channel names Z-A*

### After
**Showing channel list via network right-click menu, keyboard shortcut**
*Behaves the same as before, no change*

**Showing channel list via `/list`**
![Dialog shown when running '/list' on new client, channel results shown without any extra steps, sorted in ascending channel name](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-list-cmd-ui-chanfilter/List%20command%20run%20-%20after%2C%20list.png#v1 )
*`Channel List` dialog immediately shows channel listing, no clicking buttons required, channel names A-Z*

**Searching for a specific channel via `/list #test`**
![Dialog shown when running '/list #test' on new client, specific channel result shown without any extra steps, sorted in ascending channel name](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-list-cmd-ui-chanfilter/List%20command%20run%20-%20after%2C%20list%20single.png#v1 )
*`Channel List` dialog immediately shows specific channel listing, enabling advanced mode, no clicking buttons required, channel names A-Z*

### No network selected
*Connect to core that has no networks connected, so Quassel keeps the welcome logo visible.  Run `/list` without selecting a network.*
![Dialog shown when running '/list' and no valid network is selected](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-list-cmd-ui-chanfilter/List%20command%20run%2C%20no%20network%20selected.png#v1 )

> \[dialog box with title `No network selected`\]
>
> :information_source: **No network selected**
>
> Select a network before trying to view the channel list.
>
> \[OK button\]