### PR TITLE
Allow to disable spell checking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,7 +350,7 @@ if (USE_QT5)
         if (ECM_FOUND)
             list(APPEND CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
             if (WITH_KDE)
-                find_package(KF5 COMPONENTS ConfigWidgets CoreAddons Notifications NotifyConfig TextWidgets WidgetsAddons XmlGui QUIET)
+                find_package(KF5 COMPONENTS ConfigWidgets CoreAddons Notifications NotifyConfig Sonnet TextWidgets WidgetsAddons XmlGui QUIET REQUIRED)
                 set_package_properties(KF5 PROPERTIES TYPE REQUIRED
                     URL "http://www.kde.org"
                     DESCRIPTION "KDE Frameworks"

--- a/src/qtui/inputwidget.cpp
+++ b/src/qtui/inputwidget.cpp
@@ -118,11 +118,6 @@ InputWidget::InputWidget(QWidget *parent)
 
     UiSettings s("InputWidget");
 
-#ifdef HAVE_KDE4
-    s.notify("EnableSpellCheck", this, SLOT(setEnableSpellCheck(QVariant)));
-    setEnableSpellCheck(s.value("EnableSpellCheck", false));
-#endif
-
     s.notify("EnableEmacsMode", this, SLOT(setEnableEmacsMode(QVariant)));
     setEnableEmacsMode(s.value("EnableEmacsMode", false));
 
@@ -186,12 +181,6 @@ void InputWidget::setCustomFont(const QVariant &v)
     font.setUnderline(false);
     font.setStrikeOut(false);
     ui.inputEdit->setCustomFont(font);
-}
-
-
-void InputWidget::setEnableSpellCheck(const QVariant &v)
-{
-    ui.inputEdit->setSpellCheckEnabled(v.toBool());
 }
 
 

--- a/src/qtui/inputwidget.h
+++ b/src/qtui/inputwidget.h
@@ -102,7 +102,6 @@ protected slots:
 private slots:
     void setCustomFont(const QVariant &font);
     void setUseCustomFont(const QVariant &);
-    void setEnableSpellCheck(const QVariant &);
     void setEnableEmacsMode(const QVariant &);
     void setShowNickSelector(const QVariant &);
     void setShowStyleButtons(const QVariant &);

--- a/src/qtui/settingspages/inputwidgetsettingspage.cpp
+++ b/src/qtui/settingspages/inputwidgetsettingspage.cpp
@@ -24,10 +24,5 @@ InputWidgetSettingsPage::InputWidgetSettingsPage(QWidget *parent)
     : SettingsPage(tr("Interface"), tr("Input Widget"), parent)
 {
     ui.setupUi(this);
-
-#ifndef HAVE_KDE4
-    ui.enableSpellCheck->hide();
-#endif
-
     initAutoWidgets();
 }

--- a/src/qtui/settingspages/inputwidgetsettingspage.ui
+++ b/src/qtui/settingspages/inputwidgetsettingspage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>507</width>
+    <width>512</width>
     <height>514</height>
    </rect>
   </property>
@@ -43,19 +43,6 @@
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="enableSpellCheck">
-     <property name="text">
-      <string>Enable spell check</string>
-     </property>
-     <property name="settingsKey" stdset="0">
-      <string notr="true">EnableSpellCheck</string>
-     </property>
-     <property name="defaultValue" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
    </item>
    <item>
     <widget class="QCheckBox" name="enablePerBufferHistory">
@@ -140,7 +127,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Multi-Line Editing</string>
+      <string>&amp;Multi-Line Editing</string>
      </property>
      <property name="checkable">
       <bool>true</bool>
@@ -281,10 +268,10 @@
            <bool>false</bool>
           </property>
           <property name="settingsKey" stdset="0">
-            <string notr="true">/TabCompletion/AddSpaceMidSentence</string>
+           <string notr="true">/TabCompletion/AddSpaceMidSentence</string>
           </property>
           <property name="defaultValue" stdset="0">
-            <bool>false</bool>
+           <bool>false</bool>
           </property>
          </widget>
         </item>
@@ -331,7 +318,6 @@
  </customwidgets>
  <tabstops>
   <tabstop>customFont</tabstop>
-  <tabstop>enableSpellCheck</tabstop>
   <tabstop>showNickSelector</tabstop>
   <tabstop>groupBox</tabstop>
   <tabstop>maxNumLines</tabstop>

--- a/src/uisupport/CMakeLists.txt
+++ b/src/uisupport/CMakeLists.txt
@@ -62,7 +62,9 @@ endif()
 
 if (WITH_KF5)
     target_link_libraries(mod_uisupport KF5::CoreAddons KF5::TextWidgets KF5::XmlGui)
-elseif (KF5Sonnet_FOUND)
+endif()
+
+if (KF5Sonnet_FOUND)
     add_definitions(-DHAVE_SONNET)
     target_link_libraries(mod_uisupport KF5::SonnetUi)
 endif()

--- a/src/uisupport/multilineedit.h
+++ b/src/uisupport/multilineedit.h
@@ -35,6 +35,12 @@
 #  define MultiLineEditParent QTextEdit
 #endif
 
+#if defined HAVE_SONNET && !defined HAVE_KDE
+#  include <QContextMenuEvent>
+#  include <Sonnet/Highlighter>
+#  include <Sonnet/SpellCheckDecorator>
+#endif
+
 class MultiLineEdit : public MultiLineEditParent
 {
     Q_OBJECT
@@ -74,9 +80,6 @@ public:
     inline bool emacsMode() const { return _emacsMode; }
 
     void addCompletionSpace();
-#if defined HAVE_KF5 || defined HAVE_KDE4
-    void createHighlighter() override;
-#endif
 
 public slots:
     void setMode(Mode mode);
@@ -84,7 +87,6 @@ public slots:
     void setMaxHeight(int numLines);
     void setEmacsMode(bool enable = true);
     void setScrollBarsEnabled(bool enable = true);
-    void setSpellCheckEnabled(bool enable = true);
     void setPasteProtectionEnabled(bool enable = true, QWidget *msgBoxParent = 0);
     void setLineWrapEnabled(bool enable = false);
 
@@ -101,6 +103,10 @@ protected:
     void keyPressEvent(QKeyEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
 
+#if defined HAVE_SONNET && !defined HAVE_KDE
+    void contextMenuEvent(QContextMenuEvent *event) override;
+#endif
+
 private slots:
     void on_returnPressed();
     void on_returnPressed(QString text);
@@ -114,6 +120,12 @@ private slots:
     QString convertRichtextToMircCodes();
     QString convertMircCodesToHtml(const QString &text);
     bool mircCodesChanged(QTextCursor &cursor, QTextCursor &peekcursor);
+
+private:
+    void reset();
+    void showHistoryEntry();
+    void updateScrollBars();
+    void updateSizeHint();
 
 private:
     QStringList _history;
@@ -133,10 +145,16 @@ private:
 
     QMap<QString, QString> _mircColorMap;
 
-    void reset();
-    void showHistoryEntry();
-    void updateScrollBars();
-    void updateSizeHint();
+#if defined HAVE_SONNET && !defined HAVE_KDE
+    // This member function is provided by KTextEdit
+    Sonnet::Highlighter *highlighter() const;
+
+private slots:
+    void setSpellCheckEnabled(bool enabled);
+
+private:
+    Sonnet::SpellCheckDecorator *_spellCheckDecorator{nullptr};
+#endif
 };
 
 


### PR DESCRIPTION
Apparently, Sonnet, when used standalone (i.e. not in KTextEdit),
does not honor its own setting to disable it by default.

Explicitly read the setting when initializing the highlighter, and
set its active state accordingly. Provide a context menu option
to enable/disable spell check on-the-fly as well.

Remove the bogus/unused checkbox in the InputWidget settings page;
there is a dedicated settings page for configuring spell checking.

Explicitly depend on Sonnet when building with KDE Frameworks
(it was transitively depended upon anyway), so we can be sure to
offer the Sonnet settings page even when using Frameworks.