### PR TITLE
cmake: Add missing Boost dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,14 @@ set_package_properties(Boost PROPERTIES TYPE REQUIRED
     URL "https://www.boost.org/"
     DESCRIPTION "Boost libraries for C++"
 )
+# Older versions don't define the imported target
+if (NOT TARGET Boost::boost)
+    add_library(Boost::boost INTERFACE IMPORTED GLOBAL)
+    if (Boost_INCLUDE_DIRS)
+        set_target_properties(Boost::boost PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
+    endif()
+endif()
 
 find_package(ZLIB REQUIRED)
 set_package_properties(ZLIB PROPERTIES TYPE REQUIRED

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -62,6 +62,7 @@ target_include_directories(${TARGET} PRIVATE ${CMAKE_BINARY_DIR})
 
 target_link_libraries(${TARGET} PUBLIC
     ${CMAKE_DL_LIBS}
+    Boost::boost
     Qt5::Core
     Qt5::Network
     ZLIB::ZLIB

--- a/src/test/util/CMakeLists.txt
+++ b/src/test/util/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${TARGET} PRIVATE
 
 target_link_libraries(${TARGET}
     PUBLIC
+        Boost::boost
         Quassel::Common
         Quassel::Test::Global
 )


### PR DESCRIPTION
Add a dependency to Boost in the modules that use Boost already,
so Boost headers installed in a non-standard location are found.