### PR TITLE
Chat Monitor: Add option to always include own messages

### DIFF
--- a/src/qtui/chatmonitorfilter.cpp
+++ b/src/qtui/chatmonitorfilter.cpp
@@ -47,6 +47,7 @@ ChatMonitorFilter::ChatMonitorFilter(MessageModel *model, QObject *parent)
     QString buffersSettingsId = "Buffers";
     QString showBacklogSettingsId = "ShowBacklog";
     QString includeReadSettingsId = "IncludeRead";
+    QString alwaysOwnSettingsId = "AlwaysOwn";
 
     _showHighlights = viewSettings.value(showHighlightsSettingsId, false).toBool();
     _operationMode = viewSettings.value(operationModeSettingsId, 0).toInt();
@@ -55,12 +56,14 @@ ChatMonitorFilter::ChatMonitorFilter(MessageModel *model, QObject *parent)
     _bufferIds << v.value<BufferId>();
     _showBacklog = viewSettings.value(showBacklogSettingsId, true).toBool();
     _includeRead = viewSettings.value(includeReadSettingsId, true).toBool();
+    _alwaysOwn = viewSettings.value(alwaysOwnSettingsId, false).toBool();
 
     viewSettings.notify(showHighlightsSettingsId, this, SLOT(showHighlightsSettingChanged(const QVariant &)));
     viewSettings.notify(operationModeSettingsId, this, SLOT(operationModeSettingChanged(const QVariant &)));
     viewSettings.notify(buffersSettingsId, this, SLOT(buffersSettingChanged(const QVariant &)));
     viewSettings.notify(showBacklogSettingsId, this, SLOT(showBacklogSettingChanged(const QVariant &)));
     viewSettings.notify(includeReadSettingsId, this, SLOT(includeReadSettingChanged(const QVariant &)));
+    viewSettings.notify(alwaysOwnSettingsId, this, SLOT(alwaysOwnSettingChanged(const QVariant &)));
 }
 
 
@@ -89,6 +92,8 @@ bool ChatMonitorFilter::filterAcceptsRow(int sourceRow, const QModelIndex &sourc
 
     // ChatMonitorSettingsPage
     if (_showHighlights && flags & Message::Highlight)
+        ; // pass
+    else if (_alwaysOwn && flags & Message::Self)
         ; // pass
     else if (_operationMode == ChatViewSettings::OptOut && _bufferIds.contains(bufferId))
         return false;
@@ -187,6 +192,9 @@ void ChatMonitorFilter::showOwnMessagesSettingChanged(const QVariant &newValue)
     _showOwnMessages = newValue.toBool();
 }
 
