### PR TITLE
settings: Reset Network SASL status on load

### DIFF
--- a/src/qtui/settingspages/networkssettingspage.cpp
+++ b/src/qtui/settingspages/networkssettingspage.cpp
@@ -207,6 +207,9 @@ void NetworksSettingsPage::load()
     sslUpdated();
 #endif
 
+    // Reset network capability status in case no valid networks get selected (a rare situation)
+    resetNetworkCapStates();
+
     foreach(NetworkId netid, Client::networkIds()) {
         clientNetworkAdded(netid);
     }
@@ -355,10 +358,17 @@ void NetworksSettingsPage::setItemState(NetworkId id, QListWidgetItem *item)
 }
 
 
+void NetworksSettingsPage::resetNetworkCapStates()
+{
+    // Set the status to a blank (invalid) network ID, reseting all UI
+    setNetworkCapStates(NetworkId());
+}
+
+
 void NetworksSettingsPage::setNetworkCapStates(NetworkId id)
 {
     const Network *net = Client::network(id);
-    if (Client::isCoreFeatureEnabled(Quassel::Feature::CapNegotiation) && net) {
+    if (net && Client::isCoreFeatureEnabled(Quassel::Feature::CapNegotiation)) {
         // Capability negotiation is supported, network exists.
         // Check if the network is connected.  Don't use net->isConnected() as that won't be true
         // during capability negotiation when capabilities are added and removed.

--- a/src/qtui/settingspages/networkssettingspage.h
+++ b/src/qtui/settingspages/networkssettingspage.h
@@ -60,6 +60,16 @@ private slots:
     void setItemState(NetworkId, QListWidgetItem *item = 0);
 
     /**
+     * Reset the capability-dependent settings to the default unknown states
+     *
+     * For example, this updates the SASL text to indicate the status is unknown.  Any actual
+     * information should be set by setNetworkCapStates()
+     *
+     * @see NetworksSettingsPage::setNetworkCapStates()
+     */
+    void resetNetworkCapStates();
+
+    /**
      * Update the capability-dependent settings according to what the server supports
      *
      * For example, this updates the SASL text for when the server advertises support.  This should


### PR DESCRIPTION
## In short

* Reset IRCv3 capability-based network settings when loading networks
  * Should help fix the template text being left visible when network is unknown
  * Seems to happen with `0.11` core and modern client
  * *No negative effects introduced, but original issue unconfirmed*

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Fixes small user-facing missing icon for older cores
Risk | ★☆☆ *1/3* | May not properly fix the issue, slight additional UI churn
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Examples
*In `Configure Quassel…` → `IRC` → `Networks` → `Auto Identify`*

### Before
`[icon] Could not detect if supported by server`

### After
:information_source: `Could not detect if supported by server`

*I've not been able to reproduce this locally with a 0.12.5 core.*