### PR TITLE
common: Add "--debug-irc" to log raw IRC messages

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -202,6 +202,12 @@ int main(int argc, char **argv)
     cliParser->addOption("ssl-cert", 0, "Specify the path to the SSL Certificate", "path", "configdir/quasselCert.pem");
     cliParser->addOption("ssl-key", 0, "Specify the path to the SSL key", "path", "ssl-cert-path");
 #endif
+    cliParser->addSwitch("debug-irc", 0,
+                         "Enable logging of all raw IRC messages to debug log, including "
+                         "passwords!  In most cases you should also set --loglevel Debug");
+    cliParser->addOption("debug-irc-id", 0,
+                         "Limit raw IRC logging to this network ID.  Implies --debug-irc",
+                         "database network ID", "-1");
     cliParser->addSwitch("enable-experimental-dcc", 0, "Enable highly experimental and unfinished support for CTCP DCC (DANGEROUS)");
 #endif
 

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -483,6 +483,9 @@ private slots:
 private:
     CoreSession *_coreSession;
 
+    bool _debugLogRawIrc;     ///< If true, include raw IRC socket messages in the debug log
+    qint32 _debugLogRawNetId; ///< Network ID for logging raw IRC socket messages, or -1 for all
+
 #ifdef HAVE_SSL
     QSslSocket socket;
 #else

--- a/src/core/ircparser.h
+++ b/src/core/ircparser.h
@@ -51,6 +51,9 @@ protected:
 
 private:
     CoreSession *_coreSession;
+
+    bool _debugLogRawIrc;     ///< If true, include raw IRC socket messages in the debug log
+    qint32 _debugLogRawNetId; ///< Network ID for logging raw IRC socket messages, or -1 for all
 };
 
 


### PR DESCRIPTION
## In short

* Add `--debug-irc` option to core and monolithic builds
  * When enabled, sends all raw IRC messages to the log at `Debug` level
  * Usually should be combined with `--loglevel Debug`
  * Monolithic builds also show messages in `Debug Log` window
  * When enabled, puts plaintext IRC passwords in log; be careful on production systems
* Add `--debug-irc-id` option to limit the above to a specific network
  * Avoids noise when troubleshooting a specific network without disconnecting all others
  * Reduces unnecessary information disclosure on shared cores

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Allows troubleshooting IRC without recompiling Quassel
Risk | ★☆☆ *1/3* | Setting `--debug-irc` puts IRC passwords in debug log
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Examples
### Help
*`--help` output*

```
[...]
  --ssl-key <path>                         Specify the path to the SSL key
  --debug-irc                              Enable logging of all raw IRC
                                           messages to debug log, including
                                           passwords!  In most cases you should
                                           also set --loglevel Debug
  --debug-irc-id <database network ID>     Limit raw IRC logging to this
                                           network ID.  Implies --debug-irc
  --enable-experimental-dcc                Enable highly experimental and
                                           unfinished support for CTCP DCC
                                           (DANGEROUS)
[...]
```

*I hope the warning about passwords is clear enough…*

### Disabled
*`--debug-irc` is NOT set*

```
2018-09-02 22:29:09 [Info ] SQLite storage backend is ready. Schema version: 31 
2018-09-02 22:29:09 [Info ] Database authenticator is ready. 
2018-09-02 22:29:09 [Info ] Listening for GUI clients on IPv6 :: port 4242 using protocol version 10 
2018-09-02 22:29:09 [Info ] Listening for GUI clients on IPv4 0.0.0.0 port 4242 using protocol version 10 
2018-09-02 22:29:09 [Info ] Restoring previous core state... 
2018-09-02 22:29:15 [Info ] Client connected from 127.0.0.1 
2018-09-02 22:29:15 [Debug] Enabling compression...
2018-09-02 22:29:15 [Debug] Using the DataStream protocol...
2018-09-02 22:29:15 [Debug] Starting encryption for Client: "127.0.0.1"
2018-09-02 22:29:15 [Info ] Client 127.0.0.1 initialized and authenticated successfully as "dcircuit" (UserId: 1).
2018-09-02 22:29:39 [Debug] Received PONG with valid timestamp, marking pong replies on network "Local (Bitlbee)" (ID: 1) as usable for latency measurement
[...]
2018-09-02 22:31:49 [Warn ] Caught signal 2 - exiting.
```

