### PR TITLE
cmake: Fix OSX post-build if not all targets are requested

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -40,7 +40,7 @@ if (WANT_CORE)
     setup_executable(quasselcore -DBUILD_CORE Qt5::Core Quassel::Core)
 endif()
 
-if (WANT_CLIENT OR WANT_QTCLIENT)
+if (WANT_QTCLIENT)
     add_executable(quasselclient WIN32 main.cpp ${WIN_RC})
     setup_executable(quasselclient -DBUILD_QTUI Qt5::Core Qt5::Gui Quassel::QtUi)
     if (WITH_KDE)
@@ -58,19 +58,29 @@ endif()
 
 # Build bundles for MacOSX
 if (APPLE)
-    add_custom_command(TARGET quasselclient POST_BUILD
-                       COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makebundle.py
-                               ${CMAKE_SOURCE_DIR} "Quassel Client" ${CMAKE_BINARY_DIR}/quasselclient)
+    if (WANT_QTCLIENT)
+        add_custom_command(TARGET quasselclient POST_BUILD
+                           COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makebundle.py
+                                   ${CMAKE_SOURCE_DIR} "Quassel Client" ${CMAKE_BINARY_DIR}/quasselclient)
+    endif()
+    if (WANT_MONO)
+        add_custom_command(TARGET quassel POST_BUILD
+                           COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makebundle.py
+                                   ${CMAKE_SOURCE_DIR} "Quassel" ${CMAKE_BINARY_DIR}/quassel)
+    endif()
 
-    add_custom_command(TARGET quassel POST_BUILD
-                       COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makebundle.py
-                               ${CMAKE_SOURCE_DIR} "Quassel" ${CMAKE_BINARY_DIR}/quassel)
     if (DEPLOY)
-        add_custom_command(TARGET quasselclient POST_BUILD WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-                           COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makePackage.sh Client ${CMAKE_BINARY_DIR} qsvgicon)
-        add_custom_command(TARGET quasselcore POST_BUILD WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-                           COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makePackage.sh Core ${CMAKE_BINARY_DIR})
-        add_custom_command(TARGET quassel POST_BUILD WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-                           COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makePackage.sh Mono ${CMAKE_BINARY_DIR} qsvgicon)
+        if (WANT_QTCLIENT)
+            add_custom_command(TARGET quasselclient POST_BUILD WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                               COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makePackage.sh Client ${CMAKE_BINARY_DIR} qsvgicon)
+        endif()
+        if (WANT_CORE)
+            add_custom_command(TARGET quasselcore POST_BUILD WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                               COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makePackage.sh Core ${CMAKE_BINARY_DIR})
+        endif()
+        if (WANT_MONO)
+            add_custom_command(TARGET quassel POST_BUILD WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                               COMMAND ${CMAKE_SOURCE_DIR}/scripts/build/macosx_makePackage.sh Mono ${CMAKE_BINARY_DIR} qsvgicon)
+        endif()
     endif()
 endif()


### PR DESCRIPTION
The post-build actions for OSX were not conditional on the selected
Quassel variants, so add_custom_command would be added to an undefined
target in that case.

This bug has been there since literally forever; however, CMake < 3.0
silently ignored the custom commands in that case, and thus this
issue was not visible.

With cmake_minimum_required now set to 3.5, the new behavior is
enabled and causes an error at configure time. Fix this by adding
the missing conditions.