### PR TITLE
Improve handling of core initialization errors

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -214,6 +214,16 @@ void Client::onDbUpgradeInProgress(bool inProgress)
 }
 
 
+void Client::onExitRequested(int exitCode, const QString &reason)
+{
+    if (!reason.isEmpty()) {
+        qCritical() << reason;
+        emit exitRequested(reason);
+    }
+    QCoreApplication::exit(exitCode);
+}
+
+
 /*** Network handling ***/
 
 QList<NetworkId> Client::networkIds()

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -256,6 +256,9 @@ signals:
     //! Emitted when database schema upgrade starts or ends (only mono client)
     void dbUpgradeInProgress(bool inProgress);
 
+    //! Emitted before an exit request is handled
+    void exitRequested(const QString &reason);
+
 public slots:
     void disconnectFromCore();
 
@@ -266,6 +269,7 @@ public slots:
     void markBufferAsRead(BufferId id);
 
     void onDbUpgradeInProgress(bool inProgress);
+    void onExitRequested(int exitCode, const QString &reason);
 
 private slots:
     void setSyncedToCore();

--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -71,6 +71,7 @@ Q_IMPORT_PLUGIN(qgif)
 #endif
 
 #include "quassel.h"
+#include "types.h"
 
 int main(int argc, char **argv)
 {
@@ -241,8 +242,15 @@ int main(int argc, char **argv)
     AboutData::setQuasselPersons(&aboutData);
     KAboutData::setApplicationData(aboutData.kAboutData());
 #endif
-    if (!app.init())
-        return EXIT_FAILURE;
+    try {
+        app.init();
+    }
+    catch (ExitException e) {
+        if (!e.errorString.isEmpty()) {
+            qCritical() << e.errorString;
+        }
+        return e.exitCode;
+    }
 
     return app.exec();
 }

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -169,3 +169,17 @@ QDataStream &operator>>(QDataStream &in, T &value) {
     value = static_cast<T>(v);
     return in;
 }
+
+// Exceptions
+
+/**
+ * Thrown during initialization to enforce exiting the application before the event loop is started
+ */
+struct ExitException
+{
+    int exitCode;
+    QString errorString;
+
+    ExitException(int code = EXIT_FAILURE, QString error = {})
+        : exitCode(code), errorString(std::move(error)) {}
+};

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -68,6 +68,8 @@ public:
     Core();
     ~Core() override;
 
+    void init();
+
     /*** Storage access ***/
     // These methods are threadsafe.
 
@@ -707,8 +709,11 @@ signals:
     //! Emitted when database schema upgrade starts or ends
     void dbUpgradeInProgress(bool inProgress);
 
+    //! Emitted when a fatal error was encountered during async initialization
+    void exitRequested(int exitCode, const QString &reason);
+
 public slots:
-    bool init();
+    void initAsync();
 
     /** Persist storage.
      *

--- a/src/core/coreapplication.cpp
+++ b/src/core/coreapplication.cpp
@@ -40,11 +40,12 @@ CoreApplication::~CoreApplication()
 }
 
 
-bool CoreApplication::init()
+void CoreApplication::init()
 {
-    if (Quassel::init()) {
-        _core.reset(new Core{}); // FIXME C++14: std::make_unique
-        return _core->init();
+    if (!Quassel::init()) {
+        throw ExitException{EXIT_FAILURE, tr("Could not initialize Quassel!")};
     }
-    return false;
+
+    _core.reset(new Core{}); // FIXME C++14: std::make_unique
+    _core->init();
 }

--- a/src/core/coreapplication.h
+++ b/src/core/coreapplication.h
@@ -35,7 +35,7 @@ public:
     CoreApplication(int &argc, char **argv);
     ~CoreApplication() override;
 
-    bool init();
+    void init();
 
 private:
     std::unique_ptr<Core> _core;

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -216,6 +216,7 @@ void MainWin::init()
     connect(GraphicalUi::contextMenuActionProvider(), SIGNAL(showIgnoreList(QString)), SLOT(showIgnoreList(QString)));
     connect(Client::instance(), SIGNAL(showIgnoreList(QString)), SLOT(showIgnoreList(QString)));
     connect(Client::instance(), SIGNAL(dbUpgradeInProgress(bool)), SLOT(showMigrationWarning(bool)));
+    connect(Client::instance(), SIGNAL(exitRequested(QString)), SLOT(onExitRequested(QString)));
 
     connect(Client::coreConnection(), SIGNAL(startCoreSetup(QVariantList, QVariantList)), SLOT(showCoreConfigWizard(QVariantList, QVariantList)));
     connect(Client::coreConnection(), SIGNAL(connectionErrorPopup(QString)), SLOT(handleCoreConnectionError(QString)));
@@ -854,6 +855,19 @@ void MainWin::showMigrationWarning(bool show)
         _migrationWarning->close();
         _migrationWarning->deleteLater();
         _migrationWarning = nullptr;
+    }
+}
+
+
+void MainWin::onExitRequested(const QString &reason)
+{
+    if (!reason.isEmpty()) {
+        QMessageBox box(QMessageBox::Critical,
+                        tr("Fatal error"),
+                        "<b>" + tr("Quassel encountered a fatal error and is terminated.") + "</b>",
+                        QMessageBox::Ok, this);
+        box.setInformativeText("<p>" + tr("Reason:<em>") + " " + reason + "</em>");
+        box.exec();
     }
 }
 

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -100,6 +100,8 @@ public slots:
 
     void showMigrationWarning(bool show);
 
+    void onExitRequested(const QString &reason);
+
     //! Quit application
     void quit();
 

--- a/src/qtui/monoapplication.h
+++ b/src/qtui/monoapplication.h
@@ -36,7 +36,7 @@ public:
     MonolithicApplication(int &, char **);
     ~MonolithicApplication() override;
 
-    bool init() override;
+    void init() override;
 
 signals:
     void connectInternalPeer(QPointer<InternalPeer> peer);

--- a/src/qtui/qtuiapplication.h
+++ b/src/qtui/qtuiapplication.h
@@ -47,7 +47,7 @@ class QtUiApplication : public QApplication
 public:
     QtUiApplication(int &, char **);
     ~QtUiApplication();
-    virtual bool init();
+    virtual void init();
 
     void resumeSessionIfPossible();
     inline bool isAboutToQuit() const { return _aboutToQuit; }


### PR DESCRIPTION
Since the event loop may not be running while the core is being
initialized, calling exit() does not have the desired effect.
Instead, throw an exception with exit code and error message to
be able to handle this correctly. Exceptions must not be thrown
through the event loop, so ensure that they're caught before in
cases where the event loop was started already.

For the monolithic client, introduce an asynchronous init method
that catches potential exceptions and calls exit() instead. Show
an error popup in the UI if an error message is provided, so the
user gets some feedback before the client is terminated.