### Enabled
*`--debug-irc` is set*

`IRC net  1` refers to IRC network with ID `1`.  If multiple networks are connected, different IDs will be shown.

```
2018-09-02 22:32:03 [Info ] SQLite storage backend is ready. Schema version: 31 
2018-09-02 22:32:03 [Info ] Database authenticator is ready. 
2018-09-02 22:32:03 [Info ] Listening for GUI clients on IPv6 :: port 4242 using protocol version 10 
2018-09-02 22:32:03 [Info ] Listening for GUI clients on IPv4 0.0.0.0 port 4242 using protocol version 10 
2018-09-02 22:32:03 [Info ] Restoring previous core state... 
2018-09-02 22:32:03 [Debug] IRC net  1 >> "CAP LS 302"
2018-09-02 22:32:03 [Debug] IRC net  1 >> "NICK digitalcircuit"
2018-09-02 22:32:03 [Debug] IRC net  1 >> "USER quassel 8 * :Digital"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost NOTICE * :BitlBee-IRCd initialized, please go on"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost CAP * LS :sasl=PLAIN multi-prefix extended-join away-notify userhost-in-names"
2018-09-02 22:32:03 [Debug] IRC net  1 >> "CAP REQ :sasl"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost CAP digitalcircuit ACK :sasl"
2018-09-02 22:32:03 [Debug] IRC net  1 >> "AUTHENTICATE PLAIN"
2018-09-02 22:32:03 [Debug] IRC net  1 << "AUTHENTICATE +"
2018-09-02 22:32:03 [Debug] IRC net  1 >> "AUTHENTICATE [REDACTED]"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost 900 digitalcircuit digitalcircuit!quassel@localhost digitalcircuit :You are now logged in as digitalcircuit"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost 903 digitalcircuit :Password accepted"
2018-09-02 22:32:03 [Debug] IRC net  1 >> "CAP REQ :away-notify extended-join multi-prefix userhost-in-names"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost CAP digitalcircuit ACK :away-notify extended-join multi-prefix userhost-in-names"
2018-09-02 22:32:03 [Debug] IRC net  1 >> "CAP END"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost 001 digitalcircuit :Welcome to the BitlBee gateway, digitalcircuit"
2018-09-02 22:32:03 [Debug] IRC net  1 >> "JOIN &bitlbee "
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost 002 digitalcircuit :Host localhost is running BitlBee 3.5.1+20180731+master+69-g921ea8b-git."
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost 003 digitalcircuit :BitlBee <http://www.bitlbee.org/>"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost 004 digitalcircuit localhost 3.5.1+20180731+master+69-g921ea8b-git abiswRo ntC"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost 005 digitalcircuit PREFIX=(ohv)@%+ CHANTYPES=&# CHANMODES=,,,ntC NICKLEN=23 CHANNELLEN=23 NETWORK=BitlBee SAFELIST CASEMAPPING=rfc1459 MAXTARGETS=1 WATCH=128 FLOOD=0/9999 :are supported by this server"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost 422 digitalcircuit :We don't need MOTDs."
2018-09-02 22:32:03 [Debug] IRC net  1 << ":digitalcircuit!quassel@localhost MODE digitalcircuit :+s"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":digitalcircuit!quassel@localhost JOIN &bitlbee * :Digital"
2018-09-02 22:32:03 [Debug] IRC net  1 >> "MODE &bitlbee"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost 332 digitalcircuit &bitlbee :Welcome to the control channel. Type \x02help\x02 for help information."
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost 333 digitalcircuit &bitlbee root!root@localhost 1535945523"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost 353 digitalcircuit = &bitlbee :@digitalcircuit!quassel@localhost @root!root@localhost "
2018-09-02 22:32:03 [Debug] IRC net  1 << ":localhost 366 digitalcircuit &bitlbee :End of /NAMES list"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":root!root@localhost PRIVMSG &bitlbee :Welcome to the BitlBee gateway!"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":root!root@localhost PRIVMSG &bitlbee : "
2018-09-02 22:32:03 [Debug] IRC net  1 << ":root!root@localhost PRIVMSG &bitlbee :Running BitlBee 3.5.1+20180731+master+69-g921ea8b-git"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":root!root@localhost PRIVMSG &bitlbee : "
2018-09-02 22:32:03 [Debug] IRC net  1 << ":root!root@localhost PRIVMSG &bitlbee :If you've never used BitlBee before, please do read the help information using the \x02help\x02 command. Lots of FAQs are answered there."
2018-09-02 22:32:03 [Debug] IRC net  1 << ":root!root@localhost PRIVMSG &bitlbee :If you already have an account on this server, just use the \x02identify\x02 command to identify yourself."
2018-09-02 22:32:03 [Debug] IRC net  1 << ":root!root@localhost PRIVMSG &bitlbee :Password accepted, settings and accounts loaded"
2018-09-02 22:32:03 [Debug] IRC net  1 << ":digitalcircuit!quassel@localhost MODE digitalcircuit :+R"
2018-09-02 22:32:04 [Debug] IRC net  1 << ":localhost 900 digitalcircuit digitalcircuit!quassel@localhost digitalcircuit :You are now logged in as digitalcircuit"
2018-09-02 22:32:04 [Debug] IRC net  1 << ":root!root@localhost PRIVMSG &bitlbee :Trying to get all accounts connected..."
2018-09-02 22:32:04 [Debug] IRC net  1 << ":root!root@localhost PRIVMSG &bitlbee :jabber - Logging in: Connecting"
[...]
2018-09-02 22:32:04 [Debug] IRC net  1 << ":localhost 324 digitalcircuit &bitlbee +Ct"
2018-09-02 22:32:04 [Debug] IRC net  1 << ":root!root@localhost PRIVMSG &bitlbee :jabber - Logging in: Logged in"
[...]
2018-09-02 22:32:04 [Info ] Client connected from 127.0.0.1 
2018-09-02 22:32:04 [Debug] Enabling compression...
2018-09-02 22:32:04 [Debug] Using the DataStream protocol...
2018-09-02 22:32:04 [Debug] Starting encryption for Client: "127.0.0.1"
2018-09-02 22:32:04 [Info ] Client 127.0.0.1 initialized and authenticated successfully as "dcircuit" (UserId: 1). 
[...]
2018-09-02 22:32:33 [Debug] IRC net  1 >> "PING 22:32:33.689"
2018-09-02 22:32:33 [Debug] IRC net  1 >> "WHO &bitlbee"
2018-09-02 22:32:33 [Debug] IRC net  1 << ":localhost PONG localhost :22:32:33.689"
2018-09-02 22:32:33 [Debug] Received PONG with valid timestamp, marking pong replies on network "Local (Bitlbee)" (ID: 1) as usable for latency measurement
[...]
2018-09-02 22:32:33 [Debug] IRC net  1 << ":localhost 315 digitalcircuit &bitlbee :End of /WHO list"
[...]
2018-09-02 22:33:08 [Warn ] Caught signal 2 - exiting.
```

