### PR TITLE
Stylesheet support for hovered-upon URLs; disable color codes in highlighted messages

### DIFF
--- a/data/stylesheets/default.qss
+++ b/data/stylesheets/default.qss
@@ -14,6 +14,7 @@ ChatLine {
 ChatLine[label="highlight"] {
   foreground: black;
   background: #ff8000;
+  allow-foreground-override: false;
   allow-background-override: false;
 }
 

--- a/data/stylesheets/default.qss
+++ b/data/stylesheets/default.qss
@@ -25,6 +25,10 @@ ChatLine[label="selected"] {
   allow-background-override: false;
 }
 
+ChatLine[label="hovered"] {
+  font-style: underline;
+}
+
 // ChatLine::sender[sender="self"] {
 //   font-style: italic;
 // }

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -20,6 +20,9 @@
 
 #include "chatitem.h"
 
+#include <algorithm>
+#include <iterator>
+
 #include <QApplication>
 #include <QClipboard>
 #include <QDesktopServices>
@@ -286,36 +289,92 @@ void ChatItem::overlayFormat(UiStyle::FormatList &fmtList, quint16 start, quint1
 
 QVector<QTextLayout::FormatRange> ChatItem::additionalFormats() const
 {
-    return selectionFormats();
-}
-
-
-QVector<QTextLayout::FormatRange> ChatItem::selectionFormats() const
-{
-    if (!hasSelection())
-        return QVector<QTextLayout::FormatRange>();
-
-    quint16 start, end;
-    if (_selectionMode == FullSelection) {
-        start = 0;
-        end = data(MessageModel::DisplayRole).toString().length();
-    }
-    else {
-        start = qMin(_selectionStart, _selectionEnd);
-        end = qMax(_selectionStart, _selectionEnd);
+    // Calculate formats to overlay (only) if there's a selection, and/or a hovered clickable
+    if (!hasSelection() && !hasActiveClickable()) {
+        return {};
     }
 
-    UiStyle::FormatList fmtList = formatList();
+    using Label = UiStyle::MessageLabel;
+    using Format = UiStyle::Format;
 
-    while (fmtList.size() > 1 && fmtList.at(1).first <= start)
-        fmtList.erase(fmtList.begin());
+    Label itemLabel = data(ChatLineModel::MsgLabelRole).value<Label>();
+    const auto &fmtList = formatList();
 
-    fmtList.front().first = start;
+    struct LabelFormat {
+        quint16 offset;
+        Format format;
+        Label label;
+    };
 
-    while (fmtList.size() > 1 && fmtList.back().first >= end)
-        fmtList.pop_back();
+    // Transform formatList() into an extended list of LabelFormats
+    std::vector<LabelFormat> labelFmtList;
+    std::transform(fmtList.cbegin(), fmtList.cend(), std::back_inserter(labelFmtList), [itemLabel](const std::pair<quint16, Format> &f) {
+        return LabelFormat{f.first, f.second, itemLabel};
+    });
+    // Append dummy element to avoid special-casing handling the last real format
+    labelFmtList.push_back(LabelFormat{quint16(data(MessageModel::DisplayRole).toString().length()), {}, itemLabel});
 
-    return QtUi::style()->toTextLayoutList(fmtList, end, data(ChatLineModel::MsgLabelRole).value<UiStyle::MessageLabel>()|UiStyle::MessageLabel::Selected).toVector();
+    // Apply the given label to the given range in the format list, splitting formats as necessary
+    auto applyLabel = [&labelFmtList](quint16 start, quint16 end, Label label) {
+        size_t i = 0;
+
+        // Skip unaffected formats
+        for (; i < labelFmtList.size() - 1; ++i) {
+            if (labelFmtList[i+1].offset > start)
+                break;
+        }
+        // Range start doesn't align; split affected format and let the index point to the newly inserted copy
+        if (labelFmtList[i].offset < start) {
+            labelFmtList.insert(labelFmtList.begin() + i, labelFmtList[i]);
+            labelFmtList[++i].offset = start;
+        }
+
+        // Apply label to formats fully affected
+        for (; i < labelFmtList.size() - 1; ++i) {
+            if (labelFmtList[i+1].offset <= end) {
+                labelFmtList[i].label |= label;
+                continue;
+            }
+            // Last affected format, split if end of range doesn't align
+            if (labelFmtList[i+1].offset > end) {
+                labelFmtList.insert(labelFmtList.begin() + i, labelFmtList[i]);
+                labelFmtList[i].label |= label;
+                labelFmtList[i+1].offset = end;
+            }
+            break;
+        }
+    };
+
+    // Apply selection label
+    if (hasSelection()) {
+        quint16 start, end;
+        if (_selectionMode == FullSelection) {
+            start = 0;
+            end = data(MessageModel::DisplayRole).toString().length();
+        }
+        else {
+            start = qMin(_selectionStart, _selectionEnd);
+            end = qMax(_selectionStart, _selectionEnd);
+        }
+        applyLabel(start, end, Label::Selected);
+    }
+
+    // Apply hovered label
+    if (hasActiveClickable()) {
+        applyLabel(activeClickableRange().first, activeClickableRange().second, Label::Hovered);
+    }
+
+    // Add all formats that have an extra label to the additionalFormats list
+    QList<QTextLayout::FormatRange> additionalFormats;
+    for (size_t i = 0; i < labelFmtList.size() - 1; ++i) {
+        if (labelFmtList[i].label != itemLabel) {
+            additionalFormats << QtUi::style()->toTextLayoutList({std::make_pair(labelFmtList[i].offset, labelFmtList[i].format)},
+                                                                 labelFmtList[i+1].offset,
+                                                                 labelFmtList[i].label);
+        }
+    }
+
+    return additionalFormats.toVector();
 }
 
 
@@ -384,6 +443,18 @@ bool ChatItem::isPosOverSelection(const QPointF &pos) const
         return cursor >= qMin(_selectionStart, _selectionEnd) && cursor <= qMax(_selectionStart, _selectionEnd);
     }
     return false;
+}
+
+
+bool ChatItem::hasActiveClickable() const
+{
+    return false;
+}
+
+
+std::pair<quint16, quint16> ChatItem::activeClickableRange() const
+{
+    return {};
 }
 
 
@@ -663,6 +734,22 @@ void ContentsChatItem::doLayout(QTextLayout *layout) const
 }
 
 
