### PR TITLE
Fix issues with TreeModel

### DIFF
--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -40,7 +40,7 @@
 *  Network Items
 *****************************************/
 NetworkItem::NetworkItem(const NetworkId &netid, AbstractTreeItem *parent)
-    : PropertyMapItem(QList<QString>() << "networkName" << "currentServer" << "nickCount", parent),
+    : PropertyMapItem(parent),
     _networkId(netid),
     _statusBufferItem(0)
 {
@@ -50,6 +50,13 @@ NetworkItem::NetworkItem(const NetworkId &netid, AbstractTreeItem *parent)
     setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
     connect(this, SIGNAL(networkDataChanged(int)), this, SIGNAL(dataChanged(int)));
     connect(this, SIGNAL(beginRemoveChilds(int, int)), this, SLOT(onBeginRemoveChilds(int, int)));
+}
+
+
+QStringList NetworkItem::propertyOrder() const
+{
+    static QStringList order{"networkName", "currentServer", "nickCount"};
+    return order;
 }
 
 
@@ -283,11 +290,18 @@ void NetworkItem::onNetworkDestroyed()
 *  Fancy Buffer Items
 *****************************************/
 BufferItem::BufferItem(const BufferInfo &bufferInfo, AbstractTreeItem *parent)
-    : PropertyMapItem(QStringList() << "bufferName" << "topic" << "nickCount", parent),
+    : PropertyMapItem(parent),
     _bufferInfo(bufferInfo),
     _activity(BufferInfo::NoActivity)
 {
     setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled);
+}
+
+
+QStringList BufferItem::propertyOrder() const
+{
+    static QStringList order{"bufferName", "topic", "nickCount"};
+    return order;
 }
 
 
@@ -992,12 +1006,19 @@ void ChannelBufferItem::userModeChanged(IrcUser *ircUser)
 const QList<QChar> UserCategoryItem::categories = QList<QChar>() << 'q' << 'a' << 'o' << 'h' << 'v';
 
 UserCategoryItem::UserCategoryItem(int category, AbstractTreeItem *parent)
-    : PropertyMapItem(QStringList() << "categoryName", parent),
+    : PropertyMapItem(parent),
     _category(category)
 {
     setFlags(Qt::ItemIsEnabled);
     setTreeItemFlags(AbstractTreeItem::DeleteOnLastChildRemoved);
     setObjectName(parent->data(0, Qt::DisplayRole).toString() + "/" + QString::number(category));
+}
+
+
+QStringList UserCategoryItem::propertyOrder() const
+{
+    static QStringList order{"categoryName"};
+    return order;
 }
 
 
@@ -1094,13 +1115,20 @@ QVariant UserCategoryItem::data(int column, int role) const
 *  Irc User Items
 *****************************************/
 IrcUserItem::IrcUserItem(IrcUser *ircUser, AbstractTreeItem *parent)
-    : PropertyMapItem(QStringList() << "nickName", parent),
+    : PropertyMapItem(parent),
     _ircUser(ircUser)
 {
     setObjectName(ircUser->nick());
     connect(ircUser, SIGNAL(quited()), this, SLOT(ircUserQuited()));
     connect(ircUser, SIGNAL(nickSet(QString)), this, SIGNAL(dataChanged()));
     connect(ircUser, SIGNAL(awaySet(bool)), this, SIGNAL(dataChanged()));
+}
+
+
+QStringList IrcUserItem::propertyOrder() const
+{
+    static QStringList order{"nickName"};
+    return order;
 }
 
 

--- a/src/client/networkmodel.h
+++ b/src/client/networkmodel.h
@@ -41,7 +41,9 @@ class NetworkItem : public PropertyMapItem
     Q_PROPERTY(int nickCount READ nickCount)
 
 public :
-        NetworkItem(const NetworkId &netid, AbstractTreeItem *parent = 0);
+    NetworkItem(const NetworkId &netid, AbstractTreeItem *parent = 0);
+
+    virtual QStringList propertyOrder() const;
 
     virtual QVariant data(int column, int row) const;
 
@@ -106,7 +108,9 @@ class BufferItem : public PropertyMapItem
     Q_PROPERTY(int nickCount READ nickCount)
 
 public :
-        BufferItem(const BufferInfo &bufferInfo, AbstractTreeItem *parent = 0);
+    BufferItem(const BufferInfo &bufferInfo, AbstractTreeItem *parent = 0);
+
+    virtual QStringList propertyOrder() const;
 
     inline const BufferInfo &bufferInfo() const { return _bufferInfo; }
     virtual QVariant data(int column, int role) const;
