### PR TITLE
cipher.cpp: Default to CBC instead of ECB

### DIFF
--- a/src/core/cipher.cpp
+++ b/src/core/cipher.cpp
@@ -56,7 +56,8 @@ bool Cipher::setKey(QByteArray key)
 //    if(Preferences::self()->encryptionType())
 //      m_cbc = true;
 //    else
-        m_cbc = false;
+//    default to CBC
+        m_cbc = true;
         m_key = key;
     }
     return true;


### PR DESCRIPTION
For security reasons (and compatibility to other irc-client's implementations), default to CBC for blowfish encryption.