### PR TITLE
[master] core: Internal identd listen all, fix config-from-env

### DIFF
--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -358,7 +358,7 @@ void Quassel::setupCliParser()
              tr("The port quasselcore will listen at for ident requests. Only meaningful with --ident-daemon."),
              tr("port"),
              "10113"},
-            {"ident-listen", tr("The address(es) quasselcore will listen on for ident requests."), tr("<address>[,<address>[,...]]"), "::1,127.0.0.1"},
+            {"ident-listen", tr("The address(es) quasselcore will listen on for ident requests. Same format as --listen."), tr("<address>[,...]"), "::1,127.0.0.1"},
             {"oidentd", tr("Enable oidentd integration. In most cases you should also enable --strict-ident.")},
             {"oidentd-conffile", tr("Set path to oidentd configuration file."), tr("file")},
 #ifdef HAVE_SSL

--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -358,6 +358,7 @@ void Quassel::setupCliParser()
              tr("The port quasselcore will listen at for ident requests. Only meaningful with --ident-daemon."),
              tr("port"),
              "10113"},
+            {"ident-listen", tr("The address(es) quasselcore will listen on for ident requests."), tr("<address>[,<address>[,...]]"), "::1,127.0.0.1"},
             {"oidentd", tr("Enable oidentd integration. In most cases you should also enable --strict-ident.")},
             {"oidentd-conffile", tr("Set path to oidentd configuration file."), tr("file")},
 #ifdef HAVE_SSL

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -187,7 +187,9 @@ void Core::init()
             qInfo() << "Core is currently not configured! Please connect with a Quassel Client for basic setup.";
         }
     }
-    else {
+
+    // This checks separately because config-from-environment might have only configured the core just now
+    if (_configured) {
         if (Quassel::isOptionSet("add-user")) {
             bool success = createUser();
             throw ExitException{success ? EXIT_SUCCESS : EXIT_FAILURE};

--- a/src/core/identserver.cpp
+++ b/src/core/identserver.cpp
@@ -36,14 +36,14 @@ bool IdentServer::startListening()
     uint16_t port = Quassel::optionValue("ident-port").toUShort();
 
     bool success = false;
-    if (_v6server.listen(QHostAddress("::1"), port)) {
-        qInfo() << qPrintable(tr("Listening for identd clients on IPv6 %1 port %2").arg("::1").arg(_v6server.serverPort()));
+    if (_v6server.listen(QHostAddress("::"), port)) {
+        qInfo() << qPrintable(tr("Listening for identd clients on IPv6 %1 port %2").arg("::").arg(_v6server.serverPort()));
 
         success = true;
     }
 
-    if (_server.listen(QHostAddress("127.0.0.1"), port)) {
-        qInfo() << qPrintable(tr("Listening for identd clients on IPv4 %1 port %2").arg("127.0.0.1").arg(_server.serverPort()));
+    if (_server.listen(QHostAddress("0.0.0.1"), port)) {
+        qInfo() << qPrintable(tr("Listening for identd clients on IPv4 %1 port %2").arg("0.0.0.1").arg(_server.serverPort()));
 
         success = true;
     }


### PR DESCRIPTION
The internal identd is now listening on all adresses, which makes it easier for users to run the core with the required capability and without a proxy. This also makes it possible to run the core in containers, as there incoming packets are never from localhost (but usually somewhere within of 10.0.0.0/8)

Additionally, in case the core has just now been configured from environment, the core would usually ignore all options. This has now been fixed.