### PR TITLE
core: Fix auto-who nickname handling

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -1375,11 +1375,23 @@ void CoreNetwork::sendAutoWho()
         }
         if (supports("WHOX")) {
             // Use WHO extended to poll away users and/or user accounts
+            // Explicitly only match on nickname ("n"), don't rely on server defaults
+            //
+            // WHO <nickname> n%chtsunfra,<unique_number>
+            //
             // See http://faerion.sourceforge.net/doc/irc/whox.var
-            // And https://github.com/hexchat/hexchat/blob/c874a9525c9b66f1d5ddcf6c4107d046eba7e2c5/src/common/proto-irc.c#L750
-            putRawLine(serverEncode(QString("WHO %1 %%chtsunfra,%2")
-                                    .arg(serverEncode(chanOrNick), QString::number(IrcCap::ACCOUNT_NOTIFY_WHOX_NUM))));
+            // And https://github.com/quakenet/snircd/blob/master/doc/readme.who
+            // And https://github.com/hexchat/hexchat/blob/57478b65758e6b697b1d82ce21075e74aa475efc/src/common/proto-irc.c#L752
+            putRawLine(serverEncode(QString("WHO %1 n%chtsunfra,%2")
+                                    .arg(serverEncode(chanOrNick),
+                                         QString::number(IrcCap::ACCOUNT_NOTIFY_WHOX_NUM))));
         } else {
+            // Fall back to normal WHO
+            //
+            // Note: According to RFC 1459, "WHO <phrase>" can fall back to searching realname,
+            // hostmask, etc.  There's nothing we can do about that :(
+            //
+            // See https://tools.ietf.org/html/rfc1459#section-4.5.1
             putRawLine(serverEncode(QString("WHO %1").arg(chanOrNick)));
         }
         break;

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -1322,6 +1322,16 @@ void CoreNetwork::queueAutoWhoOneshot(const QString &channelOrNick)
 }
 
 
+void CoreNetwork::cancelAutoWhoOneshot(const QString &channelOrNick)
+{
+    // Remove channel/nick from queue if it exists
+    _autoWhoQueue.removeAll(channelOrNick);
+
+    // The AutoWho timer will detect if the queue is empty and automatically stop, no need to
+    // manually control it.
+}
+
+
 void CoreNetwork::setAutoWhoDelay(int delay)
 {
     _autoWhoTimer.setInterval(delay * 1000);

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -392,6 +392,18 @@ public slots:
      */
     void queueAutoWhoOneshot(const QString &channelOrNick);
 
+    /**
+     * Removes the given channel/nick from AutoWho queue for when it stops existing
+     *
+     * If not already in queue, nothing happens.  This should only be used for nicknames and
+     * channels that have suddenly stopped existing (e.g. nick joins then quits).
+     *
+     * For when a periodic channel AutoWho finishes, see CoreNetwork::setAutoWhoDone()
+     *
+     * @param channelOrNick Channel or nickname to WHO
+     */
+    void cancelAutoWhoOneshot(const QString &channelOrNick);
+
     bool setAutoWhoDone(const QString &channel);
 
     void updateIssuedModes(const QString &requestedModes);

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -753,6 +753,10 @@ void CoreSessionEventProcessor::lateProcessIrcEventQuit(IrcEvent *e)
     if (!ircuser)
         return;
 
+    // Clear the user from the AutoWho queue if in it
+    // This avoids needlessly checking a user that quickly joins then parts
+    coreNetwork(e)->cancelAutoWhoOneshot(ircuser->nick());
+
     ircuser->quit();
 }
 


### PR DESCRIPTION
## In short

* Only match on `nickname` for auto-`WHOX`, don't search realname/etc
  * Fixes `AutoWho` printing other nicks with matching realname/etc to status buffer
  * Avoids relying on server defaults
* Cancel auto-who of nicknames when they quit
  * Avoids needlessly filling up `AutoWho` queue with removed users
  * Reduces likelihood of getting an unexpected, unhidden result to `WHO` replies

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing, avoids filling server buffer with unexpected commands
Risk | ★☆☆ *1/3* | Possibly wrong `WHO`-extended output, missing `WHO` info
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

*Thanks to @genius3000 for reporting the `WHOX` issue and finding a solution!*

## Testing
### `WHOX` matching
1. Join Quassel core to an IRC network that implements the `WHOX` defaults in the [Quakenet specifications](https://github.com/quakenet/snircd/blob/master/doc/readme.who )
   * As of 2018-9-12, InspIRCd 3.0 does this
2. Have two users with different nicknames but same realname join
   * In below example, `TestRealname` is used

**Before**

```
[21:50:35] [WhoX] 369 #channel xxx hostmask server nickname G* 0 TestRealname
```

With as many of these as per other nicknames with matching realname exist.

**After**

No `WhoX` output in the status buffer.

### `AutoWho` cancel
1. Join Quassel core to a channel on an `away-notify` enabled network
2. Have another user join the same channel, then immediately quit (not part)

**Before**

Quassel needlessly sends a `WHO` for the nickname that quit, having to supress it instead.

**After**

Quassel does not send the pending `WHO` for the nickname that quit.

*If debugging statements are added to `CoreNetwork::cancelAutoWhoOneshot()`, Quassel should output something to the log.*

```
2018-09-13 01:39:33 [Debug] DEBUG: Canceled a who for "dcircuit_test"
```

*Example debugging code*
```cpp
void CoreNetwork::cancelAutoWhoOneshot(const QString &channelOrNick)
{
    // Remove channel/nick from queue if it exists
    if(_autoWhoQueue.removeAll(channelOrNick) > 0) {
        qDebug() << "DEBUG: Canceled a who for" << channelOrNick;
    }
}
```