### PR TITLE
settings: Fix Chat Monitor defaults

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -141,7 +141,8 @@ private:
     }
 
 
-    static QHash<QString, QVariant> settingsCache;
+    static QHash<QString, QVariant> settingsCache;         ///< Cached settings values
+    static QHash<QString, bool> settingsKeyPersistedCache; ///< Cached settings key exists on disk
     static QHash<QString, SettingsChangeNotifier *> settingsChangeNotifier;
 
     inline QString normalizedKey(const QString &group, const QString &key)
@@ -149,6 +150,44 @@ private:
         if (group.isEmpty())
             return key;
         return group + '/' + key;
+    }
+
+
+    /**
+     * Update the cache of whether or not a given settings key persists on disk
+     *
+     * @param normKey Normalized settings key ID
+     * @param exists  True if key exists, otherwise false
+     */
+    inline void setCacheKeyPersisted(const QString &normKey, bool exists)
+    {
+        settingsKeyPersistedCache[normKey] = exists;
+    }
+
+
+    /**
+     * Check if the given settings key ID persists on disk (rather than being a default value)
+     *
+     * @see Settings::localKeyExists()
+     *
+     * @param normKey Normalized settings key ID
+     * @return True if key exists and persistence has been cached, otherwise false
+     */
+    inline const bool &cacheKeyPersisted(const QString &normKey)
+    {
+        return settingsKeyPersistedCache[normKey];
+    }
+
+
+    /**
+     * Check if the persistence of the given settings key ID has been cached
+     *
+     * @param normKey Normalized settings key ID
+     * @return True if key persistence has been cached, otherwise false
+     */
+    inline bool isKeyPersistedCached(const QString &normKey)
+    {
+        return settingsKeyPersistedCache.contains(normKey);
     }
 
 

--- a/src/qtui/chatmonitorfilter.cpp
+++ b/src/qtui/chatmonitorfilter.cpp
@@ -34,6 +34,9 @@ ChatMonitorFilter::ChatMonitorFilter(MessageModel *model, QObject *parent)
     _showSenderBrackets = defaultSettings.showSenderBrackets();
     defaultSettings.notify("ShowSenderBrackets", this, SLOT(showSenderBracketsSettingChanged(const QVariant &)));
 
+    // NOTE: Whenever changing defaults here, also update ChatMonitorSettingsPage::loadSettings()
+    // and ChatMonitorSettingsPage::defaults() to match
+
     // Chat Monitor specific configuration
     ChatViewSettings viewSettings(idString());
     _showFields = viewSettings.value("ShowFields", AllFields).toInt();
@@ -50,12 +53,13 @@ ChatMonitorFilter::ChatMonitorFilter(MessageModel *model, QObject *parent)
     QString alwaysOwnSettingsId = "AlwaysOwn";
 
     _showHighlights = viewSettings.value(showHighlightsSettingsId, false).toBool();
-    _operationMode = viewSettings.value(operationModeSettingsId, 0).toInt();
+    _operationMode =
+            viewSettings.value(operationModeSettingsId, ChatViewSettings::InvalidMode).toInt();
     // read configured list of buffers to monitor/ignore
     foreach(QVariant v, viewSettings.value(buffersSettingsId, QVariant()).toList())
     _bufferIds << v.value<BufferId>();
     _showBacklog = viewSettings.value(showBacklogSettingsId, true).toBool();
-    _includeRead = viewSettings.value(includeReadSettingsId, true).toBool();
+    _includeRead = viewSettings.value(includeReadSettingsId, false).toBool();
     _alwaysOwn = viewSettings.value(alwaysOwnSettingsId, false).toBool();
 
     viewSettings.notify(showHighlightsSettingsId, this, SLOT(showHighlightsSettingChanged(const QVariant &)));

