### PR TITLE
common: Don't use unsafe functions in the signal handler

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Builds the common module
 
 set(SOURCES
+    abstractsignalwatcher.h
     aliasmanager.cpp
     authhandler.cpp
     backlogmanager.cpp
@@ -87,13 +88,13 @@ if (APPLE)
 endif()
 
 if (WIN32)
-    set(SOURCES ${SOURCES} logbacktrace_win.cpp)
+    set(SOURCES ${SOURCES} logbacktrace_win.cpp windowssignalwatcher.cpp)
 else()
     if (EXECINFO_FOUND)
         add_definitions(-DHAVE_EXECINFO)
         include_directories(${EXECINFO_INCLUDES})
     endif()
-    set(SOURCES ${SOURCES} logbacktrace_unix.cpp)
+    set(SOURCES ${SOURCES} logbacktrace_unix.cpp posixsignalwatcher.cpp)
 endif()
 
 qt_add_resources(SOURCES ${COMMON_RCS})

--- a/src/common/posixsignalwatcher.cpp
+++ b/src/common/posixsignalwatcher.cpp
@@ -1,0 +1,109 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2018 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include "posixsignalwatcher.h"
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <csignal>
+
+#include <QDebug>
+#include <QSocketNotifier>
+
+#include "logmessage.h"
+
+int PosixSignalWatcher::_sockpair[2];
+
+PosixSignalWatcher::PosixSignalWatcher(QObject *parent)
+    : AbstractSignalWatcher{parent}
+{
+    if (::socketpair(AF_UNIX, SOCK_STREAM, 0, _sockpair)) {
+        qWarning() << "Could not setup POSIX signal watcher:" << ::strerror(errno);
+        return;
+    }
+
+    _notifier = new QSocketNotifier(_sockpair[1], QSocketNotifier::Read, this);
+    connect(_notifier, SIGNAL(activated(int)), this, SLOT(onNotify(int)));
+    _notifier->setEnabled(true);
+
+    registerSignal(SIGINT);
+    registerSignal(SIGTERM);
+    registerSignal(SIGHUP);
+
+#ifdef HAVE_EXECINFO
+    // we only handle crashes ourselves if coredumps are disabled
+    struct rlimit *limit = (rlimit *)malloc(sizeof(struct rlimit));
+    int rc = getrlimit(RLIMIT_CORE, limit);
+    if (rc == -1 || !((long)limit->rlim_cur > 0 || limit->rlim_cur == RLIM_INFINITY)) {
+        registerSignal(SIGABRT);
+        registerSignal(SIGSEGV);
+        registerSignal(SIGBUS);
+    }
+    free(limit);
+#endif
+}
+
+void PosixSignalWatcher::registerSignal(int signal)
+{
+    struct sigaction sigact;
+    sigact.sa_handler = PosixSignalWatcher::signalHandler;
+    sigact.sa_flags = 0;
+    sigemptyset(&sigact.sa_mask);
+    sigact.sa_flags |= SA_RESTART;
+    if (sigaction(signal, &sigact, nullptr)) {
+        qWarning() << "Could not register handler for POSIX signal:" << ::strerror(errno);
+    }
+}
+
+void PosixSignalWatcher::signalHandler(int signal)
+{
+    auto bytes = ::write(_sockpair[0], &signal, sizeof(signal));
+    Q_UNUSED(bytes)
+}
+
+void PosixSignalWatcher::onNotify(int sockfd)
+{
+    int signal;
+    auto bytes = ::read(sockfd, &signal, sizeof(signal));
+    Q_UNUSED(bytes)
+    quInfo() << "Caught signal" << signal;
+
+    switch (signal) {
+    case SIGHUP:
+        emit handleSignal(Action::Reload);
+        break;
+    case SIGINT:
+    case SIGTERM:
+        emit handleSignal(Action::Terminate);
+        break;
+    case SIGABRT:
+    case SIGSEGV:
+    case SIGBUS:
+        emit handleSignal(Action::HandleCrash);
+        break;
+    default:
+        ;
+    }
+}

--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -32,6 +32,7 @@
 #include <QStringList>
 
 #include "abstractcliparser.h"
+#include "abstractsignalwatcher.h"
 #include "singleton.h"
 
 class QFile;
@@ -228,7 +229,6 @@ protected:
 
     static void setDataDirPaths(const QStringList &paths);
     static QStringList findDataDirPaths();
-    static void disableCrashHandler();
 
     friend class CoreApplication;
     friend class QtUiApplication;
@@ -237,6 +237,7 @@ protected:
 private:
     void setupEnvironment();
     void registerMetaTypes();
+    void setupSignalHandling();
 
     /**
      * Requests a reload of relevant runtime configuration.
@@ -250,13 +251,13 @@ private:
 
     void logBacktrace(const QString &filename);
 
-    static void handleSignal(int signal);
+private slots:
+    void handleSignal(AbstractSignalWatcher::Action action);
 
 private:
     BuildInfo _buildInfo;
     RunMode _runMode;
     bool _initialized{false};
-    bool _handleCrashes{true};
     bool _quitting{false};
 
     QString _coreDumpFileName;
@@ -267,6 +268,7 @@ private:
     std::shared_ptr<AbstractCliParser> _cliParser;
 
     Logger *_logger;
+    AbstractSignalWatcher *_signalWatcher{nullptr};
 
     std::vector<ReloadHandler> _reloadHandlers;
     std::vector<QuitHandler> _quitHandlers;

--- a/src/common/windowssignalwatcher.cpp
+++ b/src/common/windowssignalwatcher.cpp
@@ -1,0 +1,83 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2018 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include "windowssignalwatcher.h"
+
+#include <signal.h>
+#include <windows.h>
+
+#include <QDebug>
+
+#include "logmessage.h"
+
+// This handler is called by Windows in a different thread when a console event happens
+// FIXME: When the console window is closed, the application is supposedly terminated as soon as
+//        this handler returns. We may want to block and wait for the main thread so set some
+//        condition variable once shutdown is complete...
+static BOOL WINAPI consoleCtrlHandler(DWORD ctrlType)
+{
+  switch (ctrlType) {
+  case CTRL_C_EVENT:     // Ctrl+C
+  case CTRL_CLOSE_EVENT: // Closing the console window
+      WindowsSignalWatcher::signalHandler(SIGTERM);
+      return TRUE;
+  default:
+      return FALSE;
+  }
+}
+
+WindowsSignalWatcher::WindowsSignalWatcher(QObject *parent)
+    : AbstractSignalWatcher{parent}
+    , Singleton<WindowsSignalWatcher>{this}
+{
+    static bool registered = []() {
+        qRegisterMetaType<AbstractSignalWatcher::Action>();
+        return true;
+    }();
+    Q_UNUSED(registered)
+
+    // Use POSIX-style API to register standard signals.
+    // Not sure if this is safe to use, but it has worked so far...
+    signal(SIGTERM, signalHandler);
+    signal(SIGINT,  signalHandler);
+    signal(SIGABRT, signalHandler);
+    signal(SIGSEGV, signalHandler);
+
+    // React on console window events
+    SetConsoleCtrlHandler(consoleCtrlHandler, TRUE);
+}
+
+void WindowsSignalWatcher::signalHandler(int signal)
+{
+    quInfo() << "Caught signal" << signal;
+
+    switch (signal) {
+    case SIGINT:
+    case SIGTERM:
+        emit instance()->handleSignal(Action::Terminate);
+        break;
+    case SIGABRT:
+    case SIGSEGV:
+        emit instance()->handleSignal(Action::HandleCrash);
+        break;
+    default:
+        ;
+    }
+}

--- a/src/common/windowssignalwatcher.h
+++ b/src/common/windowssignalwatcher.h
@@ -18,32 +18,19 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#include "coreapplication.h"
+#pragma once
 
-CoreApplication::CoreApplication(int &argc, char **argv)
-    : QCoreApplication(argc, argv)
+#include <QObject>
+
+#include "abstractsignalwatcher.h"
+#include "singleton.h"
+
+class WindowsSignalWatcher : public AbstractSignalWatcher, private Singleton<WindowsSignalWatcher>
 {
-    Quassel::setRunMode(Quassel::CoreOnly);
-    Quassel::registerQuitHandler([this]() {
-        connect(_core.get(), SIGNAL(shutdownComplete()), this, SLOT(onShutdownComplete()));
-        _core->shutdown();
-    });
-}
+    Q_OBJECT
 
+public:
+    WindowsSignalWatcher(QObject *parent = nullptr);
 
-void CoreApplication::init()
-{
-    if (!Quassel::init()) {
-        throw ExitException{EXIT_FAILURE, tr("Could not initialize Quassel!")};
-    }
-
-    _core.reset(new Core{}); // FIXME C++14: std::make_unique
-    _core->init();
-}
-
-
-void CoreApplication::onShutdownComplete()
-{
-    connect(_core.get(), SIGNAL(destroyed()), QCoreApplication::instance(), SLOT(quit()));
-    _core.release()->deleteLater();
-}
+    static void signalHandler(int signal);
+};

--- a/src/qtui/monoapplication.cpp
+++ b/src/qtui/monoapplication.cpp
@@ -23,6 +23,7 @@
 #include "client.h"
 #include "core.h"
 #include "internalpeer.h"
+#include "logmessage.h"
 #include "qtui.h"
 
 class InternalPeer;
@@ -30,10 +31,6 @@ class InternalPeer;
 MonolithicApplication::MonolithicApplication(int &argc, char **argv)
     : QtUiApplication(argc, argv)
 {
-#if defined(HAVE_KDE4) || defined(Q_OS_MAC)
-    Quassel::disableCrashHandler();
-#endif /* HAVE_KDE4 || Q_OS_MAC */
-
     Quassel::setRunMode(Quassel::Monolithic);
 }
 
