### PR TITLE
common/ircchannel: Change to an early continue for a NULL IrcUser

### DIFF
--- a/src/common/ircchannel.cpp
+++ b/src/common/ircchannel.cpp
@@ -180,7 +180,9 @@ void IrcChannel::joinIrcUsers(const QList<IrcUser *> &users, const QStringList &
     IrcUser *ircuser;
     for (int i = 0; i < users.count(); i++) {
         ircuser = users[i];
-        if (!ircuser || _userModes.contains(ircuser)) {
+        if (!ircuser)
+            continue;
+        if (_userModes.contains(ircuser)) {
             if (sortedModes[i].count() > 1) {
                 // Multiple modes received, do it one at a time
                 // TODO Better way of syncing this without breaking protocol?


### PR DESCRIPTION
Happened to stumble upon this while looking through some issues on the bug tracker. As mentioned in the commit message (below), this isn't crash potential but we shouldn't try to act on a NULL IrcUser.

> Commit e9096505f07fc0c08a7c36f3680c1fde975d4f80 changed the behaviour in joinIrcUsers() from skipping a NULL IrcUser or an already tracked IrcUser to updating the usermodes of said IrcUser. The call to addUserMode() will call isKnownUser() which will log a warning of 'received IrcUser Nullpointer' and return false. This is safe from crashing, but shouldn't be allowed to happen.