--- a/src/qtui/settingspages/chatmonitorsettingspage.cpp
+++ b/src/qtui/settingspages/chatmonitorsettingspage.cpp
@@ -77,9 +77,12 @@ bool ChatMonitorSettingsPage::hasDefaults() const
 
 void ChatMonitorSettingsPage::defaults()
 {
+    // NOTE: Whenever changing defaults here, also update ChatMonitorFilter::ChatMonitorFilter()
+    // and ChatMonitorSettingsPage::loadSettings() to match
+
     settings["OperationMode"] = ChatViewSettings::OptOut;
     settings["ShowHighlights"] = false;
-    settings["ShowOwnMsgs"] = false;
+    settings["ShowOwnMsgs"] = true;
     settings["AlwaysOwn"] = false;
     settings["Buffers"] = QVariant();
     settings["Default"] = true;
@@ -130,15 +133,18 @@ void ChatMonitorSettingsPage::load()
 
 void ChatMonitorSettingsPage::loadSettings()
 {
+    // NOTE: Whenever changing defaults here, also update ChatMonitorFilter::ChatMonitorFilter()
+    // and ChatMonitorSettingsPage::defaults() to match
     ChatViewSettings chatViewSettings("ChatMonitor");
-    settings["OperationMode"] = (ChatViewSettings::OperationMode)chatViewSettings.value("OperationMode", ChatViewSettings::OptOut).toInt();
 
+    settings["OperationMode"] = (ChatViewSettings::OperationMode)
+            chatViewSettings.value("OperationMode", ChatViewSettings::OptOut).toInt();
     settings["ShowHighlights"] = chatViewSettings.value("ShowHighlights", false);
-    settings["ShowOwnMsgs"] = chatViewSettings.value("ShowOwnMsgs", false);
+    settings["ShowOwnMsgs"] = chatViewSettings.value("ShowOwnMsgs", true);
     settings["AlwaysOwn"] = chatViewSettings.value("AlwaysOwn", false);
     settings["Buffers"] = chatViewSettings.value("Buffers", QVariantList());
     settings["ShowBacklog"] = chatViewSettings.value("ShowBacklog", true);
-    settings["IncludeRead"] = chatViewSettings.value("IncludeRead", true);
+    settings["IncludeRead"] = chatViewSettings.value("IncludeRead", false);
 }
 
 


### PR DESCRIPTION
## In short

* Unify `Chat Monitor` defaults
  * Syncs three separate places for setting defaults
  * Defaults to disabling showing read messages, enabling showing own messages
  * Add a comment to explain and hopefully avoid this in the future
* Fix `Settings` default caching wrong values
  * Fix caching of default values overriding different defaults elsewhere
  * Fixes `Chat Monitor` settings showing up as invalid instead of `Opt Out`
  * Cache key persistence, possibly speeding up `localKeyExists()`

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing defaults fix-up, avoids UI quirk
Risk | ★★☆ *2/3* | Different defaults might be used, new cache mechanics
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Examples
### Before - Chat Monitor settings
*In `Settings` → `Configure Quassel…` → `Interface` → `Chat Monitor`*
![Chat Monitor settings, showing the Operation Mode combobox as having nothing selected](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-chatmon-defaults/Chat%20Monitor%20settings%20-%20before%2C%20defaults%20invalid.png#v1 )

*Chat Monitor's `Operation Mode` combobox is not selected*

### After - Chat Monitor settings
*In `Settings` → `Configure Quassel…` → `Interface` → `Chat Monitor`*
![Chat Monitor settings, showing the Operation Mode combobox as having "Opt Out" selected](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-chatmon-defaults/Chat%20Monitor%20settings%20-%20after%2C%20defaults%20correct.png#v1 )

*Chat Monitor's `Operation Mode` combobox correctly selects `Opt Out` by default*

### Debug log showing differences
*First instance is from `ChatMonitorFilter`, second is from `ChatMonitorSettingsPage`*
```
2018-08-22 16:39:06 [Debug] Settings::localValue()
Returning default value for key "QtUi/ChatView/ChatMonitor/OperationMode" ,
default QVariant(int, 0)

2018-08-22 16:39:08 [Debug] Settings::localValue()
Returning default value for key "QtUi/ChatView/ChatMonitor/OperationMode" ,
default QVariant(int, 2)
```

*Before, the default value from the first would be cached, causing `Settings` to return that value for the second even though it requested a different default.*