### PR TITLE
client: Fix settings upgrade missing some steps

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -207,9 +207,8 @@ const QVariant &Settings::localValue(const QString &key, const QVariant &def)
 bool Settings::localKeyExists(const QString &key)
 {
     QString normKey = normalizedKey(group, key);
-    if (isCached(normKey))
-        return true;
-
+    // Do NOT check the cache as default values get cached, too.  Otherwise loading a setting once
+    // will mark it as existing in settings, even when it only exists in cache (and not on disk).
     create_qsettings;
     return s.contains(normKey);
 }


### PR DESCRIPTION
## In short

* Remove cache check in `Settings::localKeyExists()`
  * Fixes settings upgrade skipping steps due to earlier steps caching default (*not stored*) values
  * Notably, creating/writing the `QtUiStyle` settings Qt StyleSheet.
  * Symptoms only visible when migrating multiple steps at once
  * Fixes bug introduced [with migration logic in pull request #185](https://github.com/quassel/quassel/pull/185 )

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Avoids user-facing unexpected UI changes on upgrade
Risk | ★☆☆ *1/3* | Possible wrong settings defaults
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Testing
### Steps
1.  Clear Quassel client configuration
2.  Restore a valid `0.12.5`-era configuration file, or use dummy file, below
3.  Launch a `0.13` client

**Dummy configuration file**
*The absolute minimum to recreate this issue: `quasselclient.conf`*
```ini
[Config]
Version=1
VersionMinor=1
```
*Remove everything else from the configuration file.*

### Difference
*With the fix, two missing settings migrations get applied, `SenderPrefixMode` to `None` and `UseCustomTimestampFormat` to `true`.*

```diff
--- <quasselclient.conf-trimmed-BEFORE>
+++ <quasselclient.conf-trimmed-AFTER>
@@ -7,8 +7,10 @@
 EnablePerChatHistory=false
 
 [QtUi]
+ChatView\__default__\SenderPrefixMode=0
 ChatView\__default__\ShowSenderBrackets=true
 ChatView\__default__\TimestampFormat=[hh:mm:ss]
+ChatView\__default__\UseCustomTimestampFormat=true
 MainWin[...]
 [...]
```

### Before
*Settings migration misses parts of steps.*

In `quasselclient.conf`:
```ini
[Config]
Version=1
VersionMinor=9

[InputWidget]
EnableLineWrap=false
EnablePerChatHistory=false

[QtUi]
ChatView\__default__\ShowSenderBrackets=true
ChatView\__default__\TimestampFormat=[hh:mm:ss]
MainWin[...]
[...]

[QtUiStyle]
Colors\Sender00=@Variant(\0\0\0\x43\x1\xff\xff\xcc\xcc\r\r\x7f\x7f\0\0)
Colors\Sender01=@Variant(\0\0\0\x43\x1\xff\xff\x8e\x8eUU\xe9\xe9\0\0)
Colors\Sender02=@Variant(\0\0\0\x43\x1\xff\xff\xb3\xb3\xe\xe\xe\xe\0\0)
Colors\Sender03=@Variant(\0\0\0\x43\x1\xff\xff\x17\x17\xb3\xb3\x39\x39\0\0)
Colors\Sender04=@Variant(\0\0\0\x43\x1\xff\xffXX\xaf\xaf\xb3\xb3\0\0)
Colors\Sender05=@Variant(\0\0\0\x43\x1\xff\xff\x9d\x9dTT\xb3\xb3\0\0)
Colors\Sender06=@Variant(\0\0\0\x43\x1\xff\xff\xb3\xb3\x97\x97uu\0\0)
Colors\Sender07=@Variant(\0\0\0\x43\x1\xff\xff\x31\x31vv\xb3\xb3\0\0)
Colors\Sender08=@Variant(\0\0\0\x43\x1\xff\xff\xe9\xe9\r\r\x7f\x7f\0\0)
Colors\Sender09=@Variant(\0\0\0\x43\x1\xff\xff\x8e\x8eUU\xe9\xe9\0\0)
Colors\Sender10=@Variant(\0\0\0\x43\x1\xff\xff\xb3\xb3\xe\xe\xe\xe\0\0)
Colors\Sender11=@Variant(\0\0\0\x43\x1\xff\xff\x17\x17\xb3\xb3\x39\x39\0\0)
Colors\Sender12=@Variant(\0\0\0\x43\x1\xff\xffXX\xaf\xaf\xb3\xb3\0\0)
Colors\Sender13=@Variant(\0\0\0\x43\x1\xff\xff\x9d\x9dTT\xb3\xb3\0\0)
Colors\Sender14=@Variant(\0\0\0\x43\x1\xff\xff\xb3\xb3\x97\x97uu\0\0)
Colors\Sender15=@Variant(\0\0\0\x43\x1\xff\xff\x31\x31vv\xb3\xb3\0\0)
Colors\SenderSelf=@Variant(\0\0\0\x43\x1\xff\xff\0\0\0\0\0\0\0\0)
Colors\UseNickGeneralColors=false
Colors\UseSenderActionColors=false
Colors\UseSenderColors=false

[Session]
[...]
```
*Removed irrelevant items from configuration.*

### After
*Settings migration applies all upgrade migrations.*

In `quasselclient.conf`:
```ini
[Config]
Version=1
VersionMinor=9

[InputWidget]
EnableLineWrap=false
EnablePerChatHistory=false

[QtUi]
ChatView\__default__\SenderPrefixMode=0
ChatView\__default__\ShowSenderBrackets=true
ChatView\__default__\TimestampFormat=[hh:mm:ss]
ChatView\__default__\UseCustomTimestampFormat=true
MainWin[...]
[...]

[QtUiStyle]
Colors\Sender00=@Variant(\0\0\0\x43\x1\xff\xff\xcc\xcc\r\r\x7f\x7f\0\0)
Colors\Sender01=@Variant(\0\0\0\x43\x1\xff\xff\x8e\x8eUU\xe9\xe9\0\0)
Colors\Sender02=@Variant(\0\0\0\x43\x1\xff\xff\xb3\xb3\xe\xe\xe\xe\0\0)
Colors\Sender03=@Variant(\0\0\0\x43\x1\xff\xff\x17\x17\xb3\xb3\x39\x39\0\0)
Colors\Sender04=@Variant(\0\0\0\x43\x1\xff\xffXX\xaf\xaf\xb3\xb3\0\0)
Colors\Sender05=@Variant(\0\0\0\x43\x1\xff\xff\x9d\x9dTT\xb3\xb3\0\0)
Colors\Sender06=@Variant(\0\0\0\x43\x1\xff\xff\xb3\xb3\x97\x97uu\0\0)
Colors\Sender07=@Variant(\0\0\0\x43\x1\xff\xff\x31\x31vv\xb3\xb3\0\0)
Colors\Sender08=@Variant(\0\0\0\x43\x1\xff\xff\xe9\xe9\r\r\x7f\x7f\0\0)
Colors\Sender09=@Variant(\0\0\0\x43\x1\xff\xff\x8e\x8eUU\xe9\xe9\0\0)
Colors\Sender10=@Variant(\0\0\0\x43\x1\xff\xff\xb3\xb3\xe\xe\xe\xe\0\0)
Colors\Sender11=@Variant(\0\0\0\x43\x1\xff\xff\x17\x17\xb3\xb3\x39\x39\0\0)
Colors\Sender12=@Variant(\0\0\0\x43\x1\xff\xffXX\xaf\xaf\xb3\xb3\0\0)
Colors\Sender13=@Variant(\0\0\0\x43\x1\xff\xff\x9d\x9dTT\xb3\xb3\0\0)
Colors\Sender14=@Variant(\0\0\0\x43\x1\xff\xff\xb3\xb3\x97\x97uu\0\0)
Colors\Sender15=@Variant(\0\0\0\x43\x1\xff\xff\x31\x31vv\xb3\xb3\0\0)
Colors\SenderSelf=@Variant(\0\0\0\x43\x1\xff\xff\0\0\0\0\0\0\0\0)
Colors\UseNickGeneralColors=false
Colors\UseSenderActionColors=false
Colors\UseSenderColors=false

[Session]
[...]
```
*Removed irrelevant items from configuration.*