### PR TITLE
client: Fix duplicated query quit messages

### DIFF
--- a/src/client/messagefilter.h
+++ b/src/client/messagefilter.h
@@ -22,6 +22,7 @@
 #define MESSAGEFILTER_H_
 
 #include <QSortFilterProxyModel>
+#include <set>
 
 #include "bufferinfo.h"
 #include "client.h"
@@ -62,7 +63,7 @@ private:
     void init();
 
     QSet<BufferId> _validBuffers;
-    QMultiHash<QString, qint64> _filteredQuitMsgs;
+    std::set<qint64> _filteredQuitMsgTime; ///< Timestamps (ms) of already forwarded quit messages
     int _messageTypeFilter;
 
     int _userNoticesTarget;


### PR DESCRIPTION
## In short

* Fix duplicate `<nick> has quit` messages in queries
  * Search quit message timestamps ±1000 ms, not relying on seconds rounding
  * Fixes existing bug made worse by 64-bit time precision in commit 6a63070246d89aa2a2474e3a9a1035fa889ad77e
* Clean up approach
  * Don't needlessly track nicknames in hashmap
  * Add more documentation

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes user-facing annoying UI regression from `0.12.5`
Risk | ★☆☆ *1/3* | Possibly hiding quit messages or showing too many
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

*Fixes regression from [changes made in pull request #357](https://github.com/quassel/quassel/pull/357 ).*

## Implementation
Replace the `.contains()` check with `std::binary_search` on message timestamps, passing a custom comparator that provides ± `1000` ms of fuzzy matching.  If a quit message is received and doesn't exist within this time range, it gets forwarded to the query, otherwise discarded.

Remove the `QMultiHash` method that tracked quit nicknames.  Each query gets a unique `MessageFilter`, so there's no need to store and filter that.  This will need modified if e.g. adding an option for quit messages in the Chat Monitor.

This fixes an existing bug made much worse with millisecond timestamp precision.  Before the 64-bit time changes, quit messages would only be duplicated if they got split over the turn of a second, a rare occurrence.  Afterwards, they'd get duplicated if split over the turn of a millisecond, a much more common occurrence.

Fixes regression from commit 6a63070246d89aa2a2474e3a9a1035fa889ad77e .

## Testing
### Steps
1.  Connect a `0.13` core and client to network
2.  Join several channels
3.  Start a query with a test nickname in multiple channels
4.  Quit the test nickname
5.  Observe the query inside Quassel

*It's also worthwhile testing setting backlog fetching to `1`, then fetching backlog in reverse order, newest to oldest.*

### Before
*Multiple quit messages shown, one for each shared channel, `5` in this case*
```
[12:00:00 am] - {Day changed to Sunday, August 5, 2018}
[11:21:16 pm] <-- nickname (ident@hostmask) has quit (Quit: Leaving)
[11:21:16 pm] <-- nickname (ident@hostmask) has quit (Quit: Leaving)
[11:21:16 pm] <-- nickname (ident@hostmask) has quit (Quit: Leaving)
[11:21:16 pm] <-- nickname (ident@hostmask) has quit (Quit: Leaving)
[11:21:16 pm] <-- nickname (ident@hostmask) has quit (Quit: Leaving)
[12:00:00 am] - {Day changed to Monday, August 6, 2018}
```

### After
*Single quit message shown for any 1 second block of time*
```
[12:00:00 am] - {Day changed to Sunday, August 5, 2018}
[11:21:16 pm] <-- nickname (ident@hostmask) has quit (Quit: Leaving)
[12:00:00 am] - {Day changed to Monday, August 6, 2018}
```