*This also works in the Monolithic `Debug Log` GUI.  Client cannot add this as raw messages are not transmitted from core to client.*

### Enabled, limited to specific network
*`--debug-irc-id 2` is set, where ID `2` is `Freenode`*

```
2018-09-02 23:29:32 [Info ] SQLite storage backend is ready. Schema version: 31 
2018-09-02 23:29:32 [Info ] Database authenticator is ready. 
2018-09-02 23:29:32 [Info ] Listening for GUI clients on IPv6 :: port 4242 using protocol version 10 
2018-09-02 23:29:32 [Info ] Listening for GUI clients on IPv4 0.0.0.0 port 4242 using protocol version 10 
2018-09-02 23:29:32 [Info ] Restoring previous core state... 
2018-09-02 23:29:36 [Info ] Client connected from 127.0.0.1 
2018-09-02 23:29:36 [Debug] Enabling compression...
2018-09-02 23:29:36 [Debug] Using the DataStream protocol...
2018-09-02 23:29:36 [Debug] Starting encryption for Client: "127.0.0.1"
2018-09-02 23:29:36 [Info ] Client 127.0.0.1 initialized and authenticated successfully as "dcircuit" (UserId: 1). 
2018-09-02 23:29:45 [Debug] IRC net  2 >> "CAP LS 302"
2018-09-02 23:29:45 [Debug] IRC net  2 >> "NICK dcircuit_dev"
2018-09-02 23:29:45 [Debug] IRC net  2 >> "USER quasseldev 8 * :Digital (development)"
2018-09-02 23:29:45 [Debug] IRC net  2 << ":barjavel.freenode.net NOTICE * :*** Looking up your hostname..."
2018-09-02 23:29:45 [Debug] IRC net  2 << ":barjavel.freenode.net NOTICE * :*** Checking Ident"
2018-09-02 23:29:49 [Debug] IRC net  2 << ":barjavel.freenode.net NOTICE * :*** Couldn't look up your hostname"
2018-09-02 23:29:54 [Debug] IRC net  2 << ":barjavel.freenode.net NOTICE * :*** No Ident response"
2018-09-02 23:29:54 [Debug] IRC net  2 << ":barjavel.freenode.net CAP * LS :account-notify extended-join identify-msg multi-prefix sasl"
2018-09-02 23:29:54 [Debug] IRC net  2 >> "CAP REQ :account-notify extended-join multi-prefix"
2018-09-02 23:29:54 [Debug] IRC net  2 << ":barjavel.freenode.net CAP dcircuit_dev ACK :account-notify extended-join multi-prefix "
2018-09-02 23:29:54 [Debug] IRC net  2 >> "CAP END"
2018-09-02 23:29:54 [Debug] IRC net  2 << ":barjavel.freenode.net 001 dcircuit_dev :Welcome to the freenode Internet Relay Chat Network dcircuit_dev"
[...]
2018-09-02 23:30:02 [Debug] Received PONG with valid timestamp, marking pong replies on network "Local (Bitlbee)" (ID: 1) as usable for latency measurement
2018-09-02 23:30:04 [Debug] IRC net  2 >> "WHO #qcore_dev_test %%chtsunfra,369"
2018-09-02 23:30:04 [Debug] IRC net  2 << ":barjavel.freenode.net 354 dcircuit_dev 369 #qcore_dev_test ~quasselde [REDACTED] barjavel.freenode.net dcircuit_dev H@ 0 :Digital (development)"
2018-09-02 23:30:04 [Debug] IRC net  2 << ":barjavel.freenode.net 315 dcircuit_dev #qcore_dev_test :End of /WHO list."
2018-09-02 23:30:09 [Debug] Received PONG with valid timestamp, marking pong replies on network "[REDACTED]" (ID: 3) as usable for latency measurement
2018-09-02 23:30:14 [Debug] IRC net  2 >> "PING 23:30:14.688"
2018-09-02 23:30:14 [Debug] IRC net  2 << ":barjavel.freenode.net PONG barjavel.freenode.net :23:30:14.688"
2018-09-02 23:30:14 [Debug] Received PONG with valid timestamp, marking pong replies on network "Freenode" (ID: 2) as usable for latency measurement
[...]
```

*Notice how only network ID `2` is shown in debug log despite three networks being connected.*