### PR TITLE
common: Don't add quotes to exit exceptions

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
     }
     catch (ExitException e) {
         if (!e.errorString.isEmpty()) {
-            qCritical() << e.errorString;
+            qCritical() << qPrintable(e.errorString);
         }
         return e.exitCode;
     }


### PR DESCRIPTION
## In short

* Don't add quotes to exist exception messages
  * When logging exit exceptions, wrap the `QString` in `qPrintable()`
  * Removes extra quotes added by the debug logger

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Small cosmetic change to debug logs
Risk | ★☆☆ *1/3* | Might cause issues with printing exit exception messages
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

There's a [backport to `0.13` available here](https://github.com/quassel/quassel/pull/471 ).

## Examples
### Before
```
2019-01-27 02:28:52 [Error] Could not open any network interfaces to listen on!
2019-01-27 02:28:52 [Error] "Cannot open port for listening!"
```


### After
```
2019-01-27 02:33:17 [Error] Could not open any network interfaces to listen on!
2019-01-27 02:33:17 [Error] Cannot open port for listening!
```