### PR TITLE
QSS fixes

### DIFF
--- a/src/qtui/qtuistyle.cpp
+++ b/src/qtui/qtuistyle.cpp
@@ -215,15 +215,16 @@ QString QtUiStyle::color(const QString &key, UiSettings &settings, const QColor 
 
 QString QtUiStyle::fontDescription(const QFont &font) const
 {
-    QString desc = "font: ";
-    if (font.italic())
-        desc += "italic ";
-    if (font.bold())
-        desc += "bold ";
-    if (!font.italic() && !font.bold())
-        desc += "normal ";
-    desc += QString("%1pt \"%2\"").arg(font.pointSize()).arg(font.family());
-    return desc;
+    QFont::Style style = font.style();
+    int weight = font.weight();
+
+    return QString("font: %1 %2 %3pt \"%4\"")
+        .arg(style == QFont::StyleItalic  ? "italic"  :
+             style == QFont::StyleOblique ? "oblique" :
+                                            "normal")
+        .arg(100 * qBound(1, (weight * 8 + 50) / 100, 9))
+        .arg(font.pointSize())
+        .arg(font.family());
 }
 
 

--- a/src/uisupport/qssparser.cpp
+++ b/src/uisupport/qssparser.cpp
@@ -728,9 +728,9 @@ void QssParser::parseFont(const QString &value, QTextCharFormat *format)
             format->setFontItalic(true);
         else if (prop == "underline")
             format->setFontUnderline(true);
-        // Oblique is not a property supported by QTextCharFormat
-        //else if(prop == "oblique")
-        //  format->setStyle(QFont::StyleOblique);
+        else if(prop == "oblique")
+            // Oblique is not a property supported by QTextCharFormat
+            format->setFontItalic(true);
         else if (prop == "bold")
             format->setFontWeight(QFont::Bold);
         else { // number
@@ -758,9 +758,9 @@ void QssParser::parseFontStyle(const QString &value, QTextCharFormat *format)
         format->setFontUnderline(true);
     else if (value == "strikethrough")
         format->setFontStrikeOut(true);
-    // Oblique is not a property supported by QTextCharFormat
-    //else if(value == "oblique")
-    //  format->setStyle(QFont::StyleOblique);
+    else if(value == "oblique")
+        // Oblique is not a property supported by QTextCharFormat
+        format->setFontItalic(true);
     else {
         qWarning() << Q_FUNC_INFO << tr("Invalid font style specification: %1").arg(value);
     }

--- a/src/uisupport/qssparser.cpp
+++ b/src/uisupport/qssparser.cpp
@@ -721,13 +721,19 @@ void QssParser::parseFont(const QString &value, QTextCharFormat *format)
         return;
     }
     format->setFontItalic(false);
+    format->setFontUnderline(false);
+    format->setFontStrikeOut(false);
     format->setFontWeight(QFont::Normal);
     QStringList proplist = rx.cap(1).split(' ', QString::SkipEmptyParts);
     foreach(QString prop, proplist) {
-        if (prop == "italic")
+        if (prop == "normal")
+            ; // pass
+        else if (prop == "italic")
             format->setFontItalic(true);
         else if (prop == "underline")
             format->setFontUnderline(true);
+        else if (prop == "strikethrough")
+            format->setFontStrikeOut(true);
         else if(prop == "oblique")
             // Oblique is not a property supported by QTextCharFormat
             format->setFontItalic(true);


### PR DESCRIPTION
This is mostly to fix the weight handling, where the `"normal"` written by `QtUIStyle` is interpreted as an integer weight `0` by `QssParser`, causing the lightest weight to be selected.