### PR TITLE
tests: Verify ExpressionMatch with invalid regex

### DIFF
--- a/tests/common/expressionmatchtest.cpp
+++ b/tests/common/expressionmatchtest.cpp
@@ -434,3 +434,22 @@ TEST(ExpressionMatchTest, trimMultiWildcardWhitespace)
         EXPECT_EQ(ExpressionMatch::trimMultiWildcardWhitespace(result), result);
     }
 }
+
+
+TEST(ExpressionMatchTest, testInvalidRegEx)
+{
+    // Invalid regular expression pattern
+    ExpressionMatch invalidRegExMatch =
+            ExpressionMatch("*network", ExpressionMatch::MatchMode::MatchRegEx, false);
+
+    // Assert not valid
+    ASSERT_FALSE(invalidRegExMatch.isValid());
+    // Assert not empty
+    EXPECT_FALSE(invalidRegExMatch.isEmpty());
+    // Assert default match fails
+    EXPECT_FALSE(invalidRegExMatch.match(""));
+    // Assert wildcard match fails
+    EXPECT_FALSE(invalidRegExMatch.match("network"));
+    // Assert literal match fails
+    EXPECT_FALSE(invalidRegExMatch.match("*network"));
+}

--- a/tests/common/expressionmatchtest.cpp
+++ b/tests/common/expressionmatchtest.cpp
@@ -425,7 +425,7 @@ TEST(ExpressionMatchTest, trimMultiWildcardWhitespace)
     QString result;
     for (auto&& patternPair : patterns) {
         // Make sure data is valid
-        EXPECT_TRUE(patternPair.size() == 2);
+        ASSERT_TRUE(patternPair.size() == 2);
         // Run transformation
         result = ExpressionMatch::trimMultiWildcardWhitespace(patternPair[PATTERN_SOURCE]);
         // Assert that source trims into expected pattern


### PR DESCRIPTION
## In short

* Verify `ExpressionMatch` handles invalid regular expressions correctly
  * Ensure there's no crash and that this won't regress in future changes
  * Matches @justJanne 's [test for Quasseldroid-NG](https://git.kuschku.de/justJanne/QuasselDroid-ng/commit/f1f320782cb0bca3fb7974e7688ce33af19456cf )

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Further verifies proper operation of `ExpressionMatch`
Risk | ★☆☆ *1/3* | Adds another development-only test
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Example
### `ctest` run

```
[...]/Quassel/quassel-build$ ctest
Test project [...]/Quassel/quassel-build
    Start 1: ExpressionMatchTest
1/3 Test #1: ExpressionMatchTest ..............   Passed    0.00 sec
    Start 2: FuncHelpersTest
2/3 Test #2: FuncHelpersTest ..................   Passed    0.00 sec
    Start 3: SignalProxyTest
3/3 Test #3: SignalProxyTest ..................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   0.02 sec
```