### PR TITLE
Make output to syslog nicer

### DIFF
--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -37,7 +37,27 @@ namespace {
 
 QByteArray msgWithTime(const Logger::LogEntry& msg)
 {
-    return (msg.timeStamp.toString("yyyy-MM-dd hh:mm:ss ") + msg.message + "\n").toUtf8();
+    QString levelString;
+
+    switch (msg.logLevel) {
+        case Logger::LogLevel::Debug:
+            levelString = "[Debug] ";
+            break;
+        case Logger::LogLevel::Info:
+            levelString = "[Info ] ";
+            break;
+        case Logger::LogLevel::Warning:
+            levelString = "[Warn ] ";
+            break;
+        case Logger::LogLevel::Error:
+            levelString = "[Error] ";
+            break;
+        case Logger::LogLevel::Fatal:
+            levelString = "[FATAL] ";
+            break;
+    }
+
+    return (msg.timeStamp.toString("yyyy-MM-dd hh:mm:ss ") + levelString + msg.message + "\n").toUtf8();
 }
 
 }  // namespace
@@ -151,31 +171,8 @@ void Logger::handleMessage(QtMsgType type, const QString& msg)
 
 void Logger::handleMessage(LogLevel level, const QString& msg)
 {
-    QString logString;
-
-    // Only add the log level to the message if we do not output to syslog
-    if (!_syslogEnabled) {
-        switch (level) {
-        case LogLevel::Debug:
-            logString = "[Debug] ";
-            break;
-        case LogLevel::Info:
-            logString = "[Info ] ";
-            break;
-        case LogLevel::Warning:
-            logString = "[Warn ] ";
-            break;
-        case LogLevel::Error:
-            logString = "[Error] ";
-            break;
-        case LogLevel::Fatal:
-            logString = "[FATAL] ";
-            break;
-        }
-    }
-
     // Use signal connection to make this method thread-safe
-    emit messageLogged({QDateTime::currentDateTime(), level, logString += msg});
+    emit messageLogged({QDateTime::currentDateTime(), level, msg});
 }
 
 void Logger::onMessageLogged(const LogEntry& message)

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -37,27 +37,7 @@ namespace {
 
 QByteArray msgWithTime(const Logger::LogEntry& msg)
 {
-    QString levelString;
-
-    switch (msg.logLevel) {
-        case Logger::LogLevel::Debug:
-            levelString = "[Debug] ";
-            break;
-        case Logger::LogLevel::Info:
-            levelString = "[Info ] ";
-            break;
-        case Logger::LogLevel::Warning:
-            levelString = "[Warn ] ";
-            break;
-        case Logger::LogLevel::Error:
-            levelString = "[Error] ";
-            break;
-        case Logger::LogLevel::Fatal:
-            levelString = "[FATAL] ";
-            break;
-    }
-
-    return (msg.timeStamp.toString("yyyy-MM-dd hh:mm:ss ") + levelString + msg.message + "\n").toUtf8();
+    return (msg.toString() + "\n").toUtf8();
 }
 
 }  // namespace
@@ -243,4 +223,30 @@ void Logger::outputMessage(const LogEntry& message)
         }
     }
 #endif
+}
+
+
+QString Logger::LogEntry::toString() const
+{
+    QString levelString;
+
+    switch (logLevel) {
+        case Logger::LogLevel::Debug:
+            levelString = "[Debug] ";
+            break;
+        case Logger::LogLevel::Info:
+            levelString = "[Info ] ";
+            break;
+        case Logger::LogLevel::Warning:
+            levelString = "[Warn ] ";
+            break;
+        case Logger::LogLevel::Error:
+            levelString = "[Error] ";
+            break;
+        case Logger::LogLevel::Fatal:
+            levelString = "[FATAL] ";
+            break;
+    }
+
+    return timeStamp.toString("yyyy-MM-dd hh:mm:ss ") + levelString + message;
 }

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -127,9 +127,22 @@ void Logger::setup(bool keepMessages)
 #ifdef HAVE_SYSLOG
     _syslogEnabled = Quassel::isOptionSet("syslog");
 
+    Quassel::RunMode mode = Quassel::runMode();
+    Quassel::BuildInfo info = Quassel::buildInfo();
+    QString prgname = info.applicationName;
+
+    if (mode == Quassel::RunMode::ClientOnly) {
+        prgname = info.clientApplicationName;
+    } else if (mode == Quassel::RunMode::CoreOnly) {
+        prgname = info.coreApplicationName;
+    }
+
+    _prgname = prgname.toLocal8Bit();
+
     // set up options, program name, and facility for later calls to syslog(3)
-    if (_syslogEnabled)
-        openlog("quasselcore", LOG_PID, LOG_USER);
+    if (_syslogEnabled) {
+        openlog(_prgname.constData(), LOG_PID, LOG_USER);
+    }
 #endif
 
     _initialized = true;

--- a/src/common/logger.h
+++ b/src/common/logger.h
@@ -55,6 +55,13 @@ public:
         QDateTime timeStamp;
         LogLevel logLevel;
         QString message;
+
+        /**
+         * Gets this log entry in a printable format, with timestamp and log level
+         *
+         * @return the log entry, formatted with timestamp and log level
+         */
+        QString toString() const;
     };
 
     /**

--- a/src/common/logger.h
+++ b/src/common/logger.h
@@ -111,6 +111,7 @@ private:
     std::vector<LogEntry> _messages;
     bool _keepMessages{true};
     bool _initialized{false};
+    QByteArray _prgname;
 };
 
 Q_DECLARE_METATYPE(Logger::LogEntry)

--- a/src/common/logger.h
+++ b/src/common/logger.h
@@ -50,7 +50,7 @@ public:
         Fatal
     };
 
-    struct LogEntry
+    struct COMMON_EXPORT LogEntry
     {
         QDateTime timeStamp;
         LogLevel logLevel;

--- a/src/qtui/debuglogdlg.cpp
+++ b/src/qtui/debuglogdlg.cpp
@@ -41,7 +41,7 @@ DebugLogDlg::DebugLogDlg(QWidget* parent)
 
 QString DebugLogDlg::toString(const Logger::LogEntry& msg)
 {
-    return msg.timeStamp.toString("yyyy-MM-dd hh:mm:ss ") + msg.message + "\n";
+    return msg.toString() + "\n";
 }
 
 void DebugLogDlg::logUpdated(const Logger::LogEntry& msg)


### PR DESCRIPTION
Before: `2019-01-11T22:52:27+00:00 hostname info [Info ] Quitting...`
After:  `2019-01-11T16:19:43+00:00 hostname info quasselcore[4438]: Quitting...`

This patch improves quasselcore's syslog output by adding a program name and instructing the logger to include the process's PID for every message.

Additionally, it removes superfluous log levels in the log message, as syslog is already aware of them.

Potential issues: If you log to a file and syslog at the same time (not sure whether this is possible, didn't check), the log level will not be included in the log file, since the check for _syslogEnabled will override that.