### PR TITLE
client: Don't use list initialization for QStringList

### DIFF
--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -55,7 +55,7 @@ NetworkItem::NetworkItem(const NetworkId &netid, AbstractTreeItem *parent)
 
 QStringList NetworkItem::propertyOrder() const
 {
-    static QStringList order{"networkName", "currentServer", "nickCount"};
+    static auto order = QStringList() << "networkName" << "currentServer" << "nickCount";
     return order;
 }
 
@@ -300,7 +300,7 @@ BufferItem::BufferItem(const BufferInfo &bufferInfo, AbstractTreeItem *parent)
 
 QStringList BufferItem::propertyOrder() const
 {
-    static QStringList order{"bufferName", "topic", "nickCount"};
+    static auto order = QStringList() << "bufferName" << "topic" << "nickCount";
     return order;
 }
 


### PR DESCRIPTION
The minimal build requirements we defined for the 0.13 branch don't
support list initialization for QStringList, so replace the two
places where we accidentally slipped that in by the legacy way
of doing things.