### PR TITLE
[0.13] logger: Make output to syslog nicer

### DIFF
--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -36,27 +36,7 @@ namespace {
 
 QByteArray msgWithTime(const Logger::LogEntry &msg)
 {
-    QString levelString;
-
-    switch (msg.logLevel) {
-        case Logger::LogLevel::Debug:
-            levelString = "[Debug] ";
-            break;
-        case Logger::LogLevel::Info:
-            levelString = "[Info ] ";
-            break;
-        case Logger::LogLevel::Warning:
-            levelString = "[Warn ] ";
-            break;
-        case Logger::LogLevel::Error:
-            levelString = "[Error] ";
-            break;
-        case Logger::LogLevel::Fatal:
-            levelString = "[FATAL] ";
-            break;
-    }
-
-    return (msg.timeStamp.toString("yyyy-MM-dd hh:mm:ss ") + levelString + msg.message + "\n").toUtf8();
+    return (msg.toString() + "\n").toUtf8();
 };
 
 }
@@ -265,4 +245,30 @@ void Logger::outputMessage(const LogEntry &message)
     }
 #endif
 
+}
+
+
+QString Logger::LogEntry::toString() const
+{
+    QString levelString;
+
+    switch (logLevel) {
+        case Logger::LogLevel::Debug:
+            levelString = "[Debug] ";
+            break;
+        case Logger::LogLevel::Info:
+            levelString = "[Info ] ";
+            break;
+        case Logger::LogLevel::Warning:
+            levelString = "[Warn ] ";
+            break;
+        case Logger::LogLevel::Error:
+            levelString = "[Error] ";
+            break;
+        case Logger::LogLevel::Fatal:
+            levelString = "[FATAL] ";
+            break;
+    }
+
+    return timeStamp.toString("yyyy-MM-dd hh:mm:ss ") + levelString + message;
 }

--- a/src/common/logger.h
+++ b/src/common/logger.h
@@ -111,6 +111,7 @@ private:
     std::vector<LogEntry> _messages;
     bool _keepMessages{true};
     bool _initialized{false};
+    QByteArray _prgname;
 };
 
 Q_DECLARE_METATYPE(Logger::LogEntry)

--- a/src/common/logger.h
+++ b/src/common/logger.h
@@ -51,6 +51,13 @@ public:
         QDateTime timeStamp;
         LogLevel logLevel;
         QString message;
+
+        /**
+         * Gets this log entry in a printable format, with timestamp and log level
+         *
+         * @return the log entry, formatted with timestamp and log level
+         */
+        QString toString() const;
     };
 
     /**

--- a/src/qtui/debuglogdlg.cpp
+++ b/src/qtui/debuglogdlg.cpp
@@ -43,7 +43,7 @@ DebugLogDlg::DebugLogDlg(QWidget *parent)
 
 QString DebugLogDlg::toString(const Logger::LogEntry &msg)
 {
-    return msg.timeStamp.toString("yyyy-MM-dd hh:mm:ss ") + msg.message + "\n";
+    return msg.toString() + "\n";
 }
 
 


### PR DESCRIPTION
## In short

* Improves Quassel's `--syslog` output
  * Removes redundant log level messages, e.g. `[Info]`
  * Adds PID
* Deduplicate code for converting LogEntry to printable format

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Improves log handling for `--syslog`, including systemd
Risk | ★☆☆ *1/3* | Logging might be wrongly formatted or not logged at all
Intrusiveness | ★☆☆ *1/3* | Small changes, shouldn't interfere with other pull requests

*All credit to @vehk for the original work, this is just testing and an additional fix.*

## Rationale
See the [`master` branch pull request #460, "Make output to syslog nicer"](https://github.com/quassel/quassel/pull/460 ).

## Example
### Before

> Before: `2019-01-11T22:52:27+00:00 hostname info [Info ] Quitting...`

### After

> After: `2019-01-11T16:19:43+00:00 hostname info quasselcore[4438]: Quitting...`

### Additional testing with Qt 4, Qt 5, systemd

**Qt 5**

![Screenshot of Quassel client and Quassel core running on Qt 5, showing various debug logs in terminal windows and the 'Debug Log' window.  See below quotes for text.](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/backport-0.13-vehk-syslog-fixes/Debug%20logging%20works%2C%20Qt%205.png#v1 )

> **Client Debug Log dialog**
> ```
> 2019-02-13 19:20:08 [Debug] Enabling compression...
> 2019-02-13 19:20:08 [Debug] Using the DataStream protocol...
> 2019-02-13 19:20:08 [Debug] Starting encryption...
> 2019-02-13 19:24:05 [Debug] Enabling compression...
> 2019-02-13 19:24:05 [Debug] Using the DataStream protocol...
> 2019-02-13 19:24:05 [Debug] Starting encryption...
> ```
>
> **Client launch command and logging in terminal window**
> ```
> sly@kyuubi-desktop:~/Source/Chat/Quassel/scripts$ ./run-quasselclient.sh --loglevel Debug
> Quassel version: '/home/sly/Source/Chat/Quassel/quassel-build/quasselclient', in 'config_client'
> 2019-02-13 19:20:08 [Debug] Enabling compression...
> 2019-02-13 19:20:08 [Debug] Using the DataStream protocol...
> 2019-02-13 19:20:08 [Debug] Starting encryption...
> 2019-02-13 19:24:05 [Debug] Enabling compression...
> 2019-02-13 19:24:05 [Debug] Using the DataStream protocol...
> 2019-02-13 19:24:05 [Debug] Starting encryption...
> ```
> 
> **Core launch command and logging in terminal window**
> ```
> sly@kyuubi-desktop:~/Source/Chat/Quassel/scripts$ ./run-quasselcore.sh --loglevel Debug --syslog
> Quassel version: '/home/sly/Source/Chat/Quassel/quassel-build/quasselcore', in 'config_core'
> sly@kyuubi-desktop:~/Source/Chat/Quassel/scripts$
> ```
> 
> **Core logging to file**
> ```
> 2019-02-13 19:21:40 [Info ] Core shutting down... 
> 2019-02-13 19:21:40 [Info ] Core shutdown complete! 
> 2019-02-13 19:24:05 [Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 GMT 
> 2019-02-13 19:24:05 [Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 GMT 
> 2019-02-13 19:24:05 [Info ] SQLite storage backend is ready. Schema version: 31 
> 2019-02-13 19:24:05 [Info ] Database authenticator is ready. 
> 2019-02-13 19:24:05 [Info ] Listening for GUI clients on IPv6 :: port 4242 using protocol version 10 
> 2019-02-13 19:24:05 [Info ] Listening for GUI clients on IPv4 0.0.0.0 port 4242 using protocol version 10 
> 2019-02-13 19:24:05 [Info ] Restoring previous core state... 
> 2019-02-13 19:24:05 [Info ] Client connected from 127.0.0.1 
> 2019-02-13 19:24:05 [Debug] Enabling compression...
> 2019-02-13 19:24:05 [Debug] Using the DataStream protocol...
> 2019-02-13 19:24:05 [Debug] Starting encryption for Client: "127.0.0.1"
> 2019-02-13 19:24:05 [Info ] Client 127.0.0.1 initialized and authenticated successfully as "dcircuit" (UserId: 1). 
> 2019-02-13 19:24:25 [Info ] Caught signal 2 
> 2019-02-13 19:24:25 [Info ] Quitting... 
> 2019-02-13 19:24:25 [Info ] Core shutting down... 
> 2019-02-13 19:24:25 [Info ] Core shutdown complete!
> ```
> 
> **Core logging to syslog (systemd `journalctl` output)**
> 
> Sections wrapped with `<bold>…</bold>` are printed in bold in the terminal, indicating warning level.  This is customizable.
> ```
> Feb 13 19:24:05 kyuubi-desktop quasselcore[12315]: <bold>SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 GMT</bold>
> Feb 13 19:24:05 kyuubi-desktop quasselcore[12315]: <bold>SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 GMT</bold>
> Feb 13 19:24:05 kyuubi-desktop quasselcore[12315]: SQLite storage backend is ready. Schema version: 31
> Feb 13 19:24:05 kyuubi-desktop quasselcore[12315]: Database authenticator is ready.
> Feb 13 19:24:05 kyuubi-desktop quasselcore[12315]: Listening for GUI clients on IPv6 :: port 4242 using protocol version 10
> Feb 13 19:24:05 kyuubi-desktop quasselcore[12315]: Listening for GUI clients on IPv4 0.0.0.0 port 4242 using protocol version 10
> Feb 13 19:24:05 kyuubi-desktop quasselcore[12315]: Restoring previous core state...
> Feb 13 19:24:05 kyuubi-desktop quasselcore[12315]: Client connected from 127.0.0.1
> Feb 13 19:24:05 kyuubi-desktop quasselcore[12315]: Enabling compression...
> Feb 13 19:24:05 kyuubi-desktop quasselcore[12315]: Using the DataStream protocol...
> Feb 13 19:24:05 kyuubi-desktop quasselcore[12315]: Starting encryption for Client: "127.0.0.1"
> Feb 13 19:24:05 kyuubi-desktop quasselcore[12315]: Client 127.0.0.1 initialized and authenticated successfully as "dcircuit" (UserId: 1).
> Feb 13 19:24:25 kyuubi-desktop quasselcore[12315]: Caught signal 2
> Feb 13 19:24:25 kyuubi-desktop quasselcore[12315]: Quitting...
> Feb 13 19:24:25 kyuubi-desktop quasselcore[12315]: Core shutting down...
> Feb 13 19:24:25 kyuubi-desktop quasselcore[12315]: Core shutdown complete!
> ```

**Qt 4**

![Screenshot of Quassel client and Quassel core running on Qt 4, showing various debug logs in terminal windows and the 'Debug Log' window.  See below quotes for text.](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/backport-0.13-vehk-syslog-fixes/Debug%20logging%20works%2C%20Qt%204.png#v1 )

> **Client Debug Log dialog**
> ```
> 2019-02-13 19:40:08 [Warn ] Missing icon: "{inactive-quassel}"
> 2019-02-13 19:40:08 [Warn ] Missing icon: "{connect-quassel}"
> 2019-02-13 19:40:08 [Warn ] Missing icon: "{disconnect-quassel}"
> 2019-02-13 19:40:08 [Warn ] Missing icon: "{inactive-quassel-tray}"
> 2019-02-13 19:40:08 [Debug] Enabling compression... 
> 2019-02-13 19:40:08 [Debug] Using the DataStream protocol...
> 2019-02-13 19:40:08 [Debug] Starting encryption... 
> 2019-02-13 19:40:08 [Warn ] Missing icon: "{active-quassel-tray}"
> ```
>
> **Client launch command and logging in terminal window**
> ```
> sly@kyuubi-desktop:~/Source/Chat/Quassel/scripts$ ./run-quasselclient.sh --loglevel=Debug
> Quassel version: '/home/sly/Source/Chat/Quassel/quassel-build/quasselclient', in 'config_client'
> 2019-02-13 19:40:08 [Warn ] Missing icon: "{inactive-quassel}"
> 2019-02-13 19:40:08 [Warn ] Missing icon: "{connect-quassel}"
> 2019-02-13 19:40:08 [Warn ] Missing icon: "{disconnect-quassel}"
> 2019-02-13 19:40:08 [Warn ] Missing icon: "{inactive-quassel-tray}"
> 2019-02-13 19:40:08 [Debug] Enabling compression... 
> 2019-02-13 19:40:08 [Debug] Using the DataStream protocol...
> 2019-02-13 19:40:08 [Debug] Starting encryption... 
> 2019-02-13 19:40:08 [Warn ] Missing icon: "{active-quassel-tray}"
> ```
> 
> **Core launch command and logging in terminal window**
> ```
> sly@kyuubi-desktop:~/Source/Chat/Quassel/scripts$ ./run-quasselcore.sh --loglevel=Debug --syslog
> Quassel version: '/home/sly/Source/Chat/Quassel/quassel-build/quasselcore', in 'config_core'
> ```
> 
> **Core logging to file**
> ```
> 2019-02-13 19:40:03 [Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 
> 2019-02-13 19:40:03 [Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 
> 2019-02-13 19:40:03 [Warn ] PostgreSQL driver plugin not available for Qt. Installed drivers: QSQLITE 
> 2019-02-13 19:40:03 [Info ] SQLite storage backend is ready. Schema version: 31 
> 2019-02-13 19:40:03 [Info ] Database authenticator is ready. 
> 2019-02-13 19:40:03 [Info ] Listening for GUI clients on IPv6 :: port 4242 using protocol version 10 
> 2019-02-13 19:40:03 [Info ] Restoring previous core state... 
> 2019-02-13 19:40:08 [Info ] Client connected from ::FFFF:7F00:1%0 
> 2019-02-13 19:40:08 [Debug] Enabling compression... 
> 2019-02-13 19:40:08 [Debug] Using the DataStream protocol...
> 2019-02-13 19:40:08 [Debug] Starting encryption for Client: "::FFFF:7F00:1%0" 
> 2019-02-13 19:40:08 [Info ] Client ::FFFF:7F00:1%0 initialized and authenticated successfully as "dcircuit" (UserId: 1).
> ```
> 
> **Core logging to syslog (systemd `journalctl` output)**
> 
> Sections wrapped with `<bold>…</bold>` are printed in bold in the terminal, indicating warning level.  This is customizable.
> ```
> Feb 13 19:40:03 kyuubi-desktop quasselcore[15371]: <bold>SslServer: Certificate expired on Fri Jun 8 19:26:17 2018</bold>
> Feb 13 19:40:03 kyuubi-desktop quasselcore[15371]: <bold>SslServer: Certificate expired on Fri Jun 8 19:26:17 2018</bold>
> Feb 13 19:40:03 kyuubi-desktop quasselcore[15371]: <bold>PostgreSQL driver plugin not available for Qt. Installed drivers: QSQLITE</bold>
> Feb 13 19:40:03 kyuubi-desktop quasselcore[15371]: SQLite storage backend is ready. Schema version: 31
> Feb 13 19:40:03 kyuubi-desktop quasselcore[15371]: Database authenticator is ready.
> Feb 13 19:40:03 kyuubi-desktop quasselcore[15371]: Listening for GUI clients on IPv6 :: port 4242 using protocol version 10
> Feb 13 19:40:03 kyuubi-desktop quasselcore[15371]: Restoring previous core state...
> Feb 13 19:40:08 kyuubi-desktop quasselcore[15371]: Client connected from ::FFFF:7F00:1%0
> Feb 13 19:40:08 kyuubi-desktop quasselcore[15371]: Enabling compression...
> Feb 13 19:40:08 kyuubi-desktop quasselcore[15371]: Using the DataStream protocol...
> Feb 13 19:40:08 kyuubi-desktop quasselcore[15371]: Starting encryption for Client: "::FFFF:7F00:1%0"
> Feb 13 19:40:08 kyuubi-desktop quasselcore[15371]: Client ::FFFF:7F00:1%0 initialized and authenticated successfully as "dcircuit" (UserId: 1).
> ```