### PR TITLE
chatmonitor: "Always" → "Include ignored buffers"

### DIFF
--- a/src/qtui/settingspages/chatmonitorsettingspage.ui
+++ b/src/qtui/settingspages/chatmonitorsettingspage.ui
@@ -182,7 +182,7 @@ p, li { white-space: pre-wrap; }
         <string>Show own messages in chatmonitor even if the originating buffer is ignored</string>
        </property>
        <property name="text">
-        <string>Always</string>
+        <string>Include ignored buffers</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
## In brief
* Rename 'always show own messages' option to `Include ignored buffers`
   * Previously titled `Always`
   * Matches the option `Include read messages`

A quick test also confirms this functionality works compared to my defaults before.  No extensive testing done.

No functional change, just minor UI tweak before string freeze.
