### PR TITLE
Use Qt's font dialog instead of the (broken) native OSX one

### DIFF
--- a/src/uisupport/fontselector.cpp
+++ b/src/uisupport/fontselector.cpp
@@ -55,7 +55,7 @@ void FontSelector::setSelectedFont(const QFont &font)
 void FontSelector::chooseFont()
 {
     bool ok;
-    QFont font = QFontDialog::getFont(&ok, _demo->font());
+    QFont font = QFontDialog::getFont(&ok, _demo->font(), nullptr, QString(), QFontDialog::DontUseNativeDialog);
     if (ok) {
         setSelectedFont(font);
     }


### PR DESCRIPTION
By default Qt uses a different (native) font selection dialog on OSX.
But that one does not change the selected font when clicking OK.

With this PR we tell Qt to open the normal Qt font dialog instead of the native one.