@@ -56,6 +53,7 @@ void MonolithicApplication::init()
 Quassel::QuitHandler MonolithicApplication::quitHandler()
 {
     return [this]() {
+        quInfo() << "Client shutting down...";
         connect(_client.get(), SIGNAL(destroyed()), this, SLOT(onClientDestroyed()));
         _client.release()->deleteLater();
     };

--- a/src/qtui/qtuiapplication.cpp
+++ b/src/qtui/qtuiapplication.cpp
@@ -30,6 +30,7 @@
 
 #include "chatviewsettings.h"
 #include "cliparser.h"
+#include "logmessage.h"
 #include "mainwin.h"
 #include "qtui.h"
 #include "qtuisettings.h"
@@ -81,10 +82,6 @@ QtUiApplication::QtUiApplication(int &argc, char **argv)
 
 #endif /* HAVE_KDE4 */
 
-#if defined(HAVE_KDE4) || defined(Q_OS_MAC)
-    Quassel::disableCrashHandler();
-#endif /* HAVE_KDE4 || Q_OS_MAC */
-
     Quassel::setRunMode(Quassel::ClientOnly);
 
 #if QT_VERSION >= 0x050000
@@ -132,6 +129,7 @@ Quassel::QuitHandler QtUiApplication::quitHandler()
 {
     // Wait until the Client instance is destroyed before quitting the event loop
     return [this]() {
+        quInfo() << "Client shutting down...";
         connect(_client.get(), SIGNAL(destroyed()), QCoreApplication::instance(), SLOT(quit()));
         _client.release()->deleteLater();
     };


### PR DESCRIPTION
The set of functions we're allowed to safely use in a POSIX signal
handler is very limited, and certainly does not include anything Qt.
While our previous implementation seemingly worked anyway as long as
all it did was quitting the application, we now start seeing issues
when doing a proper shutdown.

Fix this by providing and using PosixSignalWatcher, which uses
socket notification to safely hand over control from the signal
handler to the Qt event loop.

NOTE: This is work-in-progress and needs to be made cross-platform.