### PR TITLE
cmake: Move libraries into a private directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,18 +422,10 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 # These RPATH settings allow for running directly from the build dir
 set(CMAKE_SKIP_BUILD_RPATH            FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH    FALSE)
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE )
 
-# Set install RPATH only if libdir isn't a system directory
-if (IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
-    set(libdir "${CMAKE_INSTALL_LIBDIR}")
-else()
-    set(libdir "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-endif()
-list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${libdir}" is_systemdir)
-if ("${is_systemdir}" STREQUAL "-1")
-   set(CMAKE_INSTALL_RPATH "${libdir}")
-endif()
+# Set RPATH for Quassel's private libraries
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}/quassel")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE )
 
 # Various config-dependent checks and settings
 #####################################################################

--- a/cmake/QuasselInstallDirs.cmake
+++ b/cmake/QuasselInstallDirs.cmake
@@ -18,10 +18,10 @@ if (NOT WITH_KDE)
         # On Windows, we have to guess good paths
         # We must check if the variables are already defined on the command line
         if (NOT DEFINED CMAKE_INSTALL_BINDIR)
-            set(CMAKE_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Install path for binaries")
+            set(CMAKE_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Install path for executables and DLLs")
         endif()
         if (NOT DEFINED CMAKE_INSTALL_LIBDIR)
-            set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Install path for libraries")
+            set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Install path for static libraries")
         endif()
         if (NOT DEFINED CMAKE_INSTALL_DATADIR)
             set(CMAKE_INSTALL_DATADIR "$ENV{APPDATA}/quassel-irc.org/share/apps" CACHE PATH "Install path for data files")

--- a/cmake/QuasselMacros.cmake
+++ b/cmake/QuasselMacros.cmake
@@ -69,8 +69,8 @@ function(quassel_add_module _module)
     if (buildmode STREQUAL "SHARED" AND NOT ${ARG_NOINSTALL})
         install(TARGETS ${target}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/quassel
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/quassel
         )
     endif()
 


### PR DESCRIPTION
Since Quassel's libraries are not meant for public consumption,
move them from libdir into libdir/quassel. Always set RPATH
accordingly, so the executables find their libraries.

On Windows, DLLs count as runtime artifacts rather than libraries,
so they remain unaffected and stay in the bindir.