### PR TITLE
Increase warning level on MSVC; fix warnings, make fatal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ script:
                             -GNinja \
                             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                             -DBUILD_TESTING=ON \
+                            -DFATAL_WARNINGS=ON \
                       && ninja install \
                       && ccache -s \
                       && ctest -VV \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ if (NOT EMBED_DEFAULT)
 endif()
 
 # The following options are not for end-user consumption, so don't list them in the feature summary
+option(FATAL_WARNINGS "Make compile warnings fatal (most useful for CI builds)" OFF)
 cmake_dependent_option(DEPLOY "Add required libs to bundle resources and create a dmg" OFF "APPLE" OFF)
 
 # List of authenticators and the cmake flags to build them

--- a/cmake/QuasselCompileSettings.cmake
+++ b/cmake/QuasselCompileSettings.cmake
@@ -45,6 +45,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         -Wundef
         -Wvla
         -Werror=return-type
+        "$<$<BOOL:${FATAL_WARNINGS}>:-Werror>"
         -Wno-unknown-pragmas
         "$<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=2>"
     )
@@ -68,7 +69,10 @@ elseif(MSVC)
     add_definitions(-DWIN32_LEAN_AND_MEAN -DUNICODE -D_UNICODE -D_USE_MATH_DEFINES -DNOMINMAX)
 
     # Compile options
-    add_compile_options(/EHsc)
+    add_compile_options(
+        /EHsc
+        "$<$<BOOL:${FATAL_WARNINGS}>:/WX>"
+    )
 
     # Increase warning level on MSVC
     # CMake puts /W3 in CMAKE_CXX_FLAGS which will be appended later, so we need to replace

--- a/cmake/QuasselCompileSettings.cmake
+++ b/cmake/QuasselCompileSettings.cmake
@@ -68,7 +68,22 @@ elseif(MSVC)
     add_definitions(-DWIN32_LEAN_AND_MEAN -DUNICODE -D_UNICODE -D_USE_MATH_DEFINES -DNOMINMAX)
 
     # Compile options
-    add_compile_options(-EHsc -W3)
+    add_compile_options(/EHsc)
+
+    # Increase warning level on MSVC
+    # CMake puts /W3 in CMAKE_CXX_FLAGS which will be appended later, so we need to replace
+    message(STATUS "CXX ${CMAKE_CXX_FLAGS} REL ${CMAKE_CXX_FLAGS_RELEASE} DEB ${CMAKE_CXX_FLAGS_DEBUG}")
+    string(REPLACE "/W3" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+    # Silence annoying/useless warnings
+    #   C4127: conditional expression is constant
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4127")
+    #   C4244: 'identifier': conversion from 't1' to 't2', possible loss of data
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
+    #   C4456: declaration of 'identifier' hides previous local declaration
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4456")
+    #   C4458: declaration of 'identifier' hides class member
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4458")
 
     # Link against the correct version of the C runtime
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/NODEFAULTLIB:libcmt /DEFAULTLIB:msvcrt ${CMAKE_EXE_LINKER_FLAGS_RELEASE}")

--- a/cmake/QuasselInstallDirs.cmake
+++ b/cmake/QuasselInstallDirs.cmake
@@ -18,10 +18,10 @@ if (NOT WITH_KDE)
         # On Windows, we have to guess good paths
         # We must check if the variables are already defined on the command line
         if (NOT DEFINED CMAKE_INSTALL_BINDIR)
-            set(CMAKE_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Install path for binaries")
+            set(CMAKE_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Install path for executables and DLLs")
         endif()
         if (NOT DEFINED CMAKE_INSTALL_LIBDIR)
-            set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Install path for libraries")
+            set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Install path for static libraries")
         endif()
         if (NOT DEFINED CMAKE_INSTALL_DATADIR)
             set(CMAKE_INSTALL_DATADIR "$ENV{APPDATA}/quassel-irc.org/share/apps" CACHE PATH "Install path for data files")

--- a/src/client/clientauthhandler.cpp
+++ b/src/client/clientauthhandler.cpp
@@ -33,8 +33,6 @@
 #include "peerfactory.h"
 #include "util.h"
 
-using namespace Protocol;
-
 ClientAuthHandler::ClientAuthHandler(CoreAccount account, QObject* parent)
     : AuthHandler(parent)
     , _peer(nullptr)
@@ -294,16 +292,16 @@ void ClientAuthHandler::startRegistration()
     useSsl = _account.useSsl();
 #endif
 
-    _peer->dispatch(RegisterClient(Quassel::Features{}, Quassel::buildInfo().fancyVersionString, Quassel::buildInfo().commitDate, useSsl));
+    _peer->dispatch(Protocol::RegisterClient(Quassel::Features{}, Quassel::buildInfo().fancyVersionString, Quassel::buildInfo().commitDate, useSsl));
 }
 
-void ClientAuthHandler::handle(const ClientDenied& msg)
+void ClientAuthHandler::handle(const Protocol::ClientDenied& msg)
 {
     emit errorPopup(msg.errorString);
     requestDisconnect(tr("The core refused connection from this client"));
 }
 
-void ClientAuthHandler::handle(const ClientRegistered& msg)
+void ClientAuthHandler::handle(const Protocol::ClientRegistered& msg)
 {
     _coreConfigured = msg.coreConfigured;
     _backendInfo = msg.backendInfo;
@@ -340,17 +338,17 @@ void ClientAuthHandler::onConnectionReady()
         login();
 }
 
-void ClientAuthHandler::setupCore(const SetupData& setupData)
+void ClientAuthHandler::setupCore(const Protocol::SetupData& setupData)
 {
     _peer->dispatch(setupData);
 }
 
-void ClientAuthHandler::handle(const SetupFailed& msg)
+void ClientAuthHandler::handle(const Protocol::SetupFailed& msg)
 {
     emit coreSetupFailed(msg.errorString);
 }
 
-void ClientAuthHandler::handle(const SetupDone& msg)
+void ClientAuthHandler::handle(const Protocol::SetupDone& msg)
 {
     Q_UNUSED(msg)
 
@@ -377,22 +375,22 @@ void ClientAuthHandler::login(const QString& previousError)
         }
     }
 
-    _peer->dispatch(Login(_account.user(), _account.password()));
+    _peer->dispatch(Protocol::Login(_account.user(), _account.password()));
 }
 
