### PR TITLE
Fix init and shutdown sequences, lifetime issues and quitting from networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 /build*
+/cmake-build-*
 *.pyc
 tags
+/.kdev4
 /.idea
-/cmake-build-*
 
 # Qt Creator configuration
-CMakeLists.txt.user
+CMakeLists.txt.user*

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <QList>
 #include <QPointer>
 
@@ -29,6 +31,7 @@
 #include "coreconnection.h"
 #include "highlightrulemanager.h"
 #include "quassel.h"
+#include "singleton.h"
 #include "types.h"
 
 class Message;
@@ -63,7 +66,7 @@ class TransferModel;
 
 struct NetworkInfo;
 
-class Client : public QObject
+class Client : public QObject, public Singleton<Client>
 {
     Q_OBJECT
 
@@ -73,10 +76,9 @@ public:
         RemoteCore
     };
 
-    static bool instanceExists();
-    static Client *instance();
-    static void destroy();
-    static void init(AbstractUi *);
+    Client(std::unique_ptr<AbstractUi>, QObject *parent = nullptr);
+    ~Client() override;
+
     static AbstractUi *mainUi();
 
     static QList<NetworkId> networkIds();
@@ -292,10 +294,6 @@ private slots:
     void sendBufferedUserInput();
 
 private:
-    Client(QObject *parent = 0);
-    virtual ~Client();
-    void init();
-
     void requestInitialBacklog();
 
     /**
@@ -311,10 +309,8 @@ private:
 
     static void addNetwork(Network *);
 
-    static QPointer<Client> instanceptr;
-
     SignalProxy *_signalProxy;
-    AbstractUi *_mainUi;
+    std::unique_ptr<AbstractUi> _mainUi;
     NetworkModel *_networkModel;
     BufferModel *_bufferModel;
     BufferSyncer *_bufferSyncer;

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCES
     remotepeer.cpp
     settings.cpp
     signalproxy.cpp
+    singleton.h
     syncableobject.cpp
     transfer.cpp
     transfermanager.cpp

--- a/src/common/internalpeer.cpp
+++ b/src/common/internalpeer.cpp
@@ -67,7 +67,7 @@ quint16 InternalPeer::port() const
 
 bool InternalPeer::isOpen() const
 {
-    return true;
+    return _isOpen;
 }
 
 
@@ -85,9 +85,8 @@ bool InternalPeer::isLocal() const
 
 void InternalPeer::close(const QString &reason)
 {
-    // FIXME
-    Q_UNUSED(reason)
-    qWarning() << "closing not implemented!";
+    Q_UNUSED(reason);
+    _isOpen = false;
 }
 
 
@@ -116,6 +115,7 @@ void InternalPeer::setSignalProxy(::SignalProxy *proxy)
 
     if (proxy && !_proxy) {
         _proxy = proxy;
+        _isOpen = true;
         return;
     }
 

--- a/src/common/internalpeer.h
+++ b/src/common/internalpeer.h
@@ -93,7 +93,7 @@ private:
 
 private:
     SignalProxy *_proxy{nullptr};
-    bool _isOpen{false};
+    bool _isOpen{true};
 };
 
 Q_DECLARE_METATYPE(QPointer<InternalPeer>)

--- a/src/common/ircchannel.cpp
+++ b/src/common/ircchannel.cpp
@@ -61,7 +61,7 @@ bool IrcChannel::isKnownUser(IrcUser *ircuser) const
     }
 
     if (!_userModes.contains(ircuser)) {
-        qWarning() << "Channel" << name() << "received data for unknown User" << ircuser->nick();
+        // This can happen e.g. when disconnecting from a network, so don't log a warning
         return false;
     }
 

--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
 #endif
 
     // Instantiate early, so log messages are handled
-    Quassel::instance();
+    Quassel quassel;
 
 #if QT_VERSION < 0x050000
     // All our source files are in UTF-8, and Qt5 even requires that

--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -54,15 +54,9 @@
 
 #include "../../version.h"
 
-Quassel *Quassel::instance()
-{
-    static Quassel instance;
-    return &instance;
-}
-
-
 Quassel::Quassel()
-    : _logger{new Logger{this}}
+    : Singleton<Quassel>{this}
+    , _logger{new Logger{this}}
 {
 }
 
@@ -126,11 +120,6 @@ bool Quassel::init()
 
     // Don't keep a debug log on the core
     return instance()->logger()->setup(runMode() != RunMode::CoreOnly);
-}
-
-
-void Quassel::destroy()
-{
 }
 
 

--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -136,12 +136,17 @@ void Quassel::registerQuitHandler(QuitHandler handler)
 
 void Quassel::quit()
 {
-    if (_quitHandlers.empty()) {
-        QCoreApplication::quit();
-    }
-    else {
-        for (auto &&handler : _quitHandlers) {
-            handler();
+    // Protect against multiple invocations (e.g. triggered by MainWin::closeEvent())
+    if (!_quitting) {
+        _quitting = true;
+        if (_quitHandlers.empty()) {
+            QCoreApplication::quit();
+        }
+        else {
+            // Note: We expect one of the registered handlers to call QCoreApplication::quit()
+            for (auto &&handler : _quitHandlers) {
+                handler();
+            }
         }
     }
 }

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -198,9 +198,25 @@ public:
 
     using QuitHandler = std::function<void()>;
 
+    /**
+     * Registers a handler that is called when the application is supposed to quit.
+     *
+     * @note If multiple handlers are registered, they are processed in order of registration.
+     * @note If any handler is registered, quit() will not call QCoreApplication::quit(). It relies
+     *       on one of the handlers doing so, instead.
+     * @param quitHandler Handler to register
+     */
     static void registerQuitHandler(QuitHandler quitHandler);
 
     const QString &coreDumpFileName();
