### PR TITLE
common: non-RegEx match all highlights, simplify UI

### DIFF
--- a/src/common/highlightrulemanager.cpp
+++ b/src/common/highlightrulemanager.cpp
@@ -166,13 +166,22 @@ bool HighlightRuleManager::match(const QString &msgContents,
             continue;
         }
 
-        QRegExp rx;
-        if (rule.isRegEx) {
-            rx = QRegExp(rule.name, rule.isCaseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
+        bool nameMatch = false;
+        if (rule.name.isEmpty()) {
+            // Empty rule, matches any message
+            nameMatch = true;
         } else {
-            rx = QRegExp("(^|\\W)" + QRegExp::escape(rule.name) + "(\\W|$)", rule.isCaseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
+            // Check according to specified rule
+            QRegExp rx;
+            if (rule.isRegEx) {
+                rx = QRegExp(rule.name,
+                             rule.isCaseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
+            } else {
+                rx = QRegExp("(^|\\W)" + QRegExp::escape(rule.name) + "(\\W|$)",
+                             rule.isCaseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
+            }
+            nameMatch = (rx.indexIn(stripFormatCodes(msgContents)) >= 0);
         }
-        bool nameMatch = (rx.indexIn(stripFormatCodes(msgContents)) >= 0);
 
         bool senderMatch;
         if (rule.sender.isEmpty()) {

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -141,12 +141,14 @@ void CoreHighlightSettingsPage::setupRuleTable(QTableWidget *table) const
     table->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::NameColumn, QHeaderView::Stretch);
     table->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::RegExColumn, QHeaderView::ResizeToContents);
     table->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::CsColumn, QHeaderView::ResizeToContents);
+    table->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::SenderColumn, QHeaderView::ResizeToContents);
     table->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::ChanColumn, QHeaderView::ResizeToContents);
 #else
     table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::EnableColumn, QHeaderView::ResizeToContents);
     table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::NameColumn, QHeaderView::Stretch);
     table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::RegExColumn, QHeaderView::ResizeToContents);
     table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::CsColumn, QHeaderView::ResizeToContents);
+    table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::SenderColumn, QHeaderView::ResizeToContents);
     table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::ChanColumn, QHeaderView::ResizeToContents);
 #endif
 }

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -161,7 +161,7 @@ QString CoreHighlightSettingsPage::getTableTooltip(column tableColumn) const
         return tr("Enable/disable this rule");
 
     case CoreHighlightSettingsPage::NameColumn:
-        return tr("Phrase to match");
+        return tr("Phrase to match, leave blank to match any message");
 
     case CoreHighlightSettingsPage::RegExColumn:
         return tr("<b>RegEx</b>: This option determines if the highlight rule, <i>Sender</i>, and "
@@ -550,8 +550,6 @@ void CoreHighlightSettingsPage::highlightTableChanged(QTableWidgetItem *item)
             highlightRule.isEnabled = (item->checkState() == Qt::Checked);
             break;
         case CoreHighlightSettingsPage::NameColumn:
-            if (item->text() == "")
-                item->setText(tr("this shouldn't be empty"));
             highlightRule.name = item->text();
             break;
         case CoreHighlightSettingsPage::RegExColumn:
@@ -589,8 +587,6 @@ void CoreHighlightSettingsPage::ignoredTableChanged(QTableWidgetItem *item)
             ignoredRule.isEnabled = (item->checkState() == Qt::Checked);
             break;
         case CoreHighlightSettingsPage::NameColumn:
-            if (item->text() == "")
-                item->setText(tr("this shouldn't be empty"));
             ignoredRule.name = item->text();
             break;
         case CoreHighlightSettingsPage::RegExColumn:

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -129,60 +129,12 @@ void CoreHighlightSettingsPage::setupRuleTable(QTableWidget *table) const
     table->verticalHeader()->hide();
     table->setShowGrid(false);
 
-    table->horizontalHeaderItem(CoreHighlightSettingsPage::EnableColumn)->setToolTip(
-                tr("Enable/disable this rule"));
-    table->horizontalHeaderItem(CoreHighlightSettingsPage::EnableColumn)->setWhatsThis(
-                table->horizontalHeaderItem(CoreHighlightSettingsPage::EnableColumn)->toolTip());
-
-    table->horizontalHeaderItem(CoreHighlightSettingsPage::NameColumn)->setToolTip(
-                tr("Phrase to match"));
-    table->horizontalHeaderItem(CoreHighlightSettingsPage::NameColumn)->setWhatsThis(
-                table->horizontalHeaderItem(CoreHighlightSettingsPage::NameColumn)->toolTip());
-
-    table->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->setToolTip(
-                tr("<b>RegEx</b>: This option determines if the highlight rule, <i>Sender</i>, and "
-                   "<i>Channel</i> should be interpreted as <b>regular expressions</b> or just as "
-                   "keywords."));
-    table->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->setWhatsThis(
-                table->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn)->toolTip());
-
-    table->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->setToolTip(
-                tr("<b>CS</b>: This option determines if the highlight rule, <i>Sender</i>, and "
-                   "<i>Channel</i> should be interpreted <b>case sensitive</b>."));
-    table->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->setWhatsThis(
-                table->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn)->toolTip());
-
-    table->horizontalHeaderItem(CoreHighlightSettingsPage::SenderColumn)->setToolTip(
-                tr("<p><b>Sender</b>: Semicolon separated list of <i>nick!ident@host</i> names, "
-                   "leave blank to match any nickname.</p>"
-                   "<p><i>Example:</i><br />"
-                   "<i>Alice!*; Bob!*@example.com; Carol*!*; !Caroline!*</i><br />"
-                   "would match on <i>Alice</i>, <i>Bob</i> with hostmask <i>example.com</i>, and "
-                   "any nickname starting with <i>Carol</i> except for <i>Caroline</i><br />"
-                   "<p>If only inverted names are specified, it will match anything except for "
-                   "what's specified (implicit wildcard).</p>"
-                   "<p><i>Example:</i><br />"
-                   "<i>!Announce*!*; !Wheatley!aperture@*</i><br />"
-                   "would match anything except for <i>Wheatley</i> with ident <i>aperture</i> or "
-                   "any nickname starting with <i>Announce</i></p>"));
-    table->horizontalHeaderItem(CoreHighlightSettingsPage::SenderColumn)->setWhatsThis(
-                table->horizontalHeaderItem(CoreHighlightSettingsPage::SenderColumn)->toolTip());
-
-    table->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->setToolTip(
-                tr("<p><b>Channel</b>: Semicolon separated list of channel names, leave blank to "
-                   "match any name.</p>"
-                   "<p><i>Example:</i><br />"
-                   "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
-                   "would match on <i>#foobar</i> and any channel starting with <i>#quassel</i> "
-                   "except for <i>#quasseldroid</i><br />"
-                   "<p>If only inverted names are specified, it will match anything except for "
-                   "what's specified (implicit wildcard).</p>"
-                   "<p><i>Example:</i><br />"
-                   "<i>!#quassel*; !#foobar</i><br />"
-                   "would match anything except for <i>#foobar</i> or any channel starting with "
-                   "<i>#quassel</i></p>"));
-    table->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->setWhatsThis(
-                table->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn)->toolTip());
+    setupTableTooltips(table->horizontalHeaderItem(CoreHighlightSettingsPage::EnableColumn),
+                       table->horizontalHeaderItem(CoreHighlightSettingsPage::NameColumn),
+                       table->horizontalHeaderItem(CoreHighlightSettingsPage::RegExColumn),
+                       table->horizontalHeaderItem(CoreHighlightSettingsPage::CsColumn),
+                       table->horizontalHeaderItem(CoreHighlightSettingsPage::SenderColumn),
+                       table->horizontalHeaderItem(CoreHighlightSettingsPage::ChanColumn));
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     table->horizontalHeader()->setResizeMode(CoreHighlightSettingsPage::EnableColumn, QHeaderView::ResizeToContents);
@@ -197,6 +149,140 @@ void CoreHighlightSettingsPage::setupRuleTable(QTableWidget *table) const
     table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::CsColumn, QHeaderView::ResizeToContents);
     table->horizontalHeader()->setSectionResizeMode(CoreHighlightSettingsPage::ChanColumn, QHeaderView::ResizeToContents);
 #endif
