### PR TITLE
core: Remove leftover getAuthUserName and SQL

### DIFF
--- a/src/core/SQL/PostgreSQL/select_authusername.sql
+++ b/src/core/SQL/PostgreSQL/select_authusername.sql
@@ -1,3 +1,0 @@
-SELECT username
-FROM quasseluser
-WHERE userid = :userid

--- a/src/core/SQL/SQLite/select_authusername.sql
+++ b/src/core/SQL/SQLite/select_authusername.sql
@@ -1,3 +1,0 @@
-SELECT username
-FROM quasseluser
-WHERE userid = :userid

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -556,13 +556,6 @@ public:
         return instance()->_storage->setBufferLastSeenMsg(user, bufferId, msgId);
     }
 
-    //! Get the auth username associated with a userId
-    /** \param user  The user to retrieve the username for
-     *  \return      The username for the user
-     */
-    static inline QString getAuthUserName(UserId user) {
-        return instance()->_storage->getAuthUserName(user);
-    }
 
     //! Get a usable sysident for the given user in oidentd-strict mode
     /** \param user    The user to retrieve the sysident for

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -2024,21 +2024,6 @@ QMap<UserId, QString> PostgreSqlStorage::getAllAuthUserNames()
 }
 
 
-QString PostgreSqlStorage::getAuthUserName(UserId user)
-{
-    QString authusername;
-    QSqlQuery query(logDb());
-    query.prepare(queryString("select_authusername"));
-    query.bindValue(":userid", user.toInt());
-    safeExec(query);
-    watchQuery(query);
-
-    if (query.first()) {
-         authusername = query.value(0).toString();
-    }
-    return authusername;
-}
-
 // void PostgreSqlStorage::safeExec(QSqlQuery &query) {
 //   qDebug() << "PostgreSqlStorage::safeExec";
 //   qDebug() << "   executing:\n" << query.executedQuery();

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -120,7 +120,6 @@ public slots:
 
     /* Sysident handling */
     QMap<UserId, QString> getAllAuthUserNames() override;
-    QString getAuthUserName(UserId user) override;
 
 protected:
     bool initDbSession(QSqlDatabase &db) override;

--- a/src/core/sql.qrc
+++ b/src/core/sql.qrc
@@ -35,7 +35,6 @@
     <file>./SQL/PostgreSQL/select_all_authusernames.sql</file>
     <file>./SQL/PostgreSQL/select_authenticator.sql</file>
     <file>./SQL/PostgreSQL/select_authuser.sql</file>
-    <file>./SQL/PostgreSQL/select_authusername.sql</file>
     <file>./SQL/PostgreSQL/select_bufferByName.sql</file>
     <file>./SQL/PostgreSQL/select_bufferExists.sql</file>
     <file>./SQL/PostgreSQL/select_buffer_bufferactivities.sql</file>
@@ -172,7 +171,6 @@
     <file>./SQL/SQLite/select_all_authusernames.sql</file>
     <file>./SQL/SQLite/select_authenticator.sql</file>
     <file>./SQL/SQLite/select_authuser.sql</file>
-    <file>./SQL/SQLite/select_authusername.sql</file>
     <file>./SQL/SQLite/select_bufferByName.sql</file>
     <file>./SQL/SQLite/select_bufferExists.sql</file>
     <file>./SQL/SQLite/select_buffer_bufferactivities.sql</file>

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -2178,25 +2178,6 @@ QMap<UserId, QString> SqliteStorage::getAllAuthUserNames()
 }
 
 
-QString SqliteStorage::getAuthUserName(UserId user) {
-    QString authusername;
-    QSqlQuery query(logDb());
-    query.prepare(queryString("select_authusername"));
-    query.bindValue(":userid", user.toInt());
-
-    lockForRead();
-    safeExec(query);
-    watchQuery(query);
-    unlock();
-
-    if (query.first()) {
-        authusername = query.value(0).toString();
-    }
-
-    return authusername;
-}
-
-
 QString SqliteStorage::backlogFile()
 {
     return Quassel::configDirPath() + "quassel-storage.sqlite";

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -121,7 +121,6 @@ public slots:
 
     /* Sysident handling */
     QMap<UserId, QString> getAllAuthUserNames() override;
-    QString getAuthUserName(UserId user) override;
 
 protected:
     void setConnectionProperties(const QVariantMap &properties,

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -533,12 +533,6 @@ public slots:
      */
     virtual QMap<UserId, QString> getAllAuthUserNames() = 0;
 
-    //! Get the auth username associated with a userId
-    /** \param user  The user to retrieve the username for
-     *  \return      The username for the user
-     */
-    virtual QString getAuthUserName(UserId user) = 0;
-
 signals:
     //! Sent when a new BufferInfo is created, or an existing one changed somehow.
     void bufferInfoUpdated(UserId user, const BufferInfo &);


### PR DESCRIPTION
## In short

* Remove unused `Storage::getAuthUserName()`/`select_authusername.sql`
  * Applies to PostgreSQL and SQLite
  * May avoid confusion in the future
  * When getting username-for-ID, consult `Core::_authUserNames` instead

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Internal code cleanup, reduces future developer confusion
Risk | ★☆☆ *1/3* | Removes unused code
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests