### PR TITLE
Fixes for identd and config-from-environment

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -189,7 +189,9 @@ void Core::init()
             quInfo() << "Core is currently not configured! Please connect with a Quassel Client for basic setup.";
         }
     }
-    else {
+
+    // This checks separately because config-from-environment might have only configured the core just now
+    if (_configured) {
         if (Quassel::isOptionSet("add-user")) {
             bool success = createUser();
             throw ExitException{success ? EXIT_SUCCESS : EXIT_FAILURE};

--- a/src/core/identserver.cpp
+++ b/src/core/identserver.cpp
@@ -37,20 +37,20 @@ bool IdentServer::startListening()
     uint16_t port = Quassel::optionValue("ident-port").toUShort();
 
     bool success = false;
-    if (_v6server.listen(QHostAddress("::1"), port)) {
+    if (_v6server.listen(QHostAddress("::"), port)) {
         quInfo() << qPrintable(
                 tr("Listening for identd clients on IPv6 %1 port %2")
-                        .arg("::1")
+                        .arg("::")
                         .arg(_v6server.serverPort())
         );
 
         success = true;
     }
 
-    if (_server.listen(QHostAddress("127.0.0.1"), port)) {
+    if (_server.listen(QHostAddress("0.0.0.0"), port)) {
         quInfo() << qPrintable(
                 tr("Listening for identd clients on IPv4 %1 port %2")
-                        .arg("127.0.0.1")
+                        .arg("0.0.0.0")
                         .arg(_server.serverPort())
         );
 


### PR DESCRIPTION
The internal identd is now listening on all adresses, which makes it easier for users to run the core with the required capability and without a proxy. This also makes it possible to run the core in containers, as there incoming packets are never from localhost (but usually somewhere within of 10.0.0.0/8)

Additionally, in case the core has just now been configured from environment, the core would usually ignore all options. This has now been fixed.