+}
+
+
+QString CoreHighlightSettingsPage::getTableTooltip(column tableColumn) const
+{
+    switch (tableColumn) {
+    case CoreHighlightSettingsPage::EnableColumn:
+        return tr("Enable/disable this rule");
+
+    case CoreHighlightSettingsPage::NameColumn:
+        return tr("Phrase to match");
+
+    case CoreHighlightSettingsPage::RegExColumn:
+        return tr("<b>RegEx</b>: This option determines if the highlight rule, <i>Sender</i>, and "
+                  "<i>Channel</i> should be interpreted as <b>regular expressions</b> or just as "
+                  "keywords.");
+
+    case CoreHighlightSettingsPage::CsColumn:
+        return tr("<b>CS</b>: This option determines if the highlight rule, <i>Sender</i>, and "
+                  "<i>Channel</i> should be interpreted <b>case sensitive</b>.");
+
+    case CoreHighlightSettingsPage::SenderColumn:
+        return tr("<p><b>Sender</b>: Semicolon separated list of <i>nick!ident@host</i> names, "
+                  "leave blank to match any nickname.</p>"
+                  "<p><i>Example:</i><br />"
+                  "<i>Alice!*; Bob!*@example.com; Carol*!*; !Caroline!*</i><br />"
+                  "would match on <i>Alice</i>, <i>Bob</i> with hostmask <i>example.com</i>, and "
+                  "any nickname starting with <i>Carol</i> except for <i>Caroline</i><br />"
+                  "<p>If only inverted names are specified, it will match anything except for "
+                  "what's specified (implicit wildcard).</p>"
+                  "<p><i>Example:</i><br />"
+                  "<i>!Announce*!*; !Wheatley!aperture@*</i><br />"
+                  "would match anything except for <i>Wheatley</i> with ident <i>aperture</i> or "
+                  "any nickname starting with <i>Announce</i></p>");
+
+    case CoreHighlightSettingsPage::ChanColumn:
+        return tr("<p><b>Channel</b>: Semicolon separated list of channel names, leave blank to "
+                  "match any name.</p>"
+                  "<p><i>Example:</i><br />"
+                  "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
+                  "would match on <i>#foobar</i> and any channel starting with <i>#quassel</i> "
+                  "except for <i>#quasseldroid</i><br />"
+                  "<p>If only inverted names are specified, it will match anything except for "
+                  "what's specified (implicit wildcard).</p>"
+                  "<p><i>Example:</i><br />"
+                  "<i>!#quassel*; !#foobar</i><br />"
+                  "would match anything except for <i>#foobar</i> or any channel starting with "
+                  "<i>#quassel</i></p>");
+
+    default:
+        // This shouldn't happen
+        return "Invalid column type in CoreHighlightSettingsPage::getTableTooltip()";
+    }
+}
+
+
+void CoreHighlightSettingsPage::setupTableTooltips(QWidget *enableWidget, QWidget *nameWidget,
+                                                   QWidget *regExWidget, QWidget *csWidget,
+                                                   QWidget *senderWidget, QWidget *chanWidget) const
+{
+    // Make sure everything's valid
+    Q_ASSERT(enableWidget);
+    Q_ASSERT(nameWidget);
+    Q_ASSERT(regExWidget);
+    Q_ASSERT(csWidget);
+    Q_ASSERT(senderWidget);
+    Q_ASSERT(chanWidget);
+
+    // Set tooltips and "What's this?" prompts
+    // Enabled
+    enableWidget->setToolTip(getTableTooltip(CoreHighlightSettingsPage::EnableColumn));
+    enableWidget->setWhatsThis(enableWidget->toolTip());
+
+    // Name
+    nameWidget->setToolTip(getTableTooltip(CoreHighlightSettingsPage::NameColumn));
+    nameWidget->setWhatsThis(nameWidget->toolTip());
+
+    // RegEx enabled
+    regExWidget->setToolTip(getTableTooltip(CoreHighlightSettingsPage::RegExColumn));
+    regExWidget->setWhatsThis(regExWidget->toolTip());
+
+    // Case-sensitivity
+    csWidget->setToolTip(getTableTooltip(CoreHighlightSettingsPage::CsColumn));
+    csWidget->setWhatsThis(csWidget->toolTip());
+
+    // Sender
+    senderWidget->setToolTip(getTableTooltip(CoreHighlightSettingsPage::SenderColumn));
+    senderWidget->setWhatsThis(senderWidget->toolTip());
+
+    // Channel/buffer name
+    chanWidget->setToolTip(getTableTooltip(CoreHighlightSettingsPage::ChanColumn));
+    chanWidget->setWhatsThis(chanWidget->toolTip());
+}
+
+
+void CoreHighlightSettingsPage::setupTableTooltips(QTableWidgetItem *enableWidget,
+                                                   QTableWidgetItem *nameWidget,
+                                                   QTableWidgetItem *regExWidget,
+                                                   QTableWidgetItem *csWidget,
+                                                   QTableWidgetItem *senderWidget,
+                                                   QTableWidgetItem *chanWidget) const
+{
+    // Make sure everything's valid
+    Q_ASSERT(enableWidget);
+    Q_ASSERT(nameWidget);
+    Q_ASSERT(regExWidget);
+    Q_ASSERT(csWidget);
+    Q_ASSERT(senderWidget);
+    Q_ASSERT(chanWidget);
+
+    // Set tooltips and "What's this?" prompts
+    // Enabled
+    enableWidget->setToolTip(getTableTooltip(CoreHighlightSettingsPage::EnableColumn));
+    enableWidget->setWhatsThis(enableWidget->toolTip());
+
+    // Name
+    nameWidget->setToolTip(getTableTooltip(CoreHighlightSettingsPage::NameColumn));
+    nameWidget->setWhatsThis(nameWidget->toolTip());
+
+    // RegEx enabled
+    regExWidget->setToolTip(getTableTooltip(CoreHighlightSettingsPage::RegExColumn));
+    regExWidget->setWhatsThis(regExWidget->toolTip());
+
+    // Case-sensitivity
+    csWidget->setToolTip(getTableTooltip(CoreHighlightSettingsPage::CsColumn));
+    csWidget->setWhatsThis(csWidget->toolTip());
+
+    // Sender
+    senderWidget->setToolTip(getTableTooltip(CoreHighlightSettingsPage::SenderColumn));
+    senderWidget->setWhatsThis(senderWidget->toolTip());
+
+    // Channel/buffer name
+    chanWidget->setToolTip(getTableTooltip(CoreHighlightSettingsPage::ChanColumn));
+    chanWidget->setWhatsThis(chanWidget->toolTip());
 }
 
 