-void ClientAuthHandler::handle(const LoginFailed& msg)
+void ClientAuthHandler::handle(const Protocol::LoginFailed& msg)
 {
     login(msg.errorString);
 }
 
-void ClientAuthHandler::handle(const LoginSuccess& msg)
+void ClientAuthHandler::handle(const Protocol::LoginSuccess& msg)
 {
     Q_UNUSED(msg)
 
     emit loginSuccessful(_account);
 }
 
-void ClientAuthHandler::handle(const SessionState& msg)
+void ClientAuthHandler::handle(const Protocol::SessionState& msg)
 {
     disconnect(socket(), nullptr, this, nullptr);  // this is the last message we shall ever get
 

--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -405,7 +405,6 @@ bool BufferItem::setData(int column, const QVariant& value, int role)
     default:
         return PropertyMapItem::setData(column, value, role);
     }
-    return true;
 }
 
 void BufferItem::setBufferName(const QString& name)

--- a/src/qtui/settingspages/shortcutsmodel.cpp
+++ b/src/qtui/settingspages/shortcutsmodel.cpp
@@ -77,18 +77,8 @@ QModelIndex ShortcutsModel::index(int row, int column, const QModelIndex& parent
     return createIndex(row, column, _categoryItems.at(row));
 }
 
-int ShortcutsModel::columnCount(const QModelIndex& parent) const
+int ShortcutsModel::columnCount(const QModelIndex&) const
 {
-    return 2;
-    if (!parent.isValid())
-        return 2;
-
-    auto* item = static_cast<Item*>(parent.internalPointer());
-    Q_ASSERT(item);
-
-    if (!item->parentItem)
-        return 2;
-
     return 2;
 }
 

--- a/src/uisupport/bufferview.cpp
+++ b/src/uisupport/bufferview.cpp
@@ -575,24 +575,6 @@ void BufferView::filterTextChanged(const QString& filterString)
     on_configChanged();  // make sure collapsation is correct
 }
 
-QSize BufferView::sizeHint() const
-{
-    return TreeViewTouch::sizeHint();
-
-    if (!model())
-        return TreeViewTouch::sizeHint();
-
-    if (model()->rowCount() == 0)
-        return {120, 50};
-
-    int columnSize = 0;
-    for (int i = 0; i < model()->columnCount(); i++) {
-        if (!isColumnHidden(i))
-            columnSize += sizeHintForColumn(i);
-    }
-    return {columnSize, 50};
-}
-
 void BufferView::changeHighlight(BufferView::Direction direction)
 {
     // If for some weird reason we get a new delegate

--- a/src/uisupport/bufferview.h
+++ b/src/uisupport/bufferview.h
@@ -83,7 +83,6 @@ protected:
     void dropEvent(QDropEvent* event) override;
     void rowsInserted(const QModelIndex& parent, int start, int end) override;
     void wheelEvent(QWheelEvent*) override;
-    QSize sizeHint() const override;
     void focusInEvent(QFocusEvent* event) override { QAbstractScrollArea::focusInEvent(event); }
     void contextMenuEvent(QContextMenuEvent* event) override;
 

--- a/src/uisupport/graphicalui.cpp
+++ b/src/uisupport/graphicalui.cpp
@@ -144,38 +144,26 @@ bool GraphicalUi::eventFilter(QObject* obj, QEvent* event)
 
 bool GraphicalUi::checkMainWidgetVisibility(bool perform)
 {
+    bool needsActivation{true};
+
 #ifdef Q_OS_WIN
     // the problem is that we lose focus when the systray icon is activated
     // and we don't know the former active window
     // therefore we watch for activation event and use our stopwatch :)
     if (GetTickCount() - _dwTickCount < 300) {
         // we were active in the last 300ms -> hide it
-        if (perform)
-            minimizeRestore(false);
-        return false;
+        needsActivation = false;
     }
-    else {
-        if (perform)
-            minimizeRestore(true);
-        return true;
-    }
-
 #else
-
-    if (!mainWidget()->isVisible() || mainWidget()->isMinimized() || !mainWidget()->isActiveWindow()) {
-        if (perform)
-            minimizeRestore(true);
-        return true;
+    if (mainWidget()->isVisible() && !mainWidget()->isMinimized() && mainWidget()->isActiveWindow()) {
+        needsActivation = false;
     }
-    else {
-        if (perform)
-            minimizeRestore(false);
-        return false;
-    }
-
 #endif
 
-    return true;
+    if (perform) {
+        minimizeRestore(needsActivation);
+    }
+    return needsActivation;
 }
 
 bool GraphicalUi::isMainWidgetVisible()


### PR DESCRIPTION
Increase the warning level on MSVC. Fix some warnings that have been found by this. Add a CMake options to make warnings fatal, and enable in Travis (for Appveyor, we'll need to update the blueprint).