@@ -252,7 +256,9 @@ class UserCategoryItem : public PropertyMapItem
     Q_PROPERTY(QString categoryName READ categoryName)
 
 public :
-        UserCategoryItem(int category, AbstractTreeItem *parent);
+    UserCategoryItem(int category, AbstractTreeItem *parent);
+
+    virtual QStringList propertyOrder() const;
 
     QString categoryName() const;
     inline int categoryId() const { return _category; }
@@ -280,7 +286,9 @@ class IrcUserItem : public PropertyMapItem
     Q_PROPERTY(QString nickName READ nickName)
 
 public :
-        IrcUserItem(IrcUser *ircUser, AbstractTreeItem *parent);
+    IrcUserItem(IrcUser *ircUser, AbstractTreeItem *parent);
+
+    virtual QStringList propertyOrder() const;
 
     inline QString nickName() const { return _ircUser ? _ircUser->nick() : QString(); }
     inline bool isActive() const { return _ircUser ? !_ircUser->isAway() : false; }

--- a/src/client/treemodel.cpp
+++ b/src/client/treemodel.cpp
@@ -316,8 +316,9 @@ bool PropertyMapItem::setData(int column, const QVariant &value, int role)
     if (column >= columnCount() || role != Qt::DisplayRole)
         return false;
 
+    setProperty(_propertyOrder[column].toLatin1(), value);
     emit dataChanged(column);
-    return setProperty(_propertyOrder[column].toLatin1(), value);
+    return true;
 }
 
 

--- a/src/client/treemodel.cpp
+++ b/src/client/treemodel.cpp
@@ -275,21 +275,8 @@ int SimpleTreeItem::columnCount() const
 /*****************************************
  * PropertyMapItem
  *****************************************/
-PropertyMapItem::PropertyMapItem(const QStringList &propertyOrder, AbstractTreeItem *parent)
-    : AbstractTreeItem(parent),
-    _propertyOrder(propertyOrder)
-{
-}
-
-
 PropertyMapItem::PropertyMapItem(AbstractTreeItem *parent)
-    : AbstractTreeItem(parent),
-    _propertyOrder(QStringList())
-{
-}
-
-
-PropertyMapItem::~PropertyMapItem()
+    : AbstractTreeItem(parent)
 {
 }
 
@@ -304,7 +291,7 @@ QVariant PropertyMapItem::data(int column, int role) const
         return toolTip(column);
     case Qt::DisplayRole:
     case TreeModel::SortRole: // fallthrough, since SortRole should default to DisplayRole
-        return property(_propertyOrder[column].toLatin1());
+        return property(propertyOrder()[column].toLatin1());
     default:
         return QVariant();
     }
@@ -316,7 +303,7 @@ bool PropertyMapItem::setData(int column, const QVariant &value, int role)
     if (column >= columnCount() || role != Qt::DisplayRole)
         return false;
 
-    setProperty(_propertyOrder[column].toLatin1(), value);
+    setProperty(propertyOrder()[column].toLatin1(), value);
     emit dataChanged(column);
     return true;
 }
@@ -324,13 +311,7 @@ bool PropertyMapItem::setData(int column, const QVariant &value, int role)
 
 int PropertyMapItem::columnCount() const
 {
-    return _propertyOrder.count();
-}
-
-
-void PropertyMapItem::appendProperty(const QString &property)
-{
-    _propertyOrder << property;
+    return propertyOrder().count();
 }
 
 

--- a/src/client/treemodel.h
+++ b/src/client/treemodel.h
@@ -126,21 +126,15 @@ class PropertyMapItem : public AbstractTreeItem
     Q_OBJECT
 
 public:
-    PropertyMapItem(const QStringList &propertyOrder, AbstractTreeItem *parent = 0);
     PropertyMapItem(AbstractTreeItem *parent = 0);
 
-    virtual ~PropertyMapItem();
+    virtual QStringList propertyOrder() const = 0;
 
     virtual QVariant data(int column, int role) const;
     virtual bool setData(int column, const QVariant &value, int role);
 
     virtual QString toolTip(int column) const { Q_UNUSED(column) return QString(); }
     virtual int columnCount() const;
-
-    void appendProperty(const QString &property);
-
-private:
-    QStringList _propertyOrder;
 };
 
 


### PR DESCRIPTION
Don't send the dataChanged() signal of PropertyMapItems before actually setting the new value.

Don't store the property list dynamically in every item instance.