### PR TITLE
client: Sort network name case-insensitively

### DIFF
--- a/src/uisupport/bufferviewfilter.cpp
+++ b/src/uisupport/bufferviewfilter.cpp
@@ -49,6 +49,8 @@ BufferViewFilter::BufferViewFilter(QAbstractItemModel *model, BufferViewConfig *
     setSourceModel(model);
 
     setDynamicSortFilter(true);
+    // Sort case-insensitively (primarily for network names; channels/nicks handled elsewhere)
+    setSortCaseSensitivity(Qt::CaseInsensitive);
 
     _enableEditMode.setCheckable(true);
     _enableEditMode.setChecked(_editMode);


### PR DESCRIPTION
## In short

* Sort buffer views case-insensitively, including network name
  * Primarily affects network name; channels/PMs already appear to be correctly sorted
  * Still able to rearrange channels/PMs when sorting is disabled
  * Doesn't provide control over sorting networks (same as before)

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | User-facing network sorting consistency
Risk | ★☆☆ *1/3* | Network order may change; [workflows might be upset](https://xkcd.com/1172/ )
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Rationale
Quassel sorts most things alphabetically in a case-insensitive manner, including the nickname list.  The network name list should also be sorted case-insensitively to match.

## Examples
### Setup
Add three networks, `Alpha`, `beta`, and `Freenode`.

### Before
* Alpha
* Freenode
* beta

### After
* Alpha
* beta
* Freenode