### PR TITLE
Remove [[clang::fallthrough]] annotations again

### DIFF
--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -1054,13 +1054,13 @@ void CoreSessionEventProcessor::processIrcEvent322(IrcEvent *e)
     switch (e->params().count()) {
     case 3:
         topic = e->params()[2];
-        [[clang::fallthrough]];
+        // fallthrough
     case 2:
         userCount = e->params()[1].toUInt();
-        [[clang::fallthrough]];
+        // fallthrough
     case 1:
         channelName = e->params()[0];
-        [[clang::fallthrough]];
+        // fallthrough
     default:
         break;
     }

--- a/src/core/eventstringifier.cpp
+++ b/src/core/eventstringifier.cpp
@@ -610,13 +610,13 @@ void EventStringifier::processIrcEvent322(IrcEvent *e)
     switch (e->params().count()) {
     case 3:
         topic = e->params()[2];
-        [[clang::fallthrough]];
+        // fallthrough
     case 2:
         userCount = e->params()[1].toUInt();
-        [[clang::fallthrough]];
+        /* fallthrough */
     case 1:
         channelName = e->params()[0];
-        [[clang::fallthrough]];
+        // blubb
     default:
         break;
     }

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -2212,7 +2212,7 @@ bool SqliteStorage::safeExec(QSqlQuery &query, int retryCount)
 
     switch (query.lastError().number()) {
     case 5: // SQLITE_BUSY         5   /* The database file is locked */
-        [[clang::fallthrough]];
+        // fallthrough
     case 6: // SQLITE_LOCKED       6   /* A table in the database is locked */
         if (retryCount < _maxRetryCount)
             return safeExec(query, retryCount + 1);

--- a/src/qtui/bufferwidget.cpp
+++ b/src/qtui/bufferwidget.cpp
@@ -232,7 +232,7 @@ bool BufferWidget::eventFilter(QObject *watched, QEvent *event)
     case Qt::Key_Down:
         if (!(keyEvent->modifiers() & Qt::ShiftModifier))
             return false;
-        [[clang::fallthrough]];
+        // fallthrough
     case Qt::Key_PageUp:
     case Qt::Key_PageDown:
         // static cast to access public qobject::event

--- a/src/qtui/chatscene.cpp
+++ b/src/qtui/chatscene.cpp
@@ -1297,7 +1297,6 @@ void ChatScene::webPreviewNextStep()
         if (webPreview.previewItem && webPreview.previewItem->scene())
             removeItem(webPreview.previewItem);
         // Fall through to deletion!
-        [[clang::fallthrough]];
     case WebPreview::HidePreview:
         if (webPreview.previewItem) {
             delete webPreview.previewItem;
@@ -1325,7 +1324,6 @@ void ChatScene::clearWebPreview(ChatItem *parentItem)
                 removeItem(webPreview.previewItem);
         }
         // fall through into to set hidden state
-        [[clang::fallthrough]];
     case WebPreview::DelayPreview:
         // we're just loading, so haven't shown the preview yet.
         webPreview.previewState = WebPreview::HidePreview;

--- a/src/uisupport/networkmodelcontroller.cpp
+++ b/src/uisupport/networkmodelcontroller.cpp
@@ -363,7 +363,7 @@ void NetworkModelController::handleHideAction(ActionType type, QAction *action)
         return;
     case HideApplyToAll:
         BufferSettings().setMessageFilter(filter);
-        [[clang::fallthrough]];
+        // fallthrough
     case HideUseDefaults:
         if (_messageFilter)
             BufferSettings(_messageFilter->idString()).removeFilter();

--- a/src/uisupport/tabcompleter.cpp
+++ b/src/uisupport/tabcompleter.cpp
@@ -109,7 +109,7 @@ void TabCompleter::buildCompletionList()
         case BufferInfo::QueryBuffer:
             if (regex.indexIn(_currentBufferName) > -1)
                 _completionMap[_currentBufferName.toLower()] = _currentBufferName;
-            [[clang::fallthrough]];
+            // fallthrough
         case BufferInfo::StatusBuffer:
             if (!_currentNetwork->myNick().isEmpty() && regex.indexIn(_currentNetwork->myNick()) > -1)
                 _completionMap[_currentNetwork->myNick().toLower()] = _currentNetwork->myNick();


### PR DESCRIPTION
These cause warnings in most compilers, so remove them again until
we can use C++17 and the official attribute.

Add comments, so we know the fallthroughs are intentional anyway.