### PR TITLE
client: Fix Add Network button state

### DIFF
--- a/src/qtui/settingspages/networkssettingspage.cpp
+++ b/src/qtui/settingspages/networkssettingspage.cpp
@@ -1070,6 +1070,8 @@ NetworkAddDlg::NetworkAddDlg(const QStringList &exist, QWidget *parent) : QDialo
     }
     connect(ui.networkName, SIGNAL(textChanged(const QString &)), SLOT(setButtonStates()));
     connect(ui.serverAddress, SIGNAL(textChanged(const QString &)), SLOT(setButtonStates()));
+    connect(ui.usePreset, SIGNAL(toggled(bool)), SLOT(setButtonStates()));
+    connect(ui.useManual, SIGNAL(toggled(bool)), SLOT(setButtonStates()));
     setButtonStates();
 }
 


### PR DESCRIPTION
## In short

* Fix `Add Network` dialog `OK` button state
  * Check if dialog's valid whenever changing `Use preset` and `Manually specify network settings`
  * Fixes `OK` button remaining enabled when selecting manual, disabled when selecting preset

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | User-facing clarification of required fields
Risk | ★☆☆ *1/3* | Dialog might not set `OK` state correctly
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Examples
### Before
*In `Configure Quassel…` → `IRC` → `Networks` → `Add…`*

![Animated screenshot of Quassel's "Add Network" dialog toggling between "Use preset" and "Manually specify network settings", with the dialog's "OK" button remaining enabled](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-addnet-button-disable/Add%20Network%20-%20before.gif#v1 )

*Notice how when toggling between `Use preset` and `Manually specify network settings`, the `OK` button remains enabled, even though there's no valid network information put in, e.g. `Network name`.*

### After
*In `Configure Quassel…` → `IRC` → `Networks` → `Add…`*

![Animated screenshot of Quassel's "Add Network" dialog toggling between "Use preset" and "Manually specify network settings", with the dialog's "OK" button enabling for preset, disabling for manual](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-addnet-button-disable/Add%20Network%20-%20after.gif#v1 )

*Now, when toggling between `Use preset` and `Manually specify network settings`, the `OK` button enables for presets, as it's valid, and disables for manual, as there's no valid network information put in, e.g. `Network name`.*