### PR TITLE
core: Fix highlight nick config save/load

### DIFF
--- a/src/core/corehighlightrulemanager.h
+++ b/src/core/corehighlightrulemanager.h
@@ -25,6 +25,11 @@
 class CoreSession;
 struct RawMessage;
 
+/**
+ * Core-side specialization for HighlightRuleManager.
+ *
+ * Adds the ability to load/save the settings from/to the database.
+ */
 class CoreHighlightRuleManager : public HighlightRuleManager
 {
     Q_OBJECT
@@ -33,7 +38,12 @@ class CoreHighlightRuleManager : public HighlightRuleManager
     using HighlightRuleManager::match;
 
 public:
-    explicit CoreHighlightRuleManager(CoreSession *parent);
+    /**
+     * Constructor.
+     *
+     * @param[in] session Pointer to the parent CoreSession (takes ownership)
+     */
+    explicit CoreHighlightRuleManager(CoreSession *session);
 
     virtual const QMetaObject *syncMetaObject() const override { return &HighlightRuleManager::staticMetaObject; }
 
@@ -50,5 +60,11 @@ public slots:
     }
 
 private slots:
-    void save() const;
+    /**
+     * Saves the config to the database.
+     */
+    void save();
+
+private:
+    CoreSession *_coreSession {nullptr};  ///< Pointer to the parent CoreSession
 };

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -738,6 +738,11 @@ void CoreHighlightSettingsPage::importRules()
         return;
     }
 
+    if (hasChanged()) {
+        // Save existing changes first to avoid overwriting them
+        save();
+    }
+
     auto clonedManager = HighlightRuleManager();
     clonedManager.fromVariantMap(Client::highlightRuleManager()->toVariantMap());
 


### PR DESCRIPTION
## In short

* Modernize `CoreHighlightRuleManager` via `SyncableObject` functions, following `DccConfig`
  * Fixes highlight nick configuration being reset on core/monolithic restart
  * Simplifies code
  * Fixes regression from [highlight protocol pull request #370](https://github.com/quassel/quassel/pull/370 )
* Save remote highlight rules if changed before importing local
  * Fixes losing unsaved rules when importing

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | User-facing common functionality - remembering highlight nick options
Risk | ★★☆ *2/3* | Core-side change, revertible with configuration loss
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Rationale
Persistence for **`Highlight Nicks`** is needed, for otherwise restarting the core **or the monolithic client** will reset nickname highlighting options, re-enabling if disabled and limiting to current nick if more had been chosen.

### Breaking changes
Anyone currently using the `master` branch will have to re-set-up their core-side highlight rules one more time (*sorry*).  Afterwards, settings persist as expected.

Upgrading from `0.12.5` or earlier works fine.

## Testing
### Steps
1.  Set up core and client
2.  In `Configure Quassel…` → `Remote Highlights`, change **`Highlight Nicks`** to something non-default
    * E.g. `All Nicks from Identity`, `Case sensitive`
3.  Apply settings, shutdown core
4.  Launch core, reconnect
5.  Open configuration to `Remote Highlights` page

### Before
**`Highlight Nicks`** settings reset to default on every load.

### After
Even after core and client restarts, **`Highlight Nicks`** settings persist and have effect on core highlight behavior.