### PR TITLE
Change the timer method for /LIST to handle large lists better

### DIFF
--- a/src/core/coreirclisthelper.h
+++ b/src/core/coreirclisthelper.h
@@ -21,10 +21,13 @@
 #ifndef COREIRCLISTHELPER_H
 #define COREIRCLISTHELPER_H
 
+#include <memory>
+
 #include "irclisthelper.h"
 
 #include "coresession.h"
 
+class QBasicTimer;
 class QTimerEvent;
 
 class CoreIrcListHelper : public IrcListHelper
@@ -58,7 +61,8 @@ private:
     QHash<NetworkId, QString> _queuedQuery;
     QHash<NetworkId, QList<ChannelDescription> > _channelLists;
     QHash<NetworkId, QVariantList> _finishedChannelLists;
-    QHash<int, NetworkId> _queryTimeout;
+    QHash<int, NetworkId> _queryTimeoutByTimerId;
+    QHash<NetworkId, std::shared_ptr<QBasicTimer>> _queryTimeoutByNetId;
 };
 
 


### PR DESCRIPTION
The current timer of 10 seconds from starting the channel list query can timeout with larger lists or strict rate-limiting. This will cause an early 'end of list' which populates the dialog in the client with what was received up till then and the client dumps the rest to the Status Buffer. The timer also isn't killed when a proper 'end of list' is received and a new query ran quickly after another can be timed out by a previous timer.  
I found `QBasicTimer` to be a better fit here as calling `start(ms)` will restart the timer if it's already running. This allows us to restart the timer after each call to `addChannel()`, letting the query take a little longer if needed but not timing out while still receiving data. The timer is now removed when a proper 'end of list' is received and a timeout will still call 'end of list'.

I found starting the timer at 5 seconds and restarting each time at 5 seconds to be a good values as rate limiting or "fakelag" can sometimes add multiple seconds to replies from the server.
#### Testing
* Small channel lists: quick retrieval of list as expected; timer is started, restarted, stopped correctly.
* Faked large channel list: retrieval of list takes a bit but doesn't over-run to the Status Buffer; timer is started, restarted, stopped correctly.
* Freenode's large channel list: again, retrieval takes a bit but doesn't over-run; timer is started, restarted, stopped correctly.

Fixes #1471