### PR TITLE
lower Boost dep version 1.56 -> 1.54

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,7 +330,7 @@ endif()
 # Non-Qt-based packages
 #####################################################################
 
-find_package(Boost 1.56 REQUIRED)
+find_package(Boost 1.54 REQUIRED)
 set_package_properties(Boost PROPERTIES TYPE REQUIRED
     URL "https://www.boost.org/"
     DESCRIPTION "Boost libraries for C++"

--- a/INSTALL
+++ b/INSTALL
@@ -34,7 +34,7 @@ compiler is needed:
 Other compilers may work, but are not officially supported.
 
 As Quassel is a Qt application, you need the Qt SDK, version 5.5 or higher.
-Furthermore, the Boost header-only libraries (at least version 1.56) and
+Furthermore, the Boost header-only libraries (at least version 1.54) and
 CMake 3.5 or later are required. CMake will tell you about any missing
 dependencies when configuring the project.
 


### PR DESCRIPTION
Require Boost 1.54 instead of 1.56.

Tested to compile and work correctly on OpenSUSE Leap 42.3.

Related issue #1510.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>