### PR TITLE
cmake: add ENABLE_SHARED option, default ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,12 @@ if (NOT WIN32)
     )
 endif()
 
+# Shared library support
+#####################################################################
+
+option(ENABLE_SHARED "Build modules as shared libraries" ON)
+add_feature_info(ENABLE_SHARED ENABLE_SHARED "Build modules as shared libraries")
+
 # Setup unit testing
 #####################################################################
 

--- a/cmake/QuasselMacros.cmake
+++ b/cmake/QuasselMacros.cmake
@@ -45,7 +45,7 @@ function(quassel_add_module _module)
     string(REPLACE "::" "_" target ${target})
     string(REPLACE "_" "-" output_name ${target})
 
-    if (ARG_STATIC)
+    if (ARG_STATIC OR NOT ENABLE_SHARED)
         set(buildmode STATIC)
     else()
         set(buildmode SHARED)


### PR DESCRIPTION
Add an ENABLE_SHARED option, defaults to ON, when set to OFF
quassel_add_module() will build modules as static (does not affect
platforms where modules would be built as static anyway.)

The option name ENABLE_SHARED is frequently used for this purpose in
cmake.