### PR TITLE
common: Fix buffer search wrongly showing on upgrade

### DIFF
--- a/src/common/bufferviewconfig.cpp
+++ b/src/common/bufferviewconfig.cpp
@@ -20,20 +20,10 @@
 
 #include "bufferviewconfig.h"
 
-#include "bufferinfo.h"
-
 INIT_SYNCABLE_OBJECT(BufferViewConfig)
 BufferViewConfig::BufferViewConfig(int bufferViewId, QObject *parent)
     : SyncableObject(parent),
-    _bufferViewId(bufferViewId),
-    _addNewBuffersAutomatically(true),
-    _sortAlphabetically(true),
-    _hideInactiveBuffers(false),
-    _hideInactiveNetworks(false),
-    _disableDecoration(false),
-    _allowedBufferTypes(BufferInfo::StatusBuffer | BufferInfo::ChannelBuffer | BufferInfo::QueryBuffer | BufferInfo::GroupBuffer),
-    _minimumActivity(0),
-    _showSearch(false)
+    _bufferViewId(bufferViewId)
 {
     setObjectName(QString::number(bufferViewId));
 }

--- a/src/common/bufferviewconfig.h
+++ b/src/common/bufferviewconfig.h
@@ -23,6 +23,7 @@
 
 #include "syncableobject.h"
 
+#include "bufferinfo.h"
 #include "types.h"
 
 class BufferViewConfig : public SyncableObject
@@ -129,17 +130,21 @@ signals:
 //   void setBufferViewNameRequested(const QString &bufferViewName);
 
 private:
-    int _bufferViewId;
-    QString _bufferViewName;
-    NetworkId _networkId;
-    bool _addNewBuffersAutomatically;
-    bool _sortAlphabetically;
-    bool _hideInactiveBuffers;
-    bool _hideInactiveNetworks;
-    bool _disableDecoration;
-    int _allowedBufferTypes;
-    int _minimumActivity;
-    bool _showSearch;
+    int _bufferViewId = 0;                   ///< ID of the associated BufferView
+    QString _bufferViewName = {};            ///< Display name of the associated BufferView
+    NetworkId _networkId = {};               ///< Network ID this buffer belongs to
+
+    bool _addNewBuffersAutomatically = true; ///< Automatically add new buffers when created
+    bool _sortAlphabetically = true;         ///< Sort buffers alphabetically
+    bool _hideInactiveBuffers = false;       ///< Hide buffers without activity
+    bool _hideInactiveNetworks = false;      ///< Hide networks without activity
+    bool _disableDecoration = false;         ///< Disable buffer decoration (not fully implemented)
+    /// Buffer types allowed within this view
+    int _allowedBufferTypes = (BufferInfo::StatusBuffer | BufferInfo::ChannelBuffer
+                               | BufferInfo::QueryBuffer | BufferInfo::GroupBuffer);
+    int _minimumActivity = 0;                ///< Minimum activity for a buffer to show
+    bool _showSearch = false;                ///< Persistently show the buffer search UI
+
     QList<BufferId> _buffers;
     QSet<BufferId> _removedBuffers;
     QSet<BufferId> _temporarilyRemovedBuffers;


### PR DESCRIPTION
## In short

* Fix initialization of default values when upgrading `BufferViewConfig`
  * Fixes wrongly enabling persistent buffer search on upgrade
  * Matches defaults for fresh configuration
  * Avoids cluttering the UI for upgrades, less likely to get complaints
  * Can still enable in the settings UI as before, or use keyboard shortcut
* Add more documentation

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Avoids user-facing unexpected UI changes on upgrade
Risk | ★☆☆ *1/3* | Possible wrong `BufferViewConfig` defaults, broken loading
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

*Polishes [changes made in pull request #190](https://github.com/quassel/quassel/pull/190).*

## Testing
### Steps
1.  Set up Quassel core `0.12.5`
2.  Connect with a client, add a network
3.  Upgrade Quassel core to latest git commit
4.  Connect with a `0.13` client

### Before
`Show search` is wrongly activated on all buffer views.

### After
`Show search` is kept disabled, following the default from a fresh (non-upgrade) configuration.