### PR TITLE
core: Limit "User is away" to 1hr or when changed

### DIFF
--- a/src/common/ircuser.cpp
+++ b/src/common/ircuser.cpp
@@ -165,6 +165,7 @@ void IrcUser::setAway(const bool &away)
 {
     if (away != _away) {
         _away = away;
+        markAwayChanged();
         SYNC(ARG(away))
         emit awaySet(away);
     }
@@ -175,6 +176,7 @@ void IrcUser::setAwayMessage(const QString &awayMessage)
 {
     if (!awayMessage.isEmpty() && _awayMessage != awayMessage) {
         _awayMessage = awayMessage;
+        markAwayChanged();
         SYNC(ARG(awayMessage))
     }
 }

--- a/src/common/ircuser.h
+++ b/src/common/ircuser.h
@@ -106,6 +106,31 @@ public :
     inline QDateTime lastSpokenTo(BufferId id) const { return _lastSpokenTo.value(id); }
     void setLastSpokenTo(BufferId id, const QDateTime &time);
 
+    /**
+     * Gets whether or not the away state has changed since it was last acknowledged
+     *
+     * Away state is marked as changed by any modification to away status (away/here, message)
+     *
+     * NOTE: On servers lacking support for IRCv3 away-notify, this won't update until an autoWHO-
+     * run for away/here changes, or until sending a message to the user for away message changes.
+     *
+     * @see IrcUser::acknowledgeAwayChanged()
+     *
+     * @return True if current away state is unchanged from last acknowledgement, otherwise false
+     */
+    inline bool hasAwayChanged() const { return _awayChanged; }
+
+    /**
+     * Sets the last away state change as acknowledged
+     *
+     * @see IrcUser::hasAwayChanged()
+     */
+    inline void acknowledgeAwayChanged()
+    {
+        // Don't sync this as individual clients may suppress different kinds of behaviors
+        _awayChanged = false;
+    }
+
 public slots:
     void setUser(const QString &user);
     void setHost(const QString &host);
@@ -191,6 +216,15 @@ private:
         return (_nick.toLower() == nickname.toLower());
     }
 
+    /**
+     * Sets the last away state change as unacknowledged
+     *
+     * @see IrcUser::hasAwayChanged()
+     */
+    inline void markAwayChanged()
+    {
+        _awayChanged = true;
+    }
 
     bool _initialized;
 
@@ -222,6 +256,10 @@ private:
 
     QHash<BufferId, QDateTime> _lastActivity;
     QHash<BufferId, QDateTime> _lastSpokenTo;
+
+    // Given it's never been acknowledged, assume changes exist on IrcUser creation
+    /// Tracks if changes in away state (away/here, message) have yet to be acknowledged
+    bool _awayChanged = true;
 };
 
 

--- a/src/core/eventstringifier.cpp
+++ b/src/core/eventstringifier.cpp
@@ -453,10 +453,18 @@ void EventStringifier::processIrcEvent301(IrcEvent *e)
             QDateTime now = QDateTime::currentDateTime();
             now.setTimeSpec(Qt::UTC);
             // Don't print "user is away" messages more often than this
-            const int silenceTime = 60;
-            if (ircuser->lastAwayMessageTime().addSecs(silenceTime) >= now)
+            // 1 hour = 60 min * 60 sec
+            const int silenceTime = 60 * 60;
+            // Check if away state has NOT changed and silence time hasn't yet elapsed
+            if (!ircuser->hasAwayChanged()
+                    && ircuser->lastAwayMessageTime().addSecs(silenceTime) >= now) {
+                // Away message hasn't changed and we're still within the period of silence; don't
+                // repeat the message
                 send = false;
+            }
             ircuser->setLastAwayMessageTime(now);
+            // Mark any changes in away as acknowledged
+            ircuser->acknowledgeAwayChanged();
         }
     }
     if (send)


### PR DESCRIPTION
## In short