+
+public slots:
+    /**
+     * Requests to quit the application.
+     *
+     * Calls any registered quit handlers. If no handlers are registered, calls QCoreApplication::quit().
+     */
+    void quit();
 
 signals:
     void messageLogged(const QDateTime &timeStamp, const QString &msg);
@@ -232,13 +248,6 @@ private:
      */
     bool reloadConfig();
 
-    /**
-     * Requests to quit the application.
-     *
-     * Calls any registered quit handlers. If no handlers are registered, calls QCoreApplication::quit().
-     */
-    void quit();
-
     void logBacktrace(const QString &filename);
 
     static void handleSignal(int signal);
@@ -248,6 +257,7 @@ private:
     RunMode _runMode;
     bool _initialized{false};
     bool _handleCrashes{true};
+    bool _quitting{false};
 
     QString _coreDumpFileName;
     QString _configDirPath;

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -32,12 +32,13 @@
 #include <QStringList>
 
 #include "abstractcliparser.h"
+#include "singleton.h"
 
 class QFile;
 
 class Logger;
 
-class Quassel : public QObject
+class Quassel : public QObject, public Singleton<Quassel>
 {
     // TODO Qt5: Use Q_GADGET
     Q_OBJECT
@@ -146,7 +147,7 @@ public:
 
     class Features;
 
-    static Quassel *instance();
+    Quassel();
 
     /**
      * Provides access to the Logger instance.
@@ -206,7 +207,6 @@ signals:
 
 protected:
     static bool init();
-    static void destroy();
 
     static void setRunMode(Quassel::RunMode runMode);
 
@@ -219,7 +219,6 @@ protected:
     friend class MonolithicApplication;
 
 private:
-    Quassel();
     void setupEnvironment();
     void registerMetaTypes();
 

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -475,8 +475,11 @@ void SignalProxy::synchronize(SyncableObject *obj)
 
 void SignalProxy::detachObject(QObject *obj)
 {
-    detachSignals(obj);
-    detachSlots(obj);
+    // Don't try to connect SignalProxy from itself on shutdown
+    if (obj != this) {
+        detachSignals(obj);
+        detachSlots(obj);
+    }
 }
 
 

--- a/src/common/singleton.h
+++ b/src/common/singleton.h
@@ -1,0 +1,107 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2018 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <QtGlobal>
+
+/**
+ * Mixin class for "pseudo" singletons.
+ *
+ * Classes inheriting from this mixin become "pseudo" singletons that can still be constructed
+ * and destroyed in a controlled manner, but also gain an instance() method for static access.
+ * This is very similar to the behavior of e.g. QCoreApplication.
+ *
+ * The mixin protects against multiple instantiation, use-before-instantiation and use-after-destruction
+ * by aborting the program. This is intended to find lifetime issues during development; abort()
+ * produces a backtrace that makes it easy to find the culprit.
+ *
+ * The Curiously Recurring Template Pattern (CRTP) is used for the mixin to be able to provide a
+ * correctly typed instance pointer.
+ */
+template<typename T>
+class Singleton
+{
+public:
+    /**
+     * Constructs the mixin.
+     *
+     * The constructor can only be called once; subsequent invocations abort the program.
+     *
+     * @param instance Pointer to the instance being created, i.e. the 'this' pointer of the parent class
+     */
+    Singleton(T *instance)
+    {
+        if (_destroyed) {
+            qFatal("Trying to reinstantiate a destroyed singleton, this must not happen!");
+            abort();  // This produces a backtrace, which is highly useful for finding the culprit
+        }
+        if (_instance) {
+            qFatal("Trying to reinstantiate a singleton that is already instantiated, this must not happen!");
+            abort();
+        }
+        _instance = instance;
+    }
+
+    // Satisfy Rule of Five
+    Singleton(const Singleton &) = delete;
+    Singleton(Singleton &&) = delete;
+    Singleton &operator=(const Singleton &) = delete;
+    Singleton &operator=(Singleton &&) = delete;
+
+    /**
+     * Destructor.
+     *
+     * Sets the instance pointer to null and flags the destruction, so a subsequent reinstantiation will fail.
+     */
+    ~Singleton()
+    {
+        _instance = nullptr;
+        _destroyed = true;
+    }
+
+    /**
+     * Accesses the instance pointer.
+     *
+     * If the singleton hasn't been instantiated yet, the program is aborted. No lazy instantiation takes place,
+     * because the singleton's lifetime shall be explicitly controlled.
+     *
+     * @returns A pointer to the instance
+     */
+    static T *instance()
+    {
+        if (_instance) {
+            return _instance;
+        }
+        qFatal("Trying to access a singleton that has not been instantiated yet");
+        abort();
+    }
+
+private:
+    static T *_instance;
+    static bool _destroyed;
+
+};
+
+template<typename T>
+T *Singleton<T>::_instance{nullptr};
+
+template<typename T>
+bool Singleton<T>::_destroyed{false};

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -67,22 +67,10 @@ public:
 // ==============================
 //  Core
 // ==============================
-Core *Core::_instance{nullptr};
-
-Core *Core::instance()
-{
-    return _instance;
-}
-
 
 Core::Core()
+    : Singleton<Core>{this}
 {
-    if (_instance) {
-        qWarning() << "Recreating core instance!";
-        delete _instance;
-    }
-    _instance = this;
-
     // Parent all QObject-derived attributes, so when the Core instance gets moved into another
     // thread, they get moved with it
     _server.setParent(this);
@@ -97,7 +85,6 @@ Core::~Core()
     qDeleteAll(_connectingClients);
     qDeleteAll(_sessions);
     syncStorage();
-    _instance = nullptr;
 }
 
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -69,6 +69,12 @@ public:
 
     void init();
 
+    /**
+     * Shuts down active core sessions, saves state and emits the shutdownComplete() signal afterwards.
+     */
+    void shutdown();
+
+
     /*** Storage access ***/
     // These methods are threadsafe.
 
@@ -704,6 +710,9 @@ signals:
     //! Emitted when a fatal error was encountered during async initialization
     void exitRequested(int exitCode, const QString &reason);
 
+    //! Emitted once core shutdown is complete
+    void shutdownComplete();
+
 public slots:
     void initAsync();
 
@@ -746,6 +755,8 @@ private slots:
     void setupClientSession(RemotePeer *, UserId);
 
     bool changeUserPass(const QString &username);
+
+    void onSessionShutdown(SessionThread *session);
 
 private:
     SessionThread *sessionForUser(UserId userId, bool restoreState = false);

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -44,6 +44,7 @@
 #include "message.h"
 #include "oidentdconfiggenerator.h"
 #include "sessionthread.h"
+#include "singleton.h"
 #include "storage.h"
 #include "types.h"
 
@@ -58,13 +59,11 @@ struct NetworkInfo;
 class AbstractSqlMigrationReader;
 class AbstractSqlMigrationWriter;
 
-class Core : public QObject
+class Core : public QObject, public Singleton<Core>
 {
     Q_OBJECT
 
 public:
-    static Core *instance();
-
     Core();
     ~Core() override;
 

--- a/src/core/coreapplication.cpp
+++ b/src/core/coreapplication.cpp
@@ -36,7 +36,6 @@ CoreApplication::CoreApplication(int &argc, char **argv)
 CoreApplication::~CoreApplication()
 {
     _core.reset();
-    Quassel::destroy();
 }
 
 

--- a/src/core/coreapplication.h
+++ b/src/core/coreapplication.h
@@ -24,6 +24,7 @@
 
 #include <QCoreApplication>
 
+#include "core.h"
 #include "quassel.h"
 
 class Core;
@@ -31,11 +32,14 @@ class Core;
 class CoreApplication : public QCoreApplication
 {
     Q_OBJECT
+
 public:
     CoreApplication(int &argc, char **argv);
-    ~CoreApplication() override;
 
     void init();
+
+private slots:
+    void onShutdownComplete();
 
 private:
     std::unique_ptr<Core> _core;

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -154,7 +154,7 @@ CoreSession::CoreSession(UserId uid, bool restoreState, bool strictIdentEnabled,
 }
 
 
-CoreSession::~CoreSession()
+void CoreSession::shutdown()
 {
     saveSessionState();
 
@@ -200,6 +200,11 @@ CoreSession::~CoreSession()
         // Delete the network now that it's closed
         delete net;
     }
+
+    _networks.clear();
+
+    // Suicide
+    deleteLater();
 }
 
 

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -63,7 +63,6 @@ class CoreSession : public QObject
 
 public:
     CoreSession(UserId, bool restoreState, bool strictIdentEnabled, QObject *parent = 0);
-    ~CoreSession();
 
     QList<BufferInfo> buffers() const;
     inline UserId user() const { return _user; }
@@ -111,6 +110,11 @@ public:
 public slots:
     void addClient(RemotePeer *peer);
     void addClient(InternalPeer *peer);
+
+    /**
+     * Shuts down the session and deletes itself afterwards.
+     */
+    void shutdown();
 
     void msgFromClient(BufferInfo, QString message);
 

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -18,9 +18,10 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef CORESESSION_H
-#define CORESESSION_H
+#pragma once
 
+#include <QHash>
+#include <QSet>
 #include <QString>
 #include <QVariant>
 
@@ -213,6 +214,8 @@ private slots:
 
     void saveSessionState() const;
 
+    void onNetworkDisconnected(NetworkId networkId);
+
 private:
     void processMessages();
 
@@ -229,10 +232,10 @@ private:
 
     SignalProxy *_signalProxy;
     CoreAliasManager _aliasManager;
-    // QHash<NetworkId, NetworkConnection *> _connections;
-    QHash<NetworkId, CoreNetwork *> _networks;
-    //  QHash<NetworkId, CoreNetwork *> _networksToRemove;
+
     QHash<IdentityId, CoreIdentity *> _identities;
+    QHash<NetworkId, CoreNetwork *> _networks;
+    QSet<NetworkId> _networksPendingDisconnect;
 
     CoreBufferSyncer *_bufferSyncer;
     CoreBacklogManager *_backlogManager;
@@ -290,5 +293,3 @@ struct RawMessage {
     RawMessage(NetworkId networkId, Message::Type type, BufferInfo::Type bufferType, const QString &target, const QString &text, const QString &sender, Message::Flags flags)
         : networkId(networkId), type(type), bufferType(bufferType), target(target), text(text), sender(sender), flags(flags) {}
 };
-
-#endif

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -823,15 +823,17 @@ void MainWin::changeActiveBufferView(int bufferViewId)
 void MainWin::showPasswordChangeDlg()
 {
     if(Client::isCoreFeatureEnabled(Quassel::Feature::PasswordChange)) {
-        PasswordChangeDlg dlg(this);
-        dlg.exec();
+        auto dlg = new PasswordChangeDlg(this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        dlg->exec();
     }
     else {
-        QMessageBox box(QMessageBox::Warning, tr("Feature Not Supported"),
-                        tr("<b>Your Quassel Core does not support this feature</b>"),
-                        QMessageBox::Ok, this);
-        box.setInformativeText(tr("You need a Quassel Core v0.12.0 or newer in order to be able to remotely change your password."));
-        box.exec();
+        auto box = new QMessageBox(QMessageBox::Warning, tr("Feature Not Supported"),
+                                   tr("<b>Your Quassel Core does not support this feature</b>"),
+                                   QMessageBox::Ok, this);
+        box->setInformativeText(tr("You need a Quassel Core v0.12.0 or newer in order to be able to remotely change your password."));
+        box->setAttribute(Qt::WA_DeleteOnClose);
+        box->exec();
     }
 }
 
@@ -862,12 +864,13 @@ void MainWin::showMigrationWarning(bool show)
 void MainWin::onExitRequested(const QString &reason)
 {
     if (!reason.isEmpty()) {
-        QMessageBox box(QMessageBox::Critical,
-                        tr("Fatal error"),
-                        "<b>" + tr("Quassel encountered a fatal error and is terminated.") + "</b>",
-                        QMessageBox::Ok, this);
-        box.setInformativeText("<p>" + tr("Reason:<em>") + " " + reason + "</em>");
-        box.exec();
+        auto box = new QMessageBox(QMessageBox::Critical,
+                                   tr("Fatal error"),
+                                   "<b>" + tr("Quassel encountered a fatal error and is terminated.") + "</b>",
+                                   QMessageBox::Ok, this);
+        box->setInformativeText("<p>" + tr("Reason:<em>") + " " + reason + "</em>");
+        box->setAttribute(Qt::WA_DeleteOnClose);
+        box->exec();
     }
 }
 
@@ -942,22 +945,25 @@ void MainWin::hideCurrentBuffer()
 
 void MainWin::showNotificationsDlg()
 {
-    SettingsPageDlg dlg(new NotificationsSettingsPage(this), this);
-    dlg.exec();
+    auto dlg = new SettingsPageDlg(new NotificationsSettingsPage(this), this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->exec();
 }
 
 
 void MainWin::on_actionConfigureNetworks_triggered()
 {
-    SettingsPageDlg dlg(new NetworksSettingsPage(this), this);
-    dlg.exec();
+    auto dlg = new SettingsPageDlg(new NetworksSettingsPage(this), this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->exec();
 }
 
 
 void MainWin::on_actionConfigureViews_triggered()
 {
-    SettingsPageDlg dlg(new BufferViewSettingsPage(this), this);
-    dlg.exec();
+    auto dlg = new SettingsPageDlg(new BufferViewSettingsPage(this), this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->exec();
 }
 
 
@@ -1393,28 +1399,31 @@ void MainWin::setDisconnectedState()
 void MainWin::userAuthenticationRequired(CoreAccount *account, bool *valid, const QString &errorMessage)
 {
     Q_UNUSED(errorMessage)
-    CoreConnectAuthDlg dlg(account, this);
-    *valid = (dlg.exec() == QDialog::Accepted);
+    auto dlg = new CoreConnectAuthDlg(account, this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    *valid = (dlg->exec() == QDialog::Accepted);
 }
 
 
 void MainWin::handleNoSslInClient(bool *accepted)
 {
-    QMessageBox box(QMessageBox::Warning, tr("Unencrypted Connection"), tr("<b>Your client does not support SSL encryption</b>"),
-        QMessageBox::Ignore|QMessageBox::Cancel, this);
-    box.setInformativeText(tr("Sensitive data, like passwords, will be transmitted unencrypted to your Quassel core."));
-    box.setDefaultButton(QMessageBox::Ignore);
-    *accepted = box.exec() == QMessageBox::Ignore;
+    auto box = new QMessageBox(QMessageBox::Warning, tr("Unencrypted Connection"), tr("<b>Your client does not support SSL encryption</b>"),
+                               QMessageBox::Ignore|QMessageBox::Cancel, this);
+    box->setInformativeText(tr("Sensitive data, like passwords, will be transmitted unencrypted to your Quassel core."));
+    box->setDefaultButton(QMessageBox::Ignore);
+    box->setAttribute(Qt::WA_DeleteOnClose);
+    *accepted = (box->exec() == QMessageBox::Ignore);
 }
 
 
 void MainWin::handleNoSslInCore(bool *accepted)
 {
-    QMessageBox box(QMessageBox::Warning, tr("Unencrypted Connection"), tr("<b>Your core does not support SSL encryption</b>"),
-        QMessageBox::Ignore|QMessageBox::Cancel, this);
-    box.setInformativeText(tr("Sensitive data, like passwords, will be transmitted unencrypted to your Quassel core."));
-    box.setDefaultButton(QMessageBox::Ignore);
-    *accepted = box.exec() == QMessageBox::Ignore;
+    auto box = new QMessageBox(QMessageBox::Warning, tr("Unencrypted Connection"), tr("<b>Your core does not support SSL encryption</b>"),
+                               QMessageBox::Ignore|QMessageBox::Cancel, this);
+    box->setInformativeText(tr("Sensitive data, like passwords, will be transmitted unencrypted to your Quassel core."));
+    box->setDefaultButton(QMessageBox::Ignore);
+    box->setAttribute(Qt::WA_DeleteOnClose);
+    *accepted = (box->exec() == QMessageBox::Ignore);
 }
 
 
@@ -1427,35 +1436,38 @@ void MainWin::handleSslErrors(const QSslSocket *socket, bool *accepted, bool *pe
     errorString += QString("<li>%1</li>").arg(error.errorString());
     errorString += "</ul>";
 
-    QMessageBox box(QMessageBox::Warning,
-        tr("Untrusted Security Certificate"),
-        tr("<b>The SSL certificate provided by the core at %1 is untrusted for the following reasons:</b>").arg(socket->peerName()),
-        QMessageBox::Cancel, this);
-    box.setInformativeText(errorString);
-    box.addButton(tr("Continue"), QMessageBox::AcceptRole);
-    box.setDefaultButton(box.addButton(tr("Show Certificate"), QMessageBox::HelpRole));
+    auto box = new QMessageBox(QMessageBox::Warning,
+                               tr("Untrusted Security Certificate"),
+                               tr("<b>The SSL certificate provided by the core at %1 is untrusted for the following reasons:</b>").arg(socket->peerName()),
+                               QMessageBox::Cancel, this);
+    box->setInformativeText(errorString);
+    box->addButton(tr("Continue"), QMessageBox::AcceptRole);
+    box->setDefaultButton(box->addButton(tr("Show Certificate"), QMessageBox::HelpRole));
+    box->setAttribute(Qt::WA_DeleteOnClose);
 
     QMessageBox::ButtonRole role;
     do {
-        box.exec();
-        role = box.buttonRole(box.clickedButton());
+        box->exec();
+        role = box->buttonRole(box->clickedButton());
         if (role == QMessageBox::HelpRole) {
-            SslInfoDlg dlg(socket, this);
-            dlg.exec();
+            auto dlg = new SslInfoDlg(socket, this);
+            dlg->setAttribute(Qt::WA_DeleteOnClose);
+            dlg->exec();
         }
     }
     while (role == QMessageBox::HelpRole);
 
     *accepted = role == QMessageBox::AcceptRole;
     if (*accepted) {
-        QMessageBox box2(QMessageBox::Warning,
-            tr("Untrusted Security Certificate"),
-            tr("Would you like to accept this certificate forever without being prompted?"),
-            0, this);
-        box2.setDefaultButton(box2.addButton(tr("Current Session Only"), QMessageBox::NoRole));
-        box2.addButton(tr("Forever"), QMessageBox::YesRole);
-        box2.exec();
-        *permanently =  box2.buttonRole(box2.clickedButton()) == QMessageBox::YesRole;
+        auto box2 = new QMessageBox(QMessageBox::Warning,
+                                    tr("Untrusted Security Certificate"),
+                                    tr("Would you like to accept this certificate forever without being prompted?"),
+                                    nullptr, this);
+        box2->setDefaultButton(box2->addButton(tr("Current Session Only"), QMessageBox::NoRole));
+        box2->addButton(tr("Forever"), QMessageBox::YesRole);
+        box2->setAttribute(Qt::WA_DeleteOnClose);
+        box2->exec();
+        *permanently = (box2->buttonRole(box2->clickedButton()) == QMessageBox::YesRole);
     }
 }
 
@@ -1470,9 +1482,10 @@ void MainWin::handleCoreConnectionError(const QString &error)
 
 void MainWin::showCoreConnectionDlg()
 {
-    CoreConnectDlg dlg(this);
-    if (dlg.exec() == QDialog::Accepted) {
-        AccountId accId = dlg.selectedAccount();
+    auto dlg = new CoreConnectDlg(this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    if (dlg->exec() == QDialog::Accepted) {
+        AccountId accId = dlg->selectedAccount();
         if (accId.isValid())
             Client::coreConnection()->connectToCore(accId);
     }
@@ -1496,11 +1509,12 @@ void MainWin::showChannelList(NetworkId netId, const QString &channelFilters, bo
         if (!netId.isValid()) {
             // We still haven't found a valid network, probably no network selected, e.g. "/list"
             // on the client homescreen when no networks are connected.
-            QMessageBox box(QMessageBox::Information, tr("No network selected"),
-                            QString("<b>%1</b>").arg(tr("No network selected")),
-                            QMessageBox::Ok, this);
-            box.setInformativeText(tr("Select a network before trying to view the channel list."));
-            box.exec();
+            auto box = new QMessageBox(QMessageBox::Information, tr("No network selected"),
+                                       QString("<b>%1</b>").arg(tr("No network selected")),
+                                       QMessageBox::Ok, this);
+            box->setInformativeText(tr("Select a network before trying to view the channel list."));
+            box->setAttribute(Qt::WA_DeleteOnClose);
+            box->exec();
             return;
         }
     }
@@ -1520,26 +1534,30 @@ void MainWin::showChannelList(NetworkId netId, const QString &channelFilters, bo
 
 void MainWin::showNetworkConfig(NetworkId netId)
 {
-    SettingsPageDlg dlg(new NetworksSettingsPage(this), this);
+    auto dlg = new SettingsPageDlg(new NetworksSettingsPage(this), this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
     if (netId.isValid())
-        qobject_cast<NetworksSettingsPage *>(dlg.currentPage())->bufferList_Open(netId);
-    dlg.exec();
+        qobject_cast<NetworksSettingsPage *>(dlg->currentPage())->bufferList_Open(netId);
+    dlg->exec();
 }
 
 
 void MainWin::showIgnoreList(QString newRule)
 {
-    SettingsPageDlg dlg(new IgnoreListSettingsPage(this), this);
+    auto dlg = new SettingsPageDlg(new IgnoreListSettingsPage(this), this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
     // prepare config dialog for new rule
     if (!newRule.isEmpty())
-        qobject_cast<IgnoreListSettingsPage *>(dlg.currentPage())->editIgnoreRule(newRule);
-    dlg.exec();
+        qobject_cast<IgnoreListSettingsPage *>(dlg->currentPage())->editIgnoreRule(newRule);
+    dlg->exec();
 }
 
 
 void MainWin::showCoreInfoDlg()
 {
-    CoreInfoDlg(this).exec();
+    auto dlg = new CoreInfoDlg(this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->exec();
 }
 
 
@@ -1565,6 +1583,7 @@ void MainWin::awayLogDestroyed()
 void MainWin::showSettingsDlg()
 {
     SettingsDlg *dlg = new SettingsDlg();
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
 
     //Category: Interface
     dlg->registerSettingsPage(new AppearanceSettingsPage(dlg));
@@ -1603,20 +1622,25 @@ void MainWin::showSettingsDlg()
 
 void MainWin::showAboutDlg()
 {
-    AboutDlg(this).exec();
+    auto dlg = new AboutDlg(this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->exec();
 }
 
 
 void MainWin::showShortcutsDlg()
 {
 #ifdef HAVE_KDE
-    KShortcutsDialog dlg(KShortcutsEditor::AllActions, KShortcutsEditor::LetterShortcutsDisallowed, this);
-    foreach(KActionCollection *coll, QtUi::actionCollections())
-    dlg.addCollection(coll, coll->property("Category").toString());
-    dlg.configure(true);
+    auto dlg = new KShortcutsDialog(KShortcutsEditor::AllActions, KShortcutsEditor::LetterShortcutsDisallowed, this);
+    foreach(KActionCollection *coll, QtUi::actionCollections()) {
+        dlg->addCollection(coll, coll->property("Category").toString());
+    }
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->configure(true);
 #else
-    SettingsPageDlg dlg(new ShortcutsSettingsPage(QtUi::actionCollections(), this), this);
-    dlg.exec();
+    auto dlg = new SettingsPageDlg(new ShortcutsSettingsPage(QtUi::actionCollections(), this), this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->exec();
 #endif
 }
 

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -68,7 +68,6 @@ class MainWin
 
 public:
     MainWin(QWidget *parent = 0);
-    virtual ~MainWin();
 
     void init();
 
@@ -101,9 +100,6 @@ public slots:
     void showMigrationWarning(bool show);
 
     void onExitRequested(const QString &reason);
-
-    //! Quit application
-    void quit();
 
 protected:
     void closeEvent(QCloseEvent *event);

--- a/src/qtui/monoapplication.cpp
+++ b/src/qtui/monoapplication.cpp
@@ -59,7 +59,6 @@ MonolithicApplication::~MonolithicApplication()
     Client::destroy();
     _coreThread.quit();
     _coreThread.wait();
-    Quassel::destroy();
 }
 
 

--- a/src/qtui/monoapplication.cpp
+++ b/src/qtui/monoapplication.cpp
@@ -65,6 +65,18 @@ Quassel::QuitHandler MonolithicApplication::quitHandler()
 void MonolithicApplication::onClientDestroyed()
 {
     if (_core) {
+        connect(_core, SIGNAL(shutdownComplete()), this, SLOT(onCoreShutdown()));
+        _core->shutdown();
+    }
+    else {
+        QCoreApplication::quit();
+    }
+}
+
+
+void MonolithicApplication::onCoreShutdown()
+{
+    if (_core) {
         connect(_core, SIGNAL(destroyed()), QCoreApplication::instance(), SLOT(quit()));
         _coreThread.quit();
         _coreThread.wait();

--- a/src/qtui/monoapplication.h
+++ b/src/qtui/monoapplication.h
@@ -34,15 +34,18 @@ class MonolithicApplication : public QtUiApplication
 
 public:
     MonolithicApplication(int &, char **);
-    ~MonolithicApplication() override;
 
     void init() override;
+
+protected:
+    Quassel::QuitHandler quitHandler() override;
 
 signals:
     void connectInternalPeer(QPointer<InternalPeer> peer);
 
 private slots:
     void onConnectionRequest(QPointer<InternalPeer> peer);
+    void onClientDestroyed();
 
 private:
     void startInternalCore();

--- a/src/qtui/monoapplication.h
+++ b/src/qtui/monoapplication.h
@@ -46,6 +46,7 @@ signals:
 private slots:
     void onConnectionRequest(QPointer<InternalPeer> peer);
     void onClientDestroyed();
+    void onCoreShutdown();
 
 private:
     void startInternalCore();

--- a/src/qtui/qtui.h
+++ b/src/qtui/qtui.h
@@ -49,7 +49,8 @@ class QtUi : public GraphicalUi
     Q_OBJECT
 
 public:
-    ~QtUi();
+    QtUi();
+    ~QtUi() override;
 
     MessageModel *createMessageModel(QObject *parent) override;
     AbstractMessageProcessor *createMessageProcessor(QObject *parent) override;
@@ -122,17 +123,16 @@ private slots:
     void useSystemTrayChanged(const QVariant &);
 
 private:
-    QtUi();
-
     /**
      * Sets up icon theme handling.
      */
     void setupIconTheme();
 
 private:
-    static MainWin *_mainWin;
     static QList<AbstractNotificationBackend *> _notificationBackends;
     static QList<AbstractNotificationBackend::Notification> _notifications;
+
+    std::unique_ptr<MainWin> _mainWin;
 
     QString _systemIconTheme;
 
@@ -144,4 +144,4 @@ private:
 };
 
 QtUiStyle *QtUi::style() { return qobject_cast<QtUiStyle *>(uiStyle()); }
-MainWin *QtUi::mainWindow() { return _mainWin; }
+MainWin *QtUi::mainWindow() { return instance()->_mainWin.get(); }

--- a/src/qtui/qtuiapplication.cpp
+++ b/src/qtui/qtuiapplication.cpp
@@ -125,7 +125,6 @@ void QtUiApplication::init()
 QtUiApplication::~QtUiApplication()
 {
     Client::destroy();
-    Quassel::destroy();
 }
 
 

--- a/src/qtui/qtuiapplication.h
+++ b/src/qtui/qtuiapplication.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <memory>
+
 #ifdef HAVE_KDE4
 #  include <KApplication>
 #else
@@ -28,6 +30,7 @@
 
 #include <QSessionManager>
 
+#include "client.h"
 #include "quassel.h"
 #include "uisettings.h"
 #include "qtuisettings.h"
@@ -46,7 +49,7 @@ class QtUiApplication : public QApplication
 
 public:
     QtUiApplication(int &, char **);
-    ~QtUiApplication();
+
     virtual void init();
 
     void resumeSessionIfPossible();
@@ -59,6 +62,9 @@ public:
     void commitData(QSessionManager &manager);
     void saveState(QSessionManager &manager);
 #endif
+
+protected:
+    virtual Quassel::QuitHandler quitHandler();
 
 private:
     /**
@@ -85,6 +91,9 @@ private:
 
 private slots:
     void initUi();
+
+protected:
+    std::unique_ptr<Client> _client;
 
 private:
     bool _aboutToQuit{false};

--- a/src/uisupport/graphicalui.cpp
+++ b/src/uisupport/graphicalui.cpp
@@ -43,23 +43,9 @@ ToolBarActionProvider *GraphicalUi::_toolBarActionProvider = 0;
 UiStyle *GraphicalUi::_uiStyle = 0;
 bool GraphicalUi::_onAllDesktops = false;
 
-namespace {
 
-GraphicalUi *_instance{nullptr};
-
-}
-
-
-GraphicalUi *GraphicalUi::instance() {
-    return _instance;
-}
-
-
-GraphicalUi::GraphicalUi(QObject *parent) : AbstractUi(parent)
+GraphicalUi::GraphicalUi(QObject *parent) : AbstractUi(parent), Singleton<GraphicalUi>(this)
 {
-    Q_ASSERT(!_instance);
-    _instance = this;
-
 #ifdef Q_OS_WIN
     _dwTickCount = 0;
 #endif

--- a/src/uisupport/graphicalui.h
+++ b/src/uisupport/graphicalui.h
@@ -22,6 +22,7 @@
 #define GRAPHICALUI_H_
 
 #include "abstractui.h"
+#include "singleton.h"
 
 class ActionCollection;
 class ContextMenuActionProvider;
@@ -35,7 +36,7 @@ class UiStyle;
 #include <Carbon/Carbon.h>
 #endif
 
-class GraphicalUi : public AbstractUi
+class GraphicalUi : public AbstractUi, protected Singleton<GraphicalUi>
 {
     Q_OBJECT
 
@@ -109,8 +110,6 @@ protected slots:
     virtual void disconnectedFromCore();
 
 private:
-    static GraphicalUi *instance();
-
     static QWidget *_mainWidget;
     static QHash<QString, ActionCollection *> _actionCollections;
     static ContextMenuActionProvider *_contextMenuActionProvider;

--- a/src/uisupport/settingspage.cpp
+++ b/src/uisupport/settingspage.cpp
@@ -36,6 +36,7 @@ SettingsPage::SettingsPage(const QString &category, const QString &title, QWidge
     _changed(false),
     _autoWidgetsChanged(false)
 {
+    setAttribute(Qt::WA_DeleteOnClose);
 }
 
 


### PR DESCRIPTION
Rework the way our singletons are handled to be able to explicitly control their lifetime. Rework the init sequence as well as the shutdown sequence to ensure that objects are created and destroyed in the right order. In particular, this fixes the issue that neither the Core nor the Client instance where destroyed at all on shutdown in most cases.

Refactor SessionThread to follow the recommended worker pattern, and ensure that CoreSession instances are shut down cleanly as well. Fix issues with the QUIT command not always being sent to the IRC server when killing the core.

Avoid crashes when the client is shut down while a dialog is still open.