### PR TITLE
add MarkActiveChatRead ui setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,7 @@ if (BUILD_GUI)
     if (ECM_FOUND)
         list(APPEND CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
         if (WITH_KDE)
-            find_package(KF5 REQUIRED COMPONENTS ConfigWidgets CoreAddons Notifications NotifyConfig Sonnet TextWidgets WidgetsAddons XmlGui)
+            find_package(KF5 REQUIRED COMPONENTS ConfigWidgets CoreAddons Notifications NotifyConfig Sonnet IdleTime TextWidgets WidgetsAddons XmlGui)
             set_package_properties(KF5 PROPERTIES TYPE REQUIRED
                 URL "http://www.kde.org"
                 DESCRIPTION "KDE Frameworks"
@@ -314,6 +314,13 @@ if (BUILD_GUI)
             URL "http://api.kde.org/frameworks-api/frameworks5-apidocs/sonnet/html"
             DESCRIPTION "framework for providing spell-checking capabilities"
             PURPOSE "Enables spell-checking support in input widgets"
+        )
+
+        find_package(KF5IdleTime QUIET)
+        set_package_properties(KF5IdleTime PROPERTIES TYPE RECOMMENDED
+            URL "https://api.kde.org/frameworks/kidletime/html/"
+            DESCRIPTION "framework for providing idle time information"
+            PURPOSE "Enables detecting when the GUI user is idle"
         )
     endif()
 endif()

--- a/src/qtui/CMakeLists.txt
+++ b/src/qtui/CMakeLists.txt
@@ -128,6 +128,11 @@ if (KF5Sonnet_FOUND)
     target_link_libraries(${TARGET} PRIVATE KF5::SonnetUi)
 endif()
 
+if (KF5IdleTime_FOUND)
+    target_compile_definitions(${TARGET} PRIVATE -DHAVE_KIDLETIME)
+    target_link_libraries(${TARGET} PRIVATE KF5::IdleTime)
+endif()
+
 if (Qt5Multimedia_FOUND)
     target_compile_definitions(${TARGET} PRIVATE -DHAVE_QTMULTIMEDIA)
     target_sources(${TARGET} PRIVATE


### PR DESCRIPTION
Add the ui setting MarkActiveChatRead to the chat view settings page,
and check this setting before calling Client::markBufferAsRead() in
MainWin::currentBufferChanged() and MainWin::event().

Defaults to true, which is the current behavior.