* Limit `* User is away` spam to once an hour, or if changed
  * Track changes to `away`/`here` state and away message, always showing if those change
  * Otherwise, only show duplicate `* User is away` messages once per hour of silence
  * `1 hour` delay follows Bitlbee's [`away_reply_timeout` default delay](https://www.bitlbee.org/user-guide.html#set_away_reply_timeout ), albeit is non-adjustable

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes user-facing annoyance, fixes missing changed messages
Risk | ★☆☆ *1/3* | Some might rely on the repetitive spam, delay might be too long
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Examples

User | Nickname
-----|---------
Quassel user (direct) | `quassel`
Test user (quoted) | `qwebirc`

### Before
```
[9:18:13 pm] <quassel> Hi
```

> ```
> /away Testing
> [21:22] == You have been marked as being away
> ```

```
[9:23:03 pm] <quassel> Hello
[9:23:04 pm] * qwebirc is away: "Testing"
[9:23:32 pm] <quassel> So I had some things to share with you for when you return...
[9:25:05 pm] <quassel> And it'll take a while.  I know you're not here right now.
[9:25:06 pm] * qwebirc is away: "Testing"
[9:27:44 pm] <quassel> Yada yada yada...
[9:27:45 pm] * qwebirc is away: "Testing"
```

> ```
> /away Different test
> [21:27] == You have been marked as being away
> ```

```
[9:28:12 pm] <quassel> More stuff!
[9:28:34 pm] <quassel> I didn't catch your new message...
[9:28:43 pm] <quassel> ...not now...
[9:28:45 pm] <quassel> ...not now...
[9:28:47 pm] <quassel> ...not now...
[9:29:49 pm] <quassel> Ah, now it should be printed.
[9:29:50 pm] * qwebirc is away: "Different test"
```

*Changing the message quickly does NOT bypass the 1 minute delay, and every time a message is sent, it resets the delay*

> ```
> /back
> [21:30] == You are no longer marked as being away
> /away Different test
> [21:30] == You have been marked as being away
> ```

```
[9:30:58 pm] <quassel> Back yet?
[9:31:02 pm] <quassel> Looks like you never removed away...
```

*On either `away-notify` capable servers, or servers with autoWHO polling fast enough to catch changes, returning from away and setting the same message does NOT trigger another prompt*

### After
```
[8:57:27 pm] <quassel> Hi
```

> ```
> /away Testing
> [20:57] == You have been marked as being away
> ```

```
[8:57:58 pm] <quassel> Hello
[8:57:58 pm] * qwebirc is away: "Testing"
[8:58:58 pm] <quassel> So I had some things to share with you for when you return...
[8:59:08 pm] <quassel> And it'll take a while.  I know you're not here right now.
[9:01:31 pm] <quassel> Yada yada yada...
```

*Notice the absence of yet another `* qwebirc is away: "Testing"`*

> ```
> /away Different test
> [21:04] == You have been marked as being away
> ```

```
[9:04:25 pm] <quassel> More stuff!
[9:04:26 pm] * qwebirc is away: "Different test"
[9:04:30 pm] <quassel> Oh, new message.
```

*Changing the message results in bypassing the 1 hour delay*

> ```
> /back
> [21:09] == You are no longer marked as being away
> /away Different test
> [21:09] == You have been marked as being away
> ```

```
[9:10:11 pm] <quassel> Back yet?
[9:10:11 pm] * qwebirc is away: "Different test"
```

*On either `away-notify` capable servers, or servers with autoWHO polling fast enough to catch changes, returning from away and setting the same message triggers another prompt*

## After, time elapsed

**For testing, the away silence delay `const int silenceTime` was reduced to 6 minutes, `6 * 60`**
```
[9:36:59 pm] <quassel> Hi
```

> ```
> /away Testing
> [21:37] == You have been marked as being away
> ```

```
[9:37:12 pm] <quassel> Hello
[9:37:14 pm] * qwebirc is away: "Testing"
[9:37:27 pm] <quassel> Here's a quick reply...
[9:44:29 pm] <quassel> Now six minutes have elapsed
[9:44:29 pm] * qwebirc is away: "Testing"
```

*Note that six minutes of silence have elapsed.  Every time a message is sent, it resets the delay, so without the testing change, `60 * 60` or 1 hour, the message would only be repeated after 1 hour of silence.*