+void ChatMonitorFilter::alwaysOwnSettingChanged(const QVariant &newValue) {
+    _alwaysOwn = newValue.toBool();
+}
 
 void ChatMonitorFilter::showHighlightsSettingChanged(const QVariant &newValue)
 {

--- a/src/qtui/chatmonitorfilter.h
+++ b/src/qtui/chatmonitorfilter.h
@@ -55,6 +55,7 @@ public slots:
 private slots:
     void showFieldsSettingChanged(const QVariant &newValue);
     void showOwnMessagesSettingChanged(const QVariant &newValue);
+    void alwaysOwnSettingChanged(const QVariant &newValue);
     void showHighlightsSettingChanged(const QVariant &newValue);
     void operationModeSettingChanged(const QVariant &newValue);
     void buffersSettingChanged(const QVariant &newValue);
@@ -70,6 +71,7 @@ private slots:
 private:
     int _showFields;
     bool _showOwnMessages;
+    bool _alwaysOwn;
     QList<BufferId> _bufferIds;
     bool _showHighlights;
     int _operationMode;

--- a/src/qtui/settingspages/chatmonitorsettingspage.cpp
+++ b/src/qtui/settingspages/chatmonitorsettingspage.cpp
@@ -63,6 +63,7 @@ ChatMonitorSettingsPage::ChatMonitorSettingsPage(QWidget *parent)
     connect(ui.operationMode, SIGNAL(currentIndexChanged(int)), SLOT(switchOperationMode(int)));
     connect(ui.showHighlights, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
     connect(ui.showOwnMessages, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
+    connect(ui.alwaysOwn, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
     connect(ui.showBacklog, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
     connect(ui.includeRead, SIGNAL(toggled(bool)), SLOT(widgetHasChanged()));
 }
@@ -79,6 +80,7 @@ void ChatMonitorSettingsPage::defaults()
     settings["OperationMode"] = ChatViewSettings::OptOut;
     settings["ShowHighlights"] = false;
     settings["ShowOwnMsgs"] = false;
+    settings["AlwaysOwn"] = false;
     settings["Buffers"] = QVariant();
     settings["Default"] = true;
     settings["ShowBacklog"] = true;
@@ -99,6 +101,7 @@ void ChatMonitorSettingsPage::load()
     ui.operationMode->setCurrentIndex(settings["OperationMode"].toInt() - 1);
     ui.showHighlights->setChecked(settings["ShowHighlights"].toBool());
     ui.showOwnMessages->setChecked(settings["ShowOwnMsgs"].toBool());
+    ui.alwaysOwn->setChecked(settings["AlwaysOwn"].toBool());
     ui.showBacklog->setChecked(settings["ShowBacklog"].toBool());
     ui.includeRead->setChecked(settings["IncludeRead"].toBool());
 
@@ -132,6 +135,7 @@ void ChatMonitorSettingsPage::loadSettings()
 
     settings["ShowHighlights"] = chatViewSettings.value("ShowHighlights", false);
     settings["ShowOwnMsgs"] = chatViewSettings.value("ShowOwnMsgs", false);
+    settings["AlwaysOwn"] = chatViewSettings.value("AlwaysOwn", false);
     settings["Buffers"] = chatViewSettings.value("Buffers", QVariantList());
     settings["ShowBacklog"] = chatViewSettings.value("ShowBacklog", true);
     settings["IncludeRead"] = chatViewSettings.value("IncludeRead", true);
@@ -145,6 +149,7 @@ void ChatMonitorSettingsPage::save()
     chatViewSettings.setValue("OperationMode", ui.operationMode->currentIndex() + 1);
     chatViewSettings.setValue("ShowHighlights", ui.showHighlights->isChecked());
     chatViewSettings.setValue("ShowOwnMsgs", ui.showOwnMessages->isChecked());
+    chatViewSettings.setValue("AlwaysOwn", ui.alwaysOwn->isChecked());
     chatViewSettings.setValue("ShowBacklog", ui.showBacklog->isChecked());
     chatViewSettings.setValue("IncludeRead", ui.includeRead->isChecked());
 
@@ -174,6 +179,8 @@ bool ChatMonitorSettingsPage::testHasChanged()
     if (settings["ShowHighlights"].toBool() != ui.showHighlights->isChecked())
         return true;
     if (settings["ShowOwnMsgs"].toBool() != ui.showOwnMessages->isChecked())
+        return true;
+    if (settings["AlwaysOwn"].toBool() != ui.alwaysOwn->isChecked())
         return true;
     if (settings["ShowBacklog"].toBool() != ui.showBacklog->isChecked())
         return true;

--- a/src/qtui/settingspages/chatmonitorsettingspage.ui
+++ b/src/qtui/settingspages/chatmonitorsettingspage.ui
@@ -159,6 +159,36 @@ p, li { white-space: pre-wrap; }
     </widget>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>16</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="alwaysOwn">
+       <property name="toolTip">
+        <string>Show own messages in chatmonitor even if the originating buffer is ignored</string>
+       </property>
+       <property name="text">
+        <string>Always</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QCheckBox" name="showBacklog">
      <property name="toolTip">
       <string>Display messages from backlog on reconnect</string>
@@ -215,11 +245,18 @@ p, li { white-space: pre-wrap; }
   <tabstop>activeBuffers</tabstop>
   <tabstop>showHighlights</tabstop>
   <tabstop>showOwnMessages</tabstop>
+  <tabstop>alwaysOwn</tabstop>
   <tabstop>showBacklog</tabstop>
   <tabstop>includeRead</tabstop>
  </tabstops>
  <resources/>
  <connections>
+  <connection>
+   <sender>showOwnMessages</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>alwaysOwn</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
   <connection>
    <sender>showBacklog</sender>
    <signal>toggled(bool)</signal>


### PR DESCRIPTION
Add an option to the chat monitor to always show own messages, similar to how highlights can be shown always.