+bool ContentsChatItem::hasActiveClickable() const
+{
+    return privateData()->currentClickable.isValid();
+}
+
+
+std::pair<quint16, quint16> ContentsChatItem::activeClickableRange() const
+{
+    const auto &clickable = privateData()->currentClickable;
+    if (clickable.isValid()) {
+        return {clickable.start(), clickable.start() + clickable.length()};
+    }
+    return {};
+}
+
+
 Clickable ContentsChatItem::clickableAt(const QPointF &pos) const
 {
     return privateData()->clickables.atCursorPos(posToCursor(pos));
@@ -679,22 +766,6 @@ UiStyle::FormatList ContentsChatItem::formatList() const
         }
     }
     return fmtList;
-}
-
-
-QVector<QTextLayout::FormatRange> ContentsChatItem::additionalFormats() const
-{
-    QVector<QTextLayout::FormatRange> fmt = ChatItem::additionalFormats();
-    // mark a clickable if hovered upon
-    if (privateData()->currentClickable.isValid()) {
-        Clickable click = privateData()->currentClickable;
-        QTextLayout::FormatRange f;
-        f.start = click.start();
-        f.length = click.length();
-        f.format.setFontUnderline(true);
-        fmt.append(f);
-    }
-    return fmt;
 }
 
 

--- a/src/qtui/chatitem.h
+++ b/src/qtui/chatitem.h
@@ -112,7 +112,6 @@ protected:
     virtual UiStyle::FormatList formatList() const;
 
     void paintBackground(QPainter *);
-    QVector<QTextLayout::FormatRange> selectionFormats() const;
     virtual QVector<QTextLayout::FormatRange> additionalFormats() const;
     void overlayFormat(UiStyle::FormatList &fmtList, quint16 start, quint16 end, UiStyle::FormatType overlayFmt) const;
 
