### PR TITLE
core: Remove away-notify WHO-on-join hack, cleanup

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -494,13 +494,13 @@ bool CoreNetwork::cipherUsesCBC(const QString &target)
 }
 #endif /* HAVE_QCA2 */
 
-bool CoreNetwork::setAutoWhoDone(const QString &channel)
+bool CoreNetwork::setAutoWhoDone(const QString &name)
 {
-    QString chan = channel.toLower();
-    if (_autoWhoPending.value(chan, 0) <= 0)
+    QString chanOrNick = name.toLower();
+    if (_autoWhoPending.value(chanOrNick, 0) <= 0)
         return false;
-    if (--_autoWhoPending[chan] <= 0)
-        _autoWhoPending.remove(chan);
+    if (--_autoWhoPending[chanOrNick] <= 0)
+        _autoWhoPending.remove(chanOrNick);
     return true;
 }
 
@@ -1308,12 +1308,12 @@ void CoreNetwork::startAutoWhoCycle()
     _autoWhoQueue = channels();
 }
 
-void CoreNetwork::queueAutoWhoOneshot(const QString &channelOrNick)
+void CoreNetwork::queueAutoWhoOneshot(const QString &name)
 {
     // Prepend so these new channels/nicks are the first to be checked
     // Don't allow duplicates
-    if (!_autoWhoQueue.contains(channelOrNick.toLower())) {
-        _autoWhoQueue.prepend(channelOrNick.toLower());
+    if (!_autoWhoQueue.contains(name.toLower())) {
+        _autoWhoQueue.prepend(name.toLower());
     }
     if (capEnabled(IrcCap::AWAY_NOTIFY)) {
         // When away-notify is active, the timer's stopped.  Start a new cycle to who this channel.
@@ -1322,10 +1322,10 @@ void CoreNetwork::queueAutoWhoOneshot(const QString &channelOrNick)
 }
 
 
-void CoreNetwork::cancelAutoWhoOneshot(const QString &channelOrNick)
+void CoreNetwork::cancelAutoWhoOneshot(const QString &name)
 {
     // Remove channel/nick from queue if it exists
-    _autoWhoQueue.removeAll(channelOrNick);
+    _autoWhoQueue.removeAll(name);
 
     // The AutoWho timer will detect if the queue is empty and automatically stop, no need to
     // manually control it.

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -1322,16 +1322,6 @@ void CoreNetwork::queueAutoWhoOneshot(const QString &name)
 }
 
 
-void CoreNetwork::cancelAutoWhoOneshot(const QString &name)
-{
-    // Remove channel/nick from queue if it exists
-    _autoWhoQueue.removeAll(name);
-
-    // The AutoWho timer will detect if the queue is empty and automatically stop, no need to
-    // manually control it.
-}
-
-
 void CoreNetwork::setAutoWhoDelay(int delay)
 {
     _autoWhoTimer.setInterval(delay * 1000);

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -90,7 +90,16 @@ public:
     inline QByteArray readChannelCipherKey(const QString &channel) const { return _cipherKeys.value(channel.toLower()); }
     inline void storeChannelCipherKey(const QString &channel, const QByteArray &key) { _cipherKeys[channel.toLower()] = key; }
 
-    inline bool isAutoWhoInProgress(const QString &channel) const { return _autoWhoPending.value(channel.toLower(), 0); }
+    /**
+     * Checks if the given target has an automatic WHO in progress
+     *
+     * @param name Channel or nickname
+     * @return True if an automatic WHO is in progress, otherwise false
+     */
+    inline bool isAutoWhoInProgress(const QString &name) const
+    {
+        return _autoWhoPending.value(name.toLower(), 0);
+    }
 
     inline UserId userId() const { return _coreSession->user(); }
 
@@ -388,23 +397,29 @@ public slots:
      * When 'away-notify' is enabled, this will trigger an immediate AutoWho since regular
      * who-cycles are disabled as per IRCv3 specifications.
      *
-     * @param[in] channelOrNick Channel or nickname to WHO
+     * @param[in] name Channel or nickname
      */
-    void queueAutoWhoOneshot(const QString &channelOrNick);
+    void queueAutoWhoOneshot(const QString &name);
 
     /**
-     * Removes the given channel/nick from AutoWho queue for when it stops existing
+     * Removes the given channel/nick from AutoWho queue
      *
-     * If not already in queue, nothing happens.  This should only be used for nicknames and
-     * channels that have suddenly stopped existing (e.g. nick joins then quits).
+     * This can avoid needlessly WHO'ng nicknames and channels that are no longer of interest, e.g.
+     * if parting a channel right after joining or if a nick joins then quits.
      *
      * For when a periodic channel AutoWho finishes, see CoreNetwork::setAutoWhoDone()
      *
-     * @param channelOrNick Channel or nickname to WHO
+     * @param name Channel or nickname
      */
-    void cancelAutoWhoOneshot(const QString &channelOrNick);
+    void cancelAutoWhoOneshot(const QString &name);
 
-    bool setAutoWhoDone(const QString &channel);
+    /**
+     * Checks if the given target has an automatic WHO in progress, and sets it as done if so
+     *
+     * @param name Channel or nickname
+     * @return True if an automatic WHO is in progress (and should be silenced), otherwise false
+     */
+    bool setAutoWhoDone(const QString &name);
 
     void updateIssuedModes(const QString &requestedModes);
     void updatePersistentModes(QString addModes, QString removeModes);

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -402,18 +402,6 @@ public slots:
     void queueAutoWhoOneshot(const QString &name);
 
     /**
-     * Removes the given channel/nick from AutoWho queue
-     *
-     * This can avoid needlessly WHO'ng nicknames and channels that are no longer of interest, e.g.
-     * if parting a channel right after joining or if a nick joins then quits.
-     *
-     * For when a periodic channel AutoWho finishes, see CoreNetwork::setAutoWhoDone()
-     *
-     * @param name Channel or nickname
-     */
-    void cancelAutoWhoOneshot(const QString &name);
-
-    /**
      * Checks if the given target has an automatic WHO in progress, and sets it as done if so
      *
      * @param name Channel or nickname


### PR DESCRIPTION
## In short

* Remove `away-notify` `AutoWho`-on-join hack for non-compliant servers
  * Removes workaround for servers not sending `:AWAY :message` when an `/away` user joins channel
  * Reduces network traffic
  * Results in missing information until servers fix their implementations
* Clean up `AutoWho` comments and variable names
  * Use the `name` convention [from RFC 1459](https://tools.ietf.org/html/rfc1459#section-4.5.1 )
  * Clarifies that channels and nicknames can be `WHO`'d

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Speedier `AutoWho` behavior, less network traffic to busy servers
Risk | ★★☆ *2/3* | Missing info on servers behind the IRCv3 times
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

*Thanks to @jwheare for pointing things out and convincing me to remove this workaround.*

## Rationale
Though Quassel should make a reasonable effort to be compatible with different, non-spec-compliant servers, it should not come at a cost in terms of bandwidth or performance to servers that do follow the IRC and IRCv3 specs.  As time goes on, servers will eventually become more compliant.

Automatically `WHO`'ng every nickname that joins an `away-notify`-enabled server imposes additional network traffic just to track `/away` state on server software that is not compliant.

In this case, it is better to [encourage IRC servers via bug reports, etc](https://bugs.unrealircd.org/view.php?id=5144 ) to properly follow [the IRCv3 `away-notify` spec](https://ircv3.net/specs/extensions/away-notify-3.1.html ).

### Advantages
* Less network traffic
  * No `WHO` for every nickname that joins
* Less likely to expose other bugs where an IRC server returns something unexpected causing auto-who output to go in the status buffer
  * Bad for debugging IRC parsing code, but good for not annoying stable release users

### Disadvantages
* On non-compliant `away-notify` IRC servers, Quassel will no longer accurately know the away status of someone that joins a channel while `/away`
* On IRC servers that implement `away-notify` but not `extended-join`, Quassel will no longer learn the logged-in account and realname for someone that joins a channel
  * This will break showing realname and fallback avatar fetching
  * Will be resolved as more IRC servers implement `extended-join`

## Testing
### Steps

1. Join an IRC server with Quassel, client A
   * Make sure to enable `--debug-irc` on core/monolithic side
2. Join a test channel, e.g. `#test`
3. Connect to the same server with another instance of Quassel, client B
   * **Do NOT join the same channel, `#test`**
4. Set client B to `/away Test`
5. Join client B to `#test`

### Before

```
2018-09-14 15:19:26 [Debug] IRC net  # << "dcircuit_test!ident@hostmask JOIN :#test"
2018-09-14 15:19:30 [Debug] IRC net  # >> "WHO dcircuit_test"
2018-09-14 15:19:30 [Debug] IRC net  # << ":irc-server.example.com 352 digitalcircuit #test ident hostmask irc-server.example.com dcircuit_test G :1 Realname"
2018-09-14 15:19:30 [Debug] IRC net  # << ":irc-server.example.com 315 digitalcircuit dcircuit_test :End of /WHO list."
```

*Note: A spec-compliant `away-notify` server would've sent an `:AWAY :Test` message after the join message*

### After

```
2018-09-14 15:06:16 [Debug] IRC net  # << ":dcircuit_test!ident@hostmask JOIN :#test"
```

*Note: A spec-compliant `away-notify` server would've sent an `:AWAY :Test` message after the join message*