### PR TITLE
Option to disable confirmation dialog for connecting to/disconnecting from all networks

### DIFF
--- a/src/qtui/settingspages/appearancesettingspage.ui
+++ b/src/qtui/settingspages/appearancesettingspage.ui
@@ -243,6 +243,19 @@
     </layout>
    </item>
    <item>
+    <widget class="QCheckBox" name="showConfirmConnectionDlg">
+     <property name="text">
+      <string>Confirm dialog for connecting to/disconnecting from all Networks</string>
+     </property>
+     <property name="settingsKey" stdset="0">
+      <string notr="true">ShowConfirmConnectionDlg</string>
+     </property>
+     <property name="defaultValue" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Message Redirection</string>

--- a/src/uisupport/networkmodelcontroller.cpp
+++ b/src/uisupport/networkmodelcontroller.cpp
@@ -38,6 +38,7 @@
 #include "icon.h"
 #include "network.h"
 #include "util.h"
+#include "../qtui/qtuisettings.h"
 
 NetworkModelController::NetworkModelController(QObject *parent)
     : QObject(parent),
@@ -238,10 +239,13 @@ void NetworkModelController::actionTriggered(QAction *action)
 void NetworkModelController::handleNetworkAction(ActionType type, QAction *)
 {
     if (type == NetworkConnectAllWithDropdown || type == NetworkDisconnectAllWithDropdown || type == NetworkConnectAll || type == NetworkDisconnectAll) {
-        if (type == NetworkConnectAllWithDropdown && QMessageBox::question(0, tr("Question"), tr("Really Connect to all IRC Networks?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::No)
-            return;
-        if (type == NetworkDisconnectAllWithDropdown && QMessageBox::question(0, tr("Question"), tr("Really disconnect from all IRC Networks?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)
-            return;
+        QtUiSettings s;
+        if (s.value("ShowConfirmConnectionDlg").toBool()) {
+            if (type == NetworkConnectAllWithDropdown && QMessageBox::question(0, tr("Question"), tr("Really Connect to all IRC Networks?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::No)
+                return;
+            if (type == NetworkDisconnectAllWithDropdown && QMessageBox::question(0, tr("Question"), tr("Really disconnect from all IRC Networks?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)
+                return;
+        }
         foreach(NetworkId id, Client::networkIds()) {
             const Network *net = Client::network(id);
             if ((type == NetworkConnectAllWithDropdown || type == NetworkConnectAll) && net->connectionState() == Network::Disconnected)


### PR DESCRIPTION
Confirmation dialogs can annoy users so this PR gives users the ability to disable the confirmation dialog for connecting to/disconnecting from all networks. I'm not sure if the AppearanceSettingsPage is the right place for the checkbox, but I think that is still the best fit.