### PR TITLE
qa: Don't return a const ref from Settings::localValue()

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -195,7 +195,7 @@ void Settings::setLocalValue(const QString &key, const QVariant &data)
 }
 
 
-const QVariant &Settings::localValue(const QString &key, const QVariant &def)
+QVariant Settings::localValue(const QString &key, const QVariant &def)
 {
     QString normKey = normalizedKey(group, key);
     if (!isCached(normKey)) {

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -108,7 +108,7 @@ protected:
     virtual QStringList localChildGroups(const QString &rootkey = QString());
 
     virtual void setLocalValue(const QString &key, const QVariant &data);
-    virtual const QVariant &localValue(const QString &key, const QVariant &def = QVariant());
+    virtual QVariant localValue(const QString &key, const QVariant &def = QVariant());
 
     /**
      * Gets if a key exists in settings


### PR DESCRIPTION
Stumbled on this by accident because one particular CI configuration
warned about Settings::localValue() returning a stack reference
(may happen if the default value (which is a const ref itself) is
returned).

Not sure why I don't see this warning in my own setup, but it's
legitimate; thus fix the issue.