@@ -123,6 +122,9 @@ protected:
     inline SelectionMode selectionMode() const { return _selectionMode; }
     inline void setSelectionMode(SelectionMode mode) { _selectionMode = mode; }
     void setSelection(SelectionMode mode, qint16 selectionStart, qint16 selectionEnd);
+
+    virtual bool hasActiveClickable() const;
+    virtual std::pair<quint16, quint16> activeClickableRange() const;
 
     qint16 posToCursor(const QPointF &pos) const;
 
@@ -206,10 +208,11 @@ protected:
     virtual void hoverMoveEvent(QGraphicsSceneHoverEvent *event);
     virtual void handleClick(const QPointF &pos, ChatScene::ClickMode clickMode);
 
+    virtual bool hasActiveClickable() const;
+    virtual std::pair<quint16, quint16> activeClickableRange() const;
+
     virtual void addActionsToMenu(QMenu *menu, const QPointF &itemPos);
     virtual void copyLinkToClipboard();
-
-    virtual QVector<QTextLayout::FormatRange> additionalFormats() const;
 
     virtual void initLayout(QTextLayout *layout) const;
     virtual void doLayout(QTextLayout *layout) const;

--- a/src/uisupport/qssparser.cpp
+++ b/src/uisupport/qssparser.cpp
@@ -293,6 +293,8 @@ std::pair<UiStyle::FormatType, UiStyle::MessageLabel> QssParser::parseFormatType
                     label |= MessageLabel::Highlight;
                 else if (condValue == "selected")
                     label |= MessageLabel::Selected;
+                else if (condValue == "hovered")
+                    label |= MessageLabel::Hovered;
                 else {
                     qWarning() << Q_FUNC_INFO << tr("Invalid message label: %1").arg(condValue);
                     return invalid;

--- a/src/uisupport/uistyle.cpp
+++ b/src/uisupport/uistyle.cpp
@@ -475,7 +475,7 @@ QTextCharFormat UiStyle::format(const Format &format, MessageLabel label) const
 
     // Merge all formats except mIRC and extended colors
     mergeFormat(charFormat, format, label & 0xffff0000);  // keep nickhash in label
-    for (quint32 mask = 0x00000001; mask <= static_cast<quint32>(MessageLabel::Selected); mask <<= 1) {
+    for (quint32 mask = 0x00000001; mask <= static_cast<quint32>(MessageLabel::Last); mask <<= 1) {
         if (static_cast<quint32>(label) & mask) {
             mergeFormat(charFormat, format, label & (mask | 0xffff0000));
         }
@@ -485,7 +485,7 @@ QTextCharFormat UiStyle::format(const Format &format, MessageLabel label) const
     // unless the AllowForegroundOverride or AllowBackgroundOverride properties are set (via stylesheet).
     if (_allowMircColors) {
         mergeColors(charFormat, format, MessageLabel::None);
-        for (quint32 mask = 0x00000001; mask <= static_cast<quint32>(MessageLabel::Selected); mask <<= 1) {
+        for (quint32 mask = 0x00000001; mask <= static_cast<quint32>(MessageLabel::Last); mask <<= 1) {
             if (static_cast<quint32>(label) & mask) {
                 mergeColors(charFormat, format, label & mask);
             }

--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -105,7 +105,9 @@ public:
         None            = 0x00000000,
         OwnMsg          = 0x00000001,
         Highlight       = 0x00000002,
-        Selected        = 0x00000004 // must be last!
+        Selected        = 0x00000004,
+        Hovered         = 0x00000008,
+        Last            = Hovered
     };
 
     enum class ItemFormatType : quint32 {


### PR DESCRIPTION
- A new message label "hovered" can now be used in stylesheets to control how a hovered-upon URLs should be rendered. The default stylesheets defines an underline.
- Fix rendering of selected, active clickable. Fixes the issue where a selected URL in a highlighted message would vanished when hovered upon.
- Disable color codes in highlighted messages in the default stylesheet.