### PR TITLE
settings: Enable local nick highlights by default

### DIFF
--- a/src/client/clientsettings.cpp
+++ b/src/client/clientsettings.cpp
@@ -320,7 +320,8 @@ void NotificationSettings::setHighlightNick(NotificationSettings::HighlightNickT
 
 NotificationSettings::HighlightNickType NotificationSettings::highlightNick()
 {
-    return (NotificationSettings::HighlightNickType)localValue("Highlights/HighlightNick", NoNick).toInt();
+    return (NotificationSettings::HighlightNickType)localValue("Highlights/HighlightNick",
+                                                               CurrentNick).toInt();
 }
 
 

--- a/src/qtui/settingspages/highlightsettingspage.cpp
+++ b/src/qtui/settingspages/highlightsettingspage.cpp
@@ -130,7 +130,7 @@ bool HighlightSettingsPage::hasDefaults() const
 
 void HighlightSettingsPage::defaults()
 {
-    ui.highlightNoNick->setChecked(true);
+    ui.highlightCurrentNick->setChecked(true);
     ui.nicksCaseSensitive->setChecked(false);
     emptyTable();
 

--- a/src/qtui/settingspages/highlightsettingspage.ui
+++ b/src/qtui/settingspages/highlightsettingspage.ui
@@ -130,9 +130,6 @@
         <property name="text">
          <string>Case sensitive</string>
         </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
## In short

* Set `Current nick` to the default for `Local Highlights`
  * Fixes upgrading the client before the core resulting in losing nickname highlights
  * Can still be changed to `None`/etc by the user
  * May introduce confusion, adds minor performance penalty
* Clean up UI to match defaults

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes seeming loss of nick highlights on new client/old core
Risk | ★☆☆ *1/3* | Confusion over two places to turn off nick highlights
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Examples
### Before
*`Local Highlights` defaults to `None` if not changed*

### After
*`Local Highlights` defaults to `Current nick` if not changed*