@@ -287,41 +373,7 @@ void CoreHighlightSettingsPage::addNewHighlightRow(bool enable, int id, const QS
 
     auto *chanNameItem = new QTableWidgetItem(chanName);
 
-    enableItem->setToolTip(tr("Enable/disable this rule"));
-    nameItem->setToolTip(tr("Phrase to match"));
-    regexItem->setToolTip(
-                tr("<b>RegEx</b>: This option determines if the highlight rule, <i>Sender</i>, and "
-                   "<i>Channel</i> should be interpreted as <b>regular expressions</b> or just as "
-                   "keywords."));
-    csItem->setToolTip(
-                tr("<b>CS</b>: This option determines if the highlight rule, <i>Sender</i>, and "
-                   "<i>Channel</i> should be interpreted <b>case sensitive</b>."));
-    senderItem->setToolTip(
-                tr("<p><b>Sender</b>: Semicolon separated list of <i>nick!ident@host</i> names, "
-                   "leave blank to match any nickname.</p>"
-                   "<p><i>Example:</i><br />"
-                   "<i>Alice!*; Bob!*@example.com; Carol*!*; !Caroline!*</i><br />"
-                   "would match on <i>Alice</i>, <i>Bob</i> with hostmask <i>example.com</i>, and "
-                   "any nickname starting with <i>Carol</i> except for <i>Caroline</i><br />"
-                   "<p>If only inverted names are specified, it will match anything except for "
-                   "what's specified (implicit wildcard).</p>"
-                   "<p><i>Example:</i><br />"
-                   "<i>!Announce*!*; !Wheatley!aperture@*</i><br />"
-                   "would match anything except for <i>Wheatley</i> with ident <i>aperture</i> or "
-                   "any nickname starting with <i>Announce</i></p>"));
-    chanNameItem->setToolTip(
-                tr("<p><b>Channel</b>: Semicolon separated list of channel names, leave blank to "
-                   "match any name.</p>"
-                   "<p><i>Example:</i><br />"
-                   "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
-                   "would match on <i>#foobar</i> and any channel starting with <i>#quassel</i> "
-                   "except for <i>#quasseldroid</i><br />"
-                   "<p>If only inverted names are specified, it will match anything except for "
-                   "what's specified (implicit wildcard).</p>"
-                   "<p><i>Example:</i><br />"
-                   "<i>!#quassel*; !#foobar</i><br />"
-                   "would match anything except for <i>#foobar</i> or any channel starting with "
-                   "<i>#quassel</i></p>"));
+    setupTableTooltips(enableItem, nameItem, regexItem, csItem, senderItem, chanNameItem);
 
     int lastRow = ui.highlightTable->rowCount() - 1;
     ui.highlightTable->setItem(lastRow, CoreHighlightSettingsPage::NameColumn, nameItem);
@@ -374,29 +426,7 @@ void CoreHighlightSettingsPage::addNewIgnoredRow(bool enable, int id, const QStr
 
     auto *senderItem = new QTableWidgetItem(sender);
 
-    enableItem->setToolTip(tr("Enable/disable this rule"));
-    nameItem->setToolTip(tr("Phrase to match"));
-    regexItem->setToolTip(
-                tr("<b>RegEx</b>: This option determines if the highlight rule should be "
-                   "interpreted as a <b>regular expression</b> or just as a keyword."));
-    csItem->setToolTip(
-                tr("<b>CS</b>: This option determines if the highlight rule should be interpreted "
-                   "<b>case sensitive</b>."));
-    senderItem->setToolTip(
-                tr("<b>Sender</b>: This option specifies which sender nicknames match.  Leave "
-                   "blank to match any nickname."));
-    chanNameItem->setToolTip(
-                tr("<p><b>Channel</b>: Semicolon separated list of channel names.</p>"
-                   "<p><i>Example:</i><br />"
-                   "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
-                   "would match on #foobar and any channel starting with <i>#quassel</i> except "
-                   "for <i>#quasseldroid</i><br />"
-                   "<p>If only inverted names are specified, it will match anything except for "
-                   "what's specified (implicit wildcard).</p>"
-                   "<p><i>Example:</i><br />"
-                   "<i>!#quassel*; !#foobar</i><br />"
-                   "would match anything except for #foobar or any channel starting with "
-                   "<i>#quassel</i></p>"));
+    setupTableTooltips(enableItem, nameItem, regexItem, csItem, senderItem, chanNameItem);
 
     int lastRow = ui.ignoredTable->rowCount() - 1;
     ui.ignoredTable->setItem(lastRow, CoreHighlightSettingsPage::NameColumn, nameItem);

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -187,8 +187,8 @@ QString CoreHighlightSettingsPage::getTableTooltip(column tableColumn) const
                   "any nickname starting with <i>Announce</i></p>");
 
     case CoreHighlightSettingsPage::ChanColumn:
-        return tr("<p><b>Channel</b>: Semicolon separated list of channel names, leave blank to "
-                  "match any name.</p>"
+        return tr("<p><b>Channel</b>: Semicolon separated list of channel/query names, leave blank "
+                  "to match any name.</p>"
                   "<p><i>Example:</i><br />"
                   "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
                   "would match on <i>#foobar</i> and any channel starting with <i>#quassel</i> "

--- a/src/qtui/settingspages/corehighlightsettingspage.h
+++ b/src/qtui/settingspages/corehighlightsettingspage.h
@@ -94,6 +94,41 @@ private:
 
     void setupRuleTable(QTableWidget *highlightTable) const;
 
+    /**
+     * Get tooltip for the specified rule table column
+     *
+     * @param tableColumn Column to retrieve tooltip
+     * @return Translated tooltip for the specified column
+     */
+    QString getTableTooltip(column tableColumn) const;
+
+    /**
+     * Setup tooltips and "What's this?" prompts for table entries
+     *
+     * @param enableWidget  Enabled checkbox
+     * @param nameWidget    Rule name
+     * @param regExWidget   RegEx enabled
+     * @param csWidget      Case-sensitive
+     * @param senderWidget  Sender name
+     * @param chanWidget    Channel name
+     */
+    void setupTableTooltips(QWidget *enableWidget, QWidget *nameWidget, QWidget *regExWidget,
+                            QWidget *csWidget, QWidget *senderWidget, QWidget *chanWidget) const;
+
+    /**
+     * Setup tooltips and "What's this?" prompts for table entries
+     *
+     * @param enableWidget  Enabled checkbox
+     * @param nameWidget    Rule name
+     * @param regExWidget   RegEx enabled
+     * @param csWidget      Case-sensitive
+     * @param senderWidget  Sender name
+     * @param chanWidget    Channel name
+     */
+    void setupTableTooltips(QTableWidgetItem *enableWidget, QTableWidgetItem *nameWidget,
+                            QTableWidgetItem *regExWidget, QTableWidgetItem *csWidget,
+                            QTableWidgetItem *senderWidget, QTableWidgetItem *chanWidget) const;
+
     /** Update the UI to show core support for highlights
      *
      * Shows or hides the UI warnings around core-side highlights according to core connection and

--- a/src/qtui/settingspages/highlightsettingspage.cpp
+++ b/src/qtui/settingspages/highlightsettingspage.cpp
@@ -64,8 +64,8 @@ HighlightSettingsPage::HighlightSettingsPage(QWidget *parent)
                 ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::CsColumn)->toolTip());
 
     ui.highlightTable->horizontalHeaderItem(HighlightSettingsPage::ChanColumn)->setToolTip(
-                tr("<p><b>Channel</b>: Semicolon separated list of channel names, leave blank to "
-                   "match any name.</p>"
+                tr("<p><b>Channel</b>: Semicolon separated list of channel/query names, leave "
+                   "blank to match any name.</p>"
                    "<p><i>Example:</i><br />"
                    "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
                    "would match on <i>#foobar</i> and any channel starting with <i>#quassel</i> "
@@ -176,8 +176,8 @@ void HighlightSettingsPage::addNewRow(QString name, bool regex, bool cs, bool en
                 tr("<b>CS</b>: This option determines if the highlight rule and <i>Channel</i> "
                    "should be interpreted <b>case sensitive</b>."));
     chanNameItem->setToolTip(
-                tr("<p><b>Channel</b>: Semicolon separated list of channel names, leave blank to "
-                   "match any name.</p>"
+                tr("<p><b>Channel</b>: Semicolon separated list of channel/query names, leave "
+                   "blank to match any name.</p>"
                    "<p><i>Example:</i><br />"
                    "<i>#quassel*; #foobar; !#quasseldroid</i><br />"
                    "would match on <i>#foobar</i> and any channel starting with <i>#quassel</i> "


### PR DESCRIPTION
## In short

* Allow empty `Name` for core-side highlights
  * Allows for matching all messages by setting `Name` to empty
  * Combine with `Sender` and `Channel` to match all from a nick/buffer
  * Removes the need for regular expressions just to match all messages
  * Update tooltips to explain
* Clarify `Channel` column tooltip functionality
  * Actually refers to buffer name, so mention `channel/query` in tooltip
  * Don't rename column as queries trigger highlights by default, less useful
* Polish settings page UI
  * Unify tooltips, fixing an outdated tooltip for `Highlight Ignore Rules`
  * Set `Sender` column to auto-resize, like other columns
  * Deduplicate code, simplifying future tooltip changes

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing requested feature, corrected help text
Risk | ★★☆ *2/3* | Confusion over accidental match-all highlight rules
Intrusiveness | ★★☆ *2/3* | UI/string changes, unlikely to interfere with other PRs

## Examples
### Highlighting all messages from a channel
1.  Create new highlight rule
2.  Set `Name` to empty
3.  Set `Channel` to name of channel

### Highlighting all messages from a nickname (e.g. announce bot)
1.  Create new highlight rule
2.  Set `Name` to empty
3.  Set `Sender` to sender nickname, e.g. `nickname!*` to match all of that nick

### UI tooltips
*`Highlight Ignore Rule` table tooltips should now be consistent with `Custom Highlights` table tooltips.*