### PR TITLE
[0.13] core: Internal identd listen all, fix config-from-env

### DIFF
--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -197,6 +197,7 @@ int main(int argc, char **argv)
     cliParser->addSwitch("strict-ident", 0, "Use users' quasselcore username as ident reply. Ignores each user's configured ident setting.");
     cliParser->addSwitch("ident-daemon", 0, "Enable internal ident daemon");
     cliParser->addOption("ident-port", 0, "The port quasselcore will listen at for ident requests. Only meaningful with --ident-daemon", "port", "10113");
+    cliParser->addOption("ident-listen", 0, "The address(es) quasselcore will listen on for ident requests", "<address>[,<address>[,...]]", "::1,127.0.0.1");
 #ifdef HAVE_SSL
     cliParser->addSwitch("require-ssl", 0, "Require SSL for remote (non-loopback) client connections");
     cliParser->addOption("ssl-cert", 0, "Specify the path to the SSL Certificate", "path", "configdir/quasselCert.pem");

--- a/src/common/main.cpp
+++ b/src/common/main.cpp
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
     cliParser->addSwitch("strict-ident", 0, "Use users' quasselcore username as ident reply. Ignores each user's configured ident setting.");
     cliParser->addSwitch("ident-daemon", 0, "Enable internal ident daemon");
     cliParser->addOption("ident-port", 0, "The port quasselcore will listen at for ident requests. Only meaningful with --ident-daemon", "port", "10113");
-    cliParser->addOption("ident-listen", 0, "The address(es) quasselcore will listen on for ident requests", "<address>[,<address>[,...]]", "::1,127.0.0.1");
+    cliParser->addOption("ident-listen", 0, "The address(es) quasselcore will listen on for ident requests. Same format as --listen.", "<address>[,...]", "::1,127.0.0.1");
 #ifdef HAVE_SSL
     cliParser->addSwitch("require-ssl", 0, "Require SSL for remote (non-loopback) client connections");
     cliParser->addOption("ssl-cert", 0, "Specify the path to the SSL Certificate", "path", "configdir/quasselCert.pem");

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -189,7 +189,9 @@ void Core::init()
             quInfo() << "Core is currently not configured! Please connect with a Quassel Client for basic setup.";
         }
     }
-    else {
+
+    // This checks separately because config-from-environment might have only configured the core just now
+    if (_configured) {
         if (Quassel::isOptionSet("add-user")) {
             bool success = createUser();
             throw ExitException{success ? EXIT_SUCCESS : EXIT_FAILURE};

--- a/src/core/identserver.cpp
+++ b/src/core/identserver.cpp
@@ -37,20 +37,20 @@ bool IdentServer::startListening()
     uint16_t port = Quassel::optionValue("ident-port").toUShort();
 
     bool success = false;
-    if (_v6server.listen(QHostAddress("::1"), port)) {
+    if (_v6server.listen(QHostAddress("::"), port)) {
         quInfo() << qPrintable(
                 tr("Listening for identd clients on IPv6 %1 port %2")
-                        .arg("::1")
+                        .arg("::")
                         .arg(_v6server.serverPort())
         );
 
         success = true;
     }
 
-    if (_server.listen(QHostAddress("127.0.0.1"), port)) {
+    if (_server.listen(QHostAddress("0.0.0.0"), port)) {
         quInfo() << qPrintable(
                 tr("Listening for identd clients on IPv4 %1 port %2")
-                        .arg("127.0.0.1")
+                        .arg("0.0.0.0")
                         .arg(_server.serverPort())
         );
 

--- a/src/core/identserver.cpp
+++ b/src/core/identserver.cpp
@@ -34,27 +34,65 @@ IdentServer::IdentServer(QObject *parent)
 
 bool IdentServer::startListening()
 {
+    bool success = false;
+
     uint16_t port = Quassel::optionValue("ident-port").toUShort();
 
-    bool success = false;
-    if (_v6server.listen(QHostAddress("::"), port)) {
-        quInfo() << qPrintable(
-                tr("Listening for identd clients on IPv6 %1 port %2")
-                        .arg("::")
-                        .arg(_v6server.serverPort())
-        );
-
-        success = true;
-    }
-
-    if (_server.listen(QHostAddress("0.0.0.0"), port)) {
-        quInfo() << qPrintable(
-                tr("Listening for identd clients on IPv4 %1 port %2")
-                        .arg("0.0.0.0")
-                        .arg(_server.serverPort())
-        );
-
-        success = true;
+    const QString listen = Quassel::optionValue("ident-listen");
+    const QStringList listen_list = listen.split(",", QString::SkipEmptyParts);
+    for (const QString &listen_term : listen_list) { // TODO: handle multiple interfaces for same TCP version gracefully
+        QHostAddress addr;
+        if (!addr.setAddress(listen_term)) {
+            qCritical() << qPrintable(
+                    tr("Invalid listen address %1")
+                            .arg(listen_term)
+            );
+        }
+        else {
+            switch (addr.protocol()) {
+                case QAbstractSocket::IPv6Protocol:
+                    if (_v6server.listen(addr, port)) {
+                        quInfo() << qPrintable(
+                                tr("Listening for identd requests on IPv6 %1 port %2")
+                                        .arg(addr.toString())
+                                        .arg(_v6server.serverPort())
+                        );
+                        success = true;
+                    }
+                    else
+                        quWarning() << qPrintable(
+                                tr("Could not open IPv6 interface %1:%2: %3")
+                                        .arg(addr.toString())
+                                        .arg(port)
+                                        .arg(_v6server.errorString()));
+                    break;
+                case QAbstractSocket::IPv4Protocol:
+                    if (_server.listen(addr, port)) {
+                        quInfo() << qPrintable(
+                                tr("Listening for identd requests on IPv4 %1 port %2")
+                                        .arg(addr.toString())
+                                        .arg(_server.serverPort())
+                        );
+                        success = true;
+                    }
+                    else {
+                        // if v6 succeeded on Any, the port will be already in use - don't display the error then
+                        if (!success || _server.serverError() != QAbstractSocket::AddressInUseError)
+                            quWarning() << qPrintable(
+                                    tr("Could not open IPv4 interface %1:%2: %3")
+                                            .arg(addr.toString())
+                                            .arg(port)
+                                            .arg(_server.errorString()));
+                    }
+                    break;
+                default:
+                    qCritical() << qPrintable(
+                            tr("Invalid listen address %1, unknown network protocol")
+                                    .arg(listen_term)
+                    );
+                    break;
+            }
+        }
     }
 
     if (!success) {


### PR DESCRIPTION
## In short

* Allow specifying internal identd listening addresses, not just local
* Fix `--config-from-environment` first-time setup ignoring other CLI arguments

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes first-time ENV configuration, allows identd without oidentd
Risk | ★☆☆ *1/3* | Opens internal identd, users should be careful
Intrusiveness | ★★☆ *2/3* | New log strings, shouldn't interfere with other pull requests

*All credit to @justJanne including the work backporting - this is just opening the PR and doing a basic test.*

## Rationale
See the [`master` branch pull request #457, "Fixes for identd and config-from-environment"](https://github.com/quassel/quassel/pull/457 ).

## Example
### Quassel core: default

**Command**

```
$ ./run-quasselcore.sh --ident-daemon
```

**Outcome**

*Quassel core identd is listening on local addresses.*

```
$ netstat --listen
tcp        0      0 localhost:10113         *:*                     LISTEN
tcp6       0      0 ip6-localhost:10113     [::]:*                  LISTEN
```

### Quassel core: all addresses

**Command**

```
$ ./run-quasselcore.sh --ident-daemon --ident-listen ::,0.0.0.0
```

**Outcome**

*Quassel core identd is listening on all addresses.*

```
$ netstat --listen
tcp        0      0 *:10113                 *:*                     LISTEN
tcp6       0      0 [::]:10113              [::]:*                  LISTEN
```

### Quassel core: all IPv6, unavailable IPv4

**Command**

```
$ ./run-quasselcore.sh --ident-daemon --ident-listen ::,1.1.1.1
```

**Outcome**

*Quassel core identd is listening on all IPv6 addresses, no IPv4.*

```
$ netstat --listen
tcp6       0      0 [::]:10113              [::]:*                  LISTEN
```

```
2019-02-13 02:15:43 [Info ] Listening for GUI clients on IPv6 :: port 4242 using protocol version 10 
2019-02-13 02:15:43 [Info ] Listening for GUI clients on IPv4 0.0.0.0 port 4242 using protocol version 10 
2019-02-13 02:15:43 [Info ] Listening for identd requests on IPv6 :: port 10113 
2019-02-13 02:15:43 [Warn ] Could not open IPv4 interface 1.1.1.1:10113: The address is not available 
2019-02-13 02:15:43 [Info ] Restoring previous core state...
```

### Quassel core: all IPv6, local IPv4

**Command**

```
$ ./run-quasselcore.sh --ident-daemon --ident-listen ::,127.0.0.1
```

**Outcome**

*Quassel core identd is listening on all IPv6 addresses, only local IPv4.*

```
$ netstat --listen
tcp        0      0 localhost:10113         *:*                     LISTEN
tcp6       0      0 [::]:10113              [::]:*                  LISTEN
```

### Quassel core: all IPv6, local IPv4, custom port

**Command**

```
$ ./run-quasselcore.sh --ident-daemon --ident-listen ::,127.0.0.1 --ident-port 55555
```

**Outcome**

*Quassel core identd is listening on all IPv6 addresses, only local IPv4, on port 55555.*

```
$ netstat --listen
tcp        0      0 localhost:55555         *:*                     LISTEN
tcp6       0      0 [::]:55555              [::]:*                  LISTEN
```

### Quassel core Qt 4: default

**Command**

```
$ ./run-quasselcore.sh --ident-daemon
```

**Outcome**

*Quassel core identd is listening on local addresses.*

```
$ netstat --listen
tcp        0      0 localhost:10113         *:*                     LISTEN
tcp6       0      0 ip6-localhost:10113     [::]:*                  LISTEN
```

### Quassel core Qt 4: all addresses

**Command**

*Note: the Qt 4 argument parser requires an `=` to set long options.*

```
$ ./run-quasselcore.sh --ident-daemon --ident-listen=::,0.0.0.0
```

**Outcome**

*Quassel core identd is listening on all addresses.*

```
$ netstat --listen
tcp6       0      0 [::]:10113              [::]:*                  LISTEN
```

**Despite not showing up in `netstat`, `nmap "localhost" -p 10113` shows the port as open.**  IPv4v6 dual-listening, perhaps..?

```
2019-02-13 02:42:33 [Info ] Listening for GUI clients on IPv6 :: port 4242 using protocol version 10 
2019-02-13 02:42:33 [Info ] Listening for identd requests on IPv6 :: port 10113 
2019-02-13 02:42:33 [Info ] Restoring previous core state...
```

### Quassel core Qt 4: all IPv6, unavailable IPv4

**Command**

```
$ ./run-quasselcore.sh --ident-daemon --ident-listen=::,1.1.1.1
```

**Outcome**

*Quassel core identd is listening on all IPv6 addresses, no IPv4.*

```
$ netstat --listen
tcp6       0      0 [::]:10113              [::]:*                  LISTEN
```

```
2019-02-13 02:49:06 [Info ] Listening for GUI clients on IPv6 :: port 4242 using protocol version 10 
2019-02-13 02:49:06 [Info ] Listening for identd requests on IPv6 :: port 10113 
2019-02-13 02:49:06 [Warn ] Could not open IPv4 interface 1.1.1.1:10113: The address is not available 
2019-02-13 02:49:06 [Info ] Restoring previous core state...
```

### Quassel core Qt 4: all IPv6, local IPv4

**Command**

```
$ ./run-quasselcore.sh --ident-daemon --ident-listen=::,127.0.0.1
```

**Outcome**

*Quassel core identd is listening on all IPv6 addresses, and likely all IPv4.*  This appears to be a Qt 4 limitation.  See earlier tests.

```
$ netstat --listen
tcp6       0      0 [::]:10113              [::]:*                  LISTEN
```

### Quassel core Qt 4: all IPv6, local IPv4, custom port

**Command**

```
$ ./run-quasselcore.sh --ident-daemon --ident-listen=::,127.0.0.1 --ident-port=55555
```

**Outcome**

*Quassel core identd is listening on all IPv6 addresses, and likely all IPv4, on port 55555.*  This appears to be a Qt 4 limitation.  See earlier tests.

```
$ netstat --listen
tcp6       0      0 [::]:55555              [::]:*                  LISTEN
```

*I haven't tested the `--config-from-environment` changes, but @justJanne is already using them in a Quassel Docker image.*