### PR TITLE
ircuser: Fix setting of away message time by pre-0.13 cores

### DIFF
--- a/src/common/ircuser.cpp
+++ b/src/common/ircuser.cpp
@@ -161,7 +161,7 @@ void IrcUser::setAccount(const QString &account)
 }
 
 
-void IrcUser::setAway(const bool &away)
+void IrcUser::setAway(bool away)
 {
     if (away != _away) {
         _away = away;
@@ -221,17 +221,16 @@ void IrcUser::setIrcOperator(const QString &ircOperator)
 
 // This function is only ever called by SYNC calls from legacy cores (pre-0.13).
 // Therefore, no SYNC call is needed here.
-void IrcUser::setLastAwayMessage(const int &lastAwayMessage)
+void IrcUser::setLastAwayMessage(int lastAwayMessage)
 {
-    QDateTime lastAwayMessageTime = QDateTime();
-    lastAwayMessageTime.setTimeSpec(Qt::UTC);
 #if QT_VERSION >= 0x050800
-    lastAwayMessageTime.fromSecsSinceEpoch(lastAwayMessage);
+    QDateTime lastAwayMessageTime = QDateTime::fromSecsSinceEpoch(lastAwayMessage);
 #else
     // toSecsSinceEpoch() was added in Qt 5.8.  Manually downconvert to seconds for now.
     // See https://doc.qt.io/qt-5/qdatetime.html#toMSecsSinceEpoch
-    lastAwayMessageTime.fromMSecsSinceEpoch(lastAwayMessage * 1000);
+    QDateTime lastAwayMessageTime = QDateTime::fromMSecsSinceEpoch(lastAwayMessage * 1000);
 #endif
+    lastAwayMessageTime.setTimeSpec(Qt::UTC);
     setLastAwayMessageTime(lastAwayMessageTime);
 }
 

--- a/src/common/ircuser.h
+++ b/src/common/ircuser.h
@@ -142,7 +142,7 @@ public slots:
      * @param[in] account Account name if logged in, * if logged out, or empty string if unknown
      */
     void setAccount(const QString &account);
-    void setAway(const bool &away);
+    void setAway(bool away);
     void setAwayMessage(const QString &awayMessage);
     void setIdleTime(const QDateTime &idleTime);
     void setLoginTime(const QDateTime &loginTime);
@@ -150,7 +150,7 @@ public slots:
     void setIrcOperator(const QString &ircOperator);
     // setLastAwayMessage is only called by legacy (pre-0.13) cores, which automatically gets
     // converted to setting the appropriate lastAwayMessageTime.  Do not use this in new code.
-    void setLastAwayMessage(const int &lastAwayMessage);
+    void setLastAwayMessage(int lastAwayMessage);
     void setLastAwayMessageTime(const QDateTime &lastAwayMessageTime);
     void setWhoisServiceReply(const QString &whoisServiceReply);
     void setSuserHost(const QString &suserHost);


### PR DESCRIPTION
IrcUser::setLastAwayMessage() is called by pre-0.13 cores (newer
cores call setLastAwayMessageTime() instead). Fix wrong use of
QDateTime::from[M]SecsSinceEpoch(), which is a static method returning
a new QDateTime instance rather than a modifying setter.

Also fix signatures passing primitive types as const refs.