### PR TITLE
[0.13] core: Workaround Qt 4 SQL bindValue() duplicates

### DIFF
--- a/src/core/SQL/PostgreSQL/select_messagesAllNew_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesAllNew_filtered.sql
@@ -4,6 +4,6 @@ JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
     AND backlog.messageid >= :firstmsg
     AND backlog.type & :type != 0
-    AND (:flags = 0 OR backlog.flags & :flags != 0)
+    AND (:flags = 0 OR backlog.flags & :flagsDup1 != 0)
 ORDER BY messageid DESC
 -- Unlike SQLite, no LIMIT clause, mimicking the unfiltered version - investigate later..?

--- a/src/core/SQL/PostgreSQL/select_messagesAll_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesAll_filtered.sql
@@ -5,6 +5,6 @@ WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
     AND backlog.messageid >= :firstmsg
     AND backlog.messageid < :lastmsg
     AND backlog.type & :type != 0
-    AND (:flags = 0 OR backlog.flags & :flags != 0)
+    AND (:flags = 0 OR backlog.flags & :flagsDup1 != 0)
 ORDER BY messageid DESC
 -- Unlike SQLite, no LIMIT clause, mimicking the unfiltered version - investigate later..?

--- a/src/core/SQL/PostgreSQL/select_messagesNewerThan_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesNewerThan_filtered.sql
@@ -2,9 +2,9 @@ SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarur
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= :first
-    AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :buffer)
+    AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferDup1)
     AND bufferid = :buffer
     AND backlog.type & :type != 0
-    AND (:flags = 0 OR backlog.flags & :flags != 0)
+    AND (:flags = 0 OR backlog.flags & :flagsDup1 != 0)
 ORDER BY messageid DESC
 LIMIT :limit

--- a/src/core/SQL/PostgreSQL/select_messagesNewestK_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesNewestK_filtered.sql
@@ -2,8 +2,8 @@ SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarur
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE bufferid = :buffer
-    AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :buffer)
+    AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferDup1)
     AND backlog.type & :type != 0
-    AND (:flags = 0 OR backlog.flags & :flags != 0)
+    AND (:flags = 0 OR backlog.flags & :flagsDup1 != 0)
 ORDER BY messageid DESC
 LIMIT :limit

--- a/src/core/SQL/PostgreSQL/select_messagesRange_filtered.sql
+++ b/src/core/SQL/PostgreSQL/select_messagesRange_filtered.sql
@@ -5,6 +5,6 @@ WHERE backlog.messageid >= :first
     AND backlog.messageid < :last
     AND bufferid = :buffer
     AND backlog.type & :type != 0
-    AND (:flags = 0 OR backlog.flags & :flags != 0)
+    AND (:flags = 0 OR backlog.flags & :flagsDup1 != 0)
 ORDER BY messageid DESC
 LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesAllNew_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesAllNew_filtered.sql
@@ -4,6 +4,6 @@ JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
     AND backlog.messageid >= :firstmsg
     AND backlog.type & :type != 0
-    AND (:flags = 0 OR backlog.flags & :flags != 0)
+    AND (:flags = 0 OR backlog.flags & :flagsDup1 != 0)
 ORDER BY messageid DESC
 LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesAll_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesAll_filtered.sql
@@ -5,6 +5,6 @@ WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
     AND backlog.messageid >= :firstmsg
     AND backlog.messageid < :lastmsg
     AND backlog.type & :type != 0
-    AND (:flags = 0 OR backlog.flags & :flags != 0)
+    AND (:flags = 0 OR backlog.flags & :flagsDup1 != 0)
 ORDER BY messageid DESC
 LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesNewerThan.sql
+++ b/src/core/SQL/SQLite/select_messagesNewerThan.sql
@@ -2,7 +2,7 @@ SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarur
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= :firstmsg
-    AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferid)
+    AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferidDup1)
     AND bufferid = :bufferid
 ORDER BY messageid DESC
 LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesNewerThan_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesNewerThan_filtered.sql
@@ -2,9 +2,9 @@ SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarur
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE backlog.messageid >= :firstmsg
-    AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferid)
+    AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferidDup1)
     AND bufferid = :bufferid
     AND backlog.type & :type != 0
-    AND (:flags = 0 OR backlog.flags & :flags != 0)
+    AND (:flags = 0 OR backlog.flags & :flagsDup1 != 0)
 ORDER BY messageid DESC
 LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesNewestK.sql
+++ b/src/core/SQL/SQLite/select_messagesNewestK.sql
@@ -2,6 +2,6 @@ SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarur
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE bufferid = :bufferid
-AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferid)
+AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferidDup1)
 ORDER BY messageid DESC
 LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesNewestK_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesNewestK_filtered.sql
@@ -2,8 +2,8 @@ SELECT messageid, time,  type, flags, sender, senderprefixes, realname, avatarur
 FROM backlog
 JOIN sender ON backlog.senderid = sender.senderid
 WHERE bufferid = :bufferid
-AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferid)
+AND backlog.messageid <= (SELECT buffer.lastmsgid FROM buffer WHERE buffer.bufferid = :bufferidDup1)
 AND backlog.type & :type != 0
-AND (:flags = 0 OR backlog.flags & :flags != 0)
+AND (:flags = 0 OR backlog.flags & :flagsDup1 != 0)
 ORDER BY messageid DESC
 LIMIT :limit

--- a/src/core/SQL/SQLite/select_messagesRange_filtered.sql
+++ b/src/core/SQL/SQLite/select_messagesRange_filtered.sql
@@ -5,6 +5,6 @@ WHERE bufferid = :bufferid
     AND backlog.messageid >= :firstmsg
     AND backlog.messageid < :lastmsg
     AND backlog.type & :type != 0
-    AND (:flags = 0 OR backlog.flags & :flags != 0)
+    AND (:flags = 0 OR backlog.flags & :flagsDup1 != 0)
 ORDER BY messageid DESC
 LIMIT :limit

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1843,13 +1843,18 @@ QList<Message> PostgreSqlStorage::requestMsgsFiltered(UserId user, BufferId buff
     QSqlQuery query(db);
     if (last == -1 && first == -1) {
         query.prepare(queryString("select_messagesNewestK_filtered"));
+        // Workaround for Qt 4 QSqlQuery::bindValue() not supporting repeated placeholder names
+        query.bindValue(":bufferDup1", bufferId.toInt());
     } else if (last == -1) {
         query.prepare(queryString("select_messagesNewerThan_filtered"));
         query.bindValue(":first", first.toQint64());
+        // Workaround for Qt 4 QSqlQuery::bindValue() not supporting repeated placeholder names
+        query.bindValue(":bufferDup1", bufferId.toInt());
     } else {
         query.prepare(queryString("select_messagesRange_filtered"));
         query.bindValue(":last", last.toQint64());
         query.bindValue(":first", first.toQint64());
+        // Workaround for Qt 4 QSqlQuery::bindValue() not needed, only has one ":buffer"
     }
     query.bindValue(":buffer", bufferId.toInt());
     query.bindValue(":limit", limit);
@@ -1857,6 +1862,8 @@ QList<Message> PostgreSqlStorage::requestMsgsFiltered(UserId user, BufferId buff
     query.bindValue(":type", typeRaw);
     int flagsRaw = flags;
     query.bindValue(":flags", flagsRaw);
+    // Workaround for Qt 4 QSqlQuery::bindValue() not supporting repeated placeholder names
+    query.bindValue(":flagsDup1", flagsRaw);
 
     safeExec(query);
     if (!watchQuery(query)) {
@@ -1979,6 +1986,8 @@ QList<Message> PostgreSqlStorage::requestAllMsgsFiltered(UserId user, MsgId firs
 
     int flagsRaw = flags;
     query.bindValue(":flags", flagsRaw);
+    // Workaround for Qt 4 QSqlQuery::bindValue() not supporting repeated placeholder names
+    query.bindValue(":flagsDup1", flagsRaw);
 
     safeExec(query);
     if (!watchQuery(query)) {

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1914,15 +1914,20 @@ QList<Message> SqliteStorage::requestMsgs(UserId user, BufferId bufferId, MsgId 
         QSqlQuery query(db);
         if (last == -1 && first == -1) {
             query.prepare(queryString("select_messagesNewestK"));
+            // Workaround for Qt 4 QSqlQuery::bindValue() not supporting repeated placeholder names
+            query.bindValue(":bufferidDup1", bufferId.toInt());
         }
         else if (last == -1) {
             query.prepare(queryString("select_messagesNewerThan"));
             query.bindValue(":firstmsg", first.toQint64());
+            // Workaround for Qt 4 QSqlQuery::bindValue() not supporting repeated placeholder names
+            query.bindValue(":bufferidDup1", bufferId.toInt());
         }
         else {
             query.prepare(queryString("select_messagesRange"));
             query.bindValue(":lastmsg", last.toQint64());
             query.bindValue(":firstmsg", first.toQint64());
+            // Workaround for Qt 4 QSqlQuery::bindValue() not needed, only has one ":bufferid"
         }
         query.bindValue(":bufferid", bufferId.toInt());
         query.bindValue(":limit", limit);
@@ -1989,15 +1994,20 @@ QList<Message> SqliteStorage::requestMsgsFiltered(UserId user, BufferId bufferId
         QSqlQuery query(db);
         if (last == -1 && first == -1) {
             query.prepare(queryString("select_messagesNewestK_filtered"));
+            // Workaround for Qt 4 QSqlQuery::bindValue() not supporting repeated placeholder names
+            query.bindValue(":bufferidDup1", bufferId.toInt());
         }
         else if (last == -1) {
             query.prepare(queryString("select_messagesNewerThan_filtered"));
             query.bindValue(":firstmsg", first.toQint64());
+            // Workaround for Qt 4 QSqlQuery::bindValue() not supporting repeated placeholder names
+            query.bindValue(":bufferidDup1", bufferId.toInt());
         }
         else {
             query.prepare(queryString("select_messagesRange_filtered"));
             query.bindValue(":lastmsg", last.toQint64());
             query.bindValue(":firstmsg", first.toQint64());
+            // Workaround for Qt 4 QSqlQuery::bindValue() not needed, only has one ":bufferid"
         }
         query.bindValue(":bufferid", bufferId.toInt());
         query.bindValue(":limit", limit);
@@ -2005,6 +2015,8 @@ QList<Message> SqliteStorage::requestMsgsFiltered(UserId user, BufferId bufferId
         query.bindValue(":type", typeRaw);
         int flagsRaw = flags;
         query.bindValue(":flags", flagsRaw);
+        // Workaround for Qt 4 QSqlQuery::bindValue() not supporting repeated placeholder names
+        query.bindValue(":flagsDup1", flagsRaw);
 
         safeExec(query);
         watchQuery(query);
@@ -2128,6 +2140,8 @@ QList<Message> SqliteStorage::requestAllMsgsFiltered(UserId user, MsgId first, M
         query.bindValue(":type", typeRaw);
         int flagsRaw = flags;
         query.bindValue(":flags", flagsRaw);
+        // Workaround for Qt 4 QSqlQuery::bindValue() not supporting repeated placeholder names
+        query.bindValue(":flagsDup1", flagsRaw);
         safeExec(query);
 
         watchQuery(query);


### PR DESCRIPTION
## In short
* Workaround [Qt 4's `QSqlQuery::bindValue()`](https://doc.qt.io/archives/qt-4.8/qsqlquery.html#bindValue) not replacing multiple placeholders
  * When a placeholder appears multiple times, rename the extra placeholders to have unique names
  * Adapt `SqliteStorage` and `PostgresqlStorage` to provide extra placeholders as needed
  * E.g. `AND (:flags = 0 OR backlog.flags & :flagsDup1 != 0)`
  * [Qt 5's `QSqlQuery::bindValue()`](https://doc.qt.io/qt-5/qsqlquery.html#bindValue) handles this correctly (*thankfully*)
  * Fixes [issue #1506](https://bugs.quassel-irc.org/issues/1506)
* No need to forward-port to 0.14/`master`, as Qt 4 support has been dropped
* Not required for `0.13.1`, can be postponed to an immediately-following `0.13.2`
  * Might reduce risk of breakage before Debian's import freeze as builds in Debian are Qt 5

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | Fixes broken backlog fetch on all Qt 4 builds (*Ubuntu 14.04, etc*)
Risk | ★★☆ *2/3* | Small changes, but mistakes could break backlog fetching for everyone
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other pull requests

*Thanks to @justjanne for finding the root cause of the issue, and suggesting the fix, and to `galfwender` and @darkstar for reporting.*

## Rationale
[Qt 4 does not support binding to multiple values](https://doc.qt.io/archives/qt-4.8/qsqlquery.html#bindValue ):

> Values cannot be bound to multiple locations in the query, eg:
> 
> ```sql
> INSERT INTO testtable (id, name, samename) VALUES (:id, :name, :name)
> ```
> 
> Binding to name will bind to the first :name, but not the second.

This is [also noted on StackOverflow](https://stackoverflow.com/questions/14277381/sqlquery-one-named-placeholders-several-times ).  [Qt 5 drops this remark](https://doc.qt.io/qt-5/qsqlquery.html#bindValue ).

For simplicity, modify the queries regardless of Qt versions, avoiding duplicated placeholder names by given every reference a unique name.  For example...

[`src/core/SQL/SQLite/select_messagesAllNew_filtered.sql`](https://github.com/quassel/quassel/pull/476/commits/62617a97e48f7a461c2bc38df8c42ca6a3fbff2f#diff-19b36c8cd7809c987a59f842961a861dL7 ):
```diff
 WHERE backlog.bufferid IN (SELECT bufferid FROM buffer WHERE userid = :userid)
     AND backlog.messageid >= :firstmsg
     AND backlog.type & :type != 0
-    AND (:flags = 0 OR backlog.flags & :flags != 0)
+    AND (:flags = 0 OR backlog.flags & :flagsDup1 != 0)
 ORDER BY messageid DESC
 LIMIT :limit
```

[`src/core/sqlitestorage.cpp`](https://github.com/quassel/quassel/pull/476/commits/62617a97e48f7a461c2bc38df8c42ca6a3fbff2f#diff-194d5b91f1de19d88826bb6079a52c03R2143):
```diff
         if (last == -1) {
             query.prepare(queryString("select_messagesAllNew_filtered"));
         }
         else {
             query.prepare(queryString("select_messagesAll_filtered"));
             query.bindValue(":lastmsg", last.toQint64());
         }
         query.bindValue(":userid", user.toInt());
         query.bindValue(":firstmsg", first.toQint64());
         query.bindValue(":limit", limit);
         int typeRaw = type;
         query.bindValue(":type", typeRaw);
         int flagsRaw = flags;
         query.bindValue(":flags", flagsRaw);
+        // Workaround for Qt 4 QSqlQuery::bindValue() not supporting repeated placeholder names
+        query.bindValue(":flagsDup1", flagsRaw);
         safeExec(query);
```

*`select_messagesAll_filtered.sql` is also modified, ignoring it just for the sake of a concise example.*

**Note: PostgreSQL prepared statements properly handle repeated `$` parameters**, so there's no need to modify those.

Test case for prepared statements:

```sql
PREPARE qcore_test_var
AS SELECT * FROM buffer WHERE bufferid = $1 AND userid = $1 AND networkid = $1;
EXECUTE qcore_test_var(1);
```

This gives a result if `bufferid` = `userid` = `networkid` = `1` exists.

### Bonus: verification

Duplicate placeholders were verified using this in the `src/core/SQL` directory:

```sh
grep -r --only-matching --no-filename -e ":\w*\w+\?" --include "*.sql" | sort | uniq | xargs --max-args=1 -I "@PARAM" grep -r --exclude="*~" --word-regexp --fixed-strings "@PARAM" --only-matching | sort | uniq --repeated
# Find all ":parameter" words in .sql files | sort | only show unique | for each ":parameter" search for usages of it, ignoring backup files | sort | only show files where it's repeated
```

**Before:**
```
[...]/quassel/src/core/SQL$ grep -r --only-matching --no-filename -e ":\w*\w+\?" --include "*.sql" | sort | uniq | xargs --max-args=1 -I "@PARAM" grep -r --exclude="*~" --word-regexp --fixed-strings "@PARAM" --only-matching | sort | uniq --repeated
PostgreSQL/select_messagesAll_filtered.sql::flags
PostgreSQL/select_messagesAllNew_filtered.sql::flags
PostgreSQL/select_messagesNewerThan_filtered.sql::buffer
PostgreSQL/select_messagesNewerThan_filtered.sql::flags
PostgreSQL/select_messagesNewestK_filtered.sql::buffer
PostgreSQL/select_messagesNewestK_filtered.sql::flags
PostgreSQL/select_messagesRange_filtered.sql::flags
SQLite/select_messagesAll_filtered.sql::flags
SQLite/select_messagesAllNew_filtered.sql::flags
SQLite/select_messagesNewerThan_filtered.sql::bufferid
SQLite/select_messagesNewerThan_filtered.sql::flags
SQLite/select_messagesNewerThan.sql::bufferid
SQLite/select_messagesNewestK_filtered.sql::bufferid
SQLite/select_messagesNewestK_filtered.sql::flags
SQLite/select_messagesNewestK.sql::bufferid
SQLite/select_messagesRange_filtered.sql::flags
[...]/quassel/src/core/SQL$ 
```

**After:**
```
[...]/quassel/src/core/SQL$ grep -r --only-matching --no-filename -e ":\w*\w+\?" --include "*.sql" | sort | uniq | xargs --max-args=1 -I "@PARAM" grep -r --exclude="*~" --word-regexp --fixed-strings "@PARAM" --only-matching | sort | uniq --repeated
[...]/quassel/src/core/SQL$ 
```

## Testing

**Testing shows improvement and no regression.**

In addition to focused testing below, individual tests of Qt 5 + PostgreSQL, and Qt 4 + SQLite verify fixes.  Thanks @darkstar !

### Steps
1.  Patch `core.cpp` to test all modified backlog message requests
2.  Compile and run before and after this branch, with Qt 4 and Qt 5
3.  Compare output, ignoring date/time in debug logging
    * In `gedit`, run the following Find & Replace with `Regular expression` checked
    * **Find:** `^.*\[(Debug|Warn|Info|Error)`, **Replace with:** `​[\1`
4.  Redact any sensitive information
    * Message ID number prefixes replaced with `AA` and `BB`
    * In `gedit`, run the following Find & Replace with `Regular expression` checked
    * **Find:** `, QDateTime.*"`, **Replace with:** `, [content removed])`

### Results

**Qt 5 does not change.**

**Qt 4 is fixed, matching Qt 5 output.**

*Differences from Qt 4 SQLite before patch, to SQLite after patch*

```diff
--- <before - qt4 - sqlite>
+++ <after - qt4 - sqlite>
@@ -10,14 +10,81 @@
 ​[Debug] -------------------- 
 ​[Debug] -------------------- 
 ​[Debug] requestMsgsFiltered(): select_messagesNewestK_filtered.sql 
+​[Debug] Message(MsgId: BB52660 , [content removed]) 
+​[Debug] Message(MsgId: BB52634 , [content removed]) 
+​[Debug] Message(MsgId: BB52629 , [content removed]) 
+​[Debug] Message(MsgId: BB52589 , [content removed]) 
+​[Debug] Message(MsgId: BB52573 , [content removed]) 
+​[Debug] Message(MsgId: BB52520 , [content removed]) 
+​[Debug] Message(MsgId: BB52517 , [content removed]) 
+​[Debug] Message(MsgId: BB52479 , [content removed]) 
+​[Debug] Message(MsgId: BB52469 , [content removed]) 
+​[Debug] Message(MsgId: BB52184 , [content removed]) 
+​[Debug] Message(MsgId: BB52182 , [content removed]) 
+​[Debug] Message(MsgId: BB52180 , [content removed]) 
+​[Debug] Message(MsgId: BB52177 , [content removed]) 
+​[Debug] Message(MsgId: BB52170 , [content removed]) 
+​[Debug] Message(MsgId: BB52162 , [content removed]) 
 ​[Debug] -------------------- 
 ​[Debug] requestMsgsFiltered(): select_messagesNewerThan_filtered.sql 
+​[Debug] Message(MsgId: BB52660 , [content removed]) 
+​[Debug] Message(MsgId: BB52634 , [content removed]) 
+​[Debug] Message(MsgId: BB52629 , [content removed]) 
+​[Debug] Message(MsgId: BB52589 , [content removed]) 
+​[Debug] Message(MsgId: BB52573 , [content removed]) 
+​[Debug] Message(MsgId: BB52520 , [content removed]) 
+​[Debug] Message(MsgId: BB52517 , [content removed]) 
+​[Debug] Message(MsgId: BB52479 , [content removed]) 
+​[Debug] Message(MsgId: BB52469 , [content removed]) 
+​[Debug] Message(MsgId: BB52184 , [content removed]) 
+​[Debug] Message(MsgId: BB52182 , [content removed]) 
+​[Debug] Message(MsgId: BB52180 , [content removed]) 
+​[Debug] Message(MsgId: BB52177 , [content removed]) 
+​[Debug] Message(MsgId: BB52170 , [content removed]) 
+​[Debug] Message(MsgId: BB52162 , [content removed]) 
 ​[Debug] -------------------- 
 ​[Debug] requestMsgsFiltered(): select_messagesRange_filtered.sql 
+​[Debug] Message(MsgId: AA41693 , [content removed]) 
+​[Debug] Message(MsgId: AA41691 , [content removed]) 
+​[Debug] Message(MsgId: AA41643 , [content removed]) 
+​[Debug] Message(MsgId: AA41619 , [content removed]) 
+​[Debug] Message(MsgId: AA41618 , [content removed]) 
+​[Debug] Message(MsgId: AA41615 , [content removed]) 
+​[Debug] Message(MsgId: AA41579 , [content removed]) 
 ​[Debug] -------------------- 
 ​[Debug] requestMsgs(): select_messagesNewestK.sql 
+​[Debug] Message(MsgId: BB52660 , [content removed]) 
+​[Debug] Message(MsgId: BB52634 , [content removed]) 
+​[Debug] Message(MsgId: BB52629 , [content removed]) 
+​[Debug] Message(MsgId: BB52589 , [content removed]) 
+​[Debug] Message(MsgId: BB52573 , [content removed]) 
+​[Debug] Message(MsgId: BB52520 , [content removed]) 
+​[Debug] Message(MsgId: BB52517 , [content removed]) 
+​[Debug] Message(MsgId: BB52479 , [content removed]) 
+​[Debug] Message(MsgId: BB52469 , [content removed]) 
+​[Debug] Message(MsgId: BB52184 , [content removed]) 
+​[Debug] Message(MsgId: BB52182 , [content removed]) 
+​[Debug] Message(MsgId: BB52180 , [content removed]) 
+​[Debug] Message(MsgId: BB52177 , [content removed]) 
+​[Debug] Message(MsgId: BB52170 , [content removed]) 
+​[Debug] Message(MsgId: BB52162 , [content removed]) 
 ​[Debug] -------------------- 
 ​[Debug] requestMsgs(): select_messagesNewerThan.sql 
+​[Debug] Message(MsgId: BB52660 , [content removed]) 
+​[Debug] Message(MsgId: BB52634 , [content removed]) 
+​[Debug] Message(MsgId: BB52629 , [content removed]) 
+​[Debug] Message(MsgId: BB52589 , [content removed]) 
+​[Debug] Message(MsgId: BB52573 , [content removed]) 
+​[Debug] Message(MsgId: BB52520 , [content removed]) 
+​[Debug] Message(MsgId: BB52517 , [content removed]) 
+​[Debug] Message(MsgId: BB52479 , [content removed]) 
+​[Debug] Message(MsgId: BB52469 , [content removed]) 
+​[Debug] Message(MsgId: BB52184 , [content removed]) 
+​[Debug] Message(MsgId: BB52182 , [content removed]) 
+​[Debug] Message(MsgId: BB52180 , [content removed]) 
+​[Debug] Message(MsgId: BB52177 , [content removed]) 
+​[Debug] Message(MsgId: BB52170 , [content removed]) 
+​[Debug] Message(MsgId: BB52162 , [content removed]) 
 ​[Debug] -------------------- 
 ​[Debug] requestMsgs(): select_messagesRange.sql 
 ​[Debug] Message(MsgId: AA41693 , [content removed]) 
@@ -29,5 +96,35 @@
 ​[Debug] Message(MsgId: AA41579 , [content removed]) 
 ​[Debug] -------------------- 
 ​[Debug] requestAllMsgsFiltered(): select_messagesAll_filtered.sql 
+​[Debug] Message(MsgId: BB65216 , [content removed]) 
+​[Debug] Message(MsgId: BB65215 , [content removed]) 
+​[Debug] Message(MsgId: BB65214 , [content removed]) 
+​[Debug] Message(MsgId: BB65213 , [content removed]) 
+​[Debug] Message(MsgId: BB65212 , [content removed]) 
+​[Debug] Message(MsgId: BB65210 , [content removed]) 
+​[Debug] Message(MsgId: BB65209 , [content removed]) 
+​[Debug] Message(MsgId: BB65207 , [content removed]) 
+​[Debug] Message(MsgId: BB65206 , [content removed]) 
+​[Debug] Message(MsgId: BB65204 , [content removed]) 
+​[Debug] Message(MsgId: BB65203 , [content removed]) 
+​[Debug] Message(MsgId: BB65201 , [content removed]) 
+​[Debug] Message(MsgId: BB65200 , [content removed]) 
+​[Debug] Message(MsgId: BB65199 , [content removed]) 
+​[Debug] Message(MsgId: BB65198 , [content removed]) 
 ​[Debug] -------------------- 
 ​[Debug] requestAllMsgsFiltered(): select_messagesAllNew_filtered.sql 
+​[Debug] Message(MsgId: AA41714 , [content removed]) 
+​[Debug] Message(MsgId: AA41713 , [content removed]) 
+​[Debug] Message(MsgId: AA41712 , [content removed]) 
+​[Debug] Message(MsgId: AA41710 , [content removed]) 
+​[Debug] Message(MsgId: AA41707 , [content removed]) 
+​[Debug] Message(MsgId: AA41705 , [content removed]) 
+​[Debug] Message(MsgId: AA41704 , [content removed]) 
+​[Debug] Message(MsgId: AA41700 , [content removed]) 
+​[Debug] Message(MsgId: AA41698 , [content removed]) 
+​[Debug] Message(MsgId: AA41697 , [content removed]) 
+​[Debug] Message(MsgId: AA41695 , [content removed]) 
+​[Debug] Message(MsgId: AA41693 , [content removed]) 
+​[Debug] Message(MsgId: AA41692 , [content removed]) 
+​[Debug] Message(MsgId: AA41691 , [content removed]) 
+​[Debug] Message(MsgId: AA41689 , [content removed])
```

*Differences from Qt 4 PostgreSQL before patch, to PostgreSQL after patch*

```diff
--- <before - qt4 - postgresql>
+++ <after - qt4 - postgresql>
@@ -10,10 +10,47 @@
 ​[Debug] -------------------- 
 ​[Debug] -------------------- 
 ​[Debug] requestMsgsFiltered(): select_messagesNewestK_filtered.sql 
+​[Debug] Message(MsgId: BB52660 , [content removed]) 
+​[Debug] Message(MsgId: BB52634 , [content removed]) 
+​[Debug] Message(MsgId: BB52629 , [content removed]) 
+​[Debug] Message(MsgId: BB52589 , [content removed]) 
+​[Debug] Message(MsgId: BB52573 , [content removed]) 
+​[Debug] Message(MsgId: BB52520 , [content removed]) 
+​[Debug] Message(MsgId: BB52517 , [content removed]) 
+​[Debug] Message(MsgId: BB52479 , [content removed]) 
+​[Debug] Message(MsgId: BB52469 , [content removed]) 
+​[Debug] Message(MsgId: BB52184 , [content removed]) 
+​[Debug] Message(MsgId: BB52182 , [content removed]) 
+​[Debug] Message(MsgId: BB52180 , [content removed]) 
+​[Debug] Message(MsgId: BB52177 , [content removed]) 
+​[Debug] Message(MsgId: BB52170 , [content removed]) 
+​[Debug] Message(MsgId: BB52162 , [content removed]) 
 ​[Debug] -------------------- 
 ​[Debug] requestMsgsFiltered(): select_messagesNewerThan_filtered.sql 
+​[Debug] Message(MsgId: BB52660 , [content removed]) 
+​[Debug] Message(MsgId: BB52634 , [content removed]) 
+​[Debug] Message(MsgId: BB52629 , [content removed]) 
+​[Debug] Message(MsgId: BB52589 , [content removed]) 
+​[Debug] Message(MsgId: BB52573 , [content removed]) 
+​[Debug] Message(MsgId: BB52520 , [content removed]) 
+​[Debug] Message(MsgId: BB52517 , [content removed]) 
+​[Debug] Message(MsgId: BB52479 , [content removed]) 
+​[Debug] Message(MsgId: BB52469 , [content removed]) 
+​[Debug] Message(MsgId: BB52184 , [content removed]) 
+​[Debug] Message(MsgId: BB52182 , [content removed]) 
+​[Debug] Message(MsgId: BB52180 , [content removed]) 
+​[Debug] Message(MsgId: BB52177 , [content removed]) 
+​[Debug] Message(MsgId: BB52170 , [content removed]) 
+​[Debug] Message(MsgId: BB52162 , [content removed]) 
 ​[Debug] -------------------- 
 ​[Debug] requestMsgsFiltered(): select_messagesRange_filtered.sql 
+​[Debug] Message(MsgId: AA41693 , [content removed]) 
+​[Debug] Message(MsgId: AA41691 , [content removed]) 
+​[Debug] Message(MsgId: AA41643 , [content removed]) 
+​[Debug] Message(MsgId: AA41619 , [content removed]) 
+​[Debug] Message(MsgId: AA41618 , [content removed]) 
+​[Debug] Message(MsgId: AA41615 , [content removed]) 
+​[Debug] Message(MsgId: AA41579 , [content removed]) 
 ​[Debug] -------------------- 
 ​[Debug] requestMsgs(): select_messagesNewestK.sql 
 ​[Debug] Message(MsgId: BB52660 , [content removed]) 
@@ -59,6 +96,36 @@
 ​[Debug] Message(MsgId: AA41579 , [content removed]) 
 ​[Debug] -------------------- 
 ​[Debug] requestAllMsgsFiltered(): select_messagesAll_filtered.sql 
+​[Debug] Message(MsgId: BB65216 , [content removed]) 
+​[Debug] Message(MsgId: BB65215 , [content removed]) 
+​[Debug] Message(MsgId: BB65214 , [content removed]) 
+​[Debug] Message(MsgId: BB65213 , [content removed]) 
+​[Debug] Message(MsgId: BB65212 , [content removed]) 
+​[Debug] Message(MsgId: BB65210 , [content removed]) 
+​[Debug] Message(MsgId: BB65209 , [content removed]) 
+​[Debug] Message(MsgId: BB65207 , [content removed]) 
+​[Debug] Message(MsgId: BB65206 , [content removed]) 
+​[Debug] Message(MsgId: BB65204 , [content removed]) 
+​[Debug] Message(MsgId: BB65203 , [content removed]) 
+​[Debug] Message(MsgId: BB65201 , [content removed]) 
+​[Debug] Message(MsgId: BB65200 , [content removed]) 
+​[Debug] Message(MsgId: BB65199 , [content removed]) 
+​[Debug] Message(MsgId: BB65198 , [content removed]) 
 ​[Debug] -------------------- 
 ​[Debug] requestAllMsgsFiltered(): select_messagesAllNew_filtered.sql 
+​[Debug] Message(MsgId: AA41714 , [content removed]) 
+​[Debug] Message(MsgId: AA41713 , [content removed]) 
+​[Debug] Message(MsgId: AA41712 , [content removed]) 
+​[Debug] Message(MsgId: AA41710 , [content removed]) 
+​[Debug] Message(MsgId: AA41707 , [content removed]) 
+​[Debug] Message(MsgId: AA41705 , [content removed]) 
+​[Debug] Message(MsgId: AA41704 , [content removed]) 
+​[Debug] Message(MsgId: AA41700 , [content removed]) 
+​[Debug] Message(MsgId: AA41698 , [content removed]) 
+​[Debug] Message(MsgId: AA41697 , [content removed]) 
+​[Debug] Message(MsgId: AA41695 , [content removed]) 
+​[Debug] Message(MsgId: AA41693 , [content removed]) 
+​[Debug] Message(MsgId: AA41692 , [content removed]) 
+​[Debug] Message(MsgId: AA41691 , [content removed]) 
+​[Debug] Message(MsgId: AA41689 , [content removed]) 
 ​[Warn ] The server version of this PostgreSQL is unknown, falling back to the client version.
```

**Qt 5, SQLite**
<details>
<summary><i>Qt 5 SQLite, v0.13</i></summary>
<pre>
[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 GMT 
[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 GMT 
[Info ] SQLite storage backend is ready. Schema version: 31 
[Info ] Database authenticator is ready. 
[Info ] Listening for GUI clients on IPv6 ::1 port 4242 using protocol version 10 
[Info ] Listening for GUI clients on IPv4 127.0.0.1 port 4242 using protocol version 10 
[Info ] Restoring previous core state... 
​[Debug] Message dumps, limit = 15
​[Debug] --------------------
​[Debug] --------------------
​[Debug] requestMsgsFiltered(): select_messagesNewestK_filtered.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgsFiltered(): select_messagesNewerThan_filtered.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgsFiltered(): select_messagesRange_filtered.sql
​[Debug] Message(MsgId: AA41693 , [content removed])
​[Debug] Message(MsgId: AA41691 , [content removed])
​[Debug] Message(MsgId: AA41643 , [content removed])
​[Debug] Message(MsgId: AA41619 , [content removed])
​[Debug] Message(MsgId: AA41618 , [content removed])
​[Debug] Message(MsgId: AA41615 , [content removed])
​[Debug] Message(MsgId: AA41579 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgs(): select_messagesNewestK.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgs(): select_messagesNewerThan.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgs(): select_messagesRange.sql
​[Debug] Message(MsgId: AA41693 , [content removed])
​[Debug] Message(MsgId: AA41691 , [content removed])
​[Debug] Message(MsgId: AA41643 , [content removed])
​[Debug] Message(MsgId: AA41619 , [content removed])
​[Debug] Message(MsgId: AA41618 , [content removed])
​[Debug] Message(MsgId: AA41615 , [content removed])
​[Debug] Message(MsgId: AA41579 , [content removed])
​[Debug] --------------------
​[Debug] requestAllMsgsFiltered(): select_messagesAll_filtered.sql
​[Debug] Message(MsgId: BB65216 , [content removed])
​[Debug] Message(MsgId: BB65215 , [content removed])
​[Debug] Message(MsgId: BB65214 , [content removed])
​[Debug] Message(MsgId: BB65213 , [content removed])
​[Debug] Message(MsgId: BB65212 , [content removed])
​[Debug] Message(MsgId: BB65210 , [content removed])
​[Debug] Message(MsgId: BB65209 , [content removed])
​[Debug] Message(MsgId: BB65207 , [content removed])
​[Debug] Message(MsgId: BB65206 , [content removed])
​[Debug] Message(MsgId: BB65204 , [content removed])
​[Debug] Message(MsgId: BB65203 , [content removed])
​[Debug] Message(MsgId: BB65201 , [content removed])
​[Debug] Message(MsgId: BB65200 , [content removed])
​[Debug] Message(MsgId: BB65199 , [content removed])
​[Debug] Message(MsgId: BB65198 , [content removed])
​[Debug] --------------------
​[Debug] requestAllMsgsFiltered(): select_messagesAllNew_filtered.sql
​[Debug] Message(MsgId: AA41714 , [content removed])
​[Debug] Message(MsgId: AA41713 , [content removed])
​[Debug] Message(MsgId: AA41712 , [content removed])
​[Debug] Message(MsgId: AA41710 , [content removed])
​[Debug] Message(MsgId: AA41707 , [content removed])
​[Debug] Message(MsgId: AA41705 , [content removed])
​[Debug] Message(MsgId: AA41704 , [content removed])
​[Debug] Message(MsgId: AA41700 , [content removed])
​[Debug] Message(MsgId: AA41698 , [content removed])
​[Debug] Message(MsgId: AA41697 , [content removed])
​[Debug] Message(MsgId: AA41695 , [content removed])
​[Debug] Message(MsgId: AA41693 , [content removed])
​[Debug] Message(MsgId: AA41692 , [content removed])
​[Debug] Message(MsgId: AA41691 , [content removed])
​[Debug] Message(MsgId: AA41689 , [content removed])
</pre>
</details>
</br>

<details>
<summary><i>Qt 5 SQLite, this patch</i></summary>
<pre>
[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 GMT 
[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 GMT 
[Info ] SQLite storage backend is ready. Schema version: 31 
[Info ] Database authenticator is ready. 
[Info ] Listening for GUI clients on IPv6 ::1 port 4242 using protocol version 10 
[Info ] Listening for GUI clients on IPv4 127.0.0.1 port 4242 using protocol version 10 
[Info ] Restoring previous core state... 
​[Debug] Message dumps, limit = 15
​[Debug] --------------------
​[Debug] --------------------
​[Debug] requestMsgsFiltered(): select_messagesNewestK_filtered.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgsFiltered(): select_messagesNewerThan_filtered.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgsFiltered(): select_messagesRange_filtered.sql
​[Debug] Message(MsgId: AA41693 , [content removed])
​[Debug] Message(MsgId: AA41691 , [content removed])
​[Debug] Message(MsgId: AA41643 , [content removed])
​[Debug] Message(MsgId: AA41619 , [content removed])
​[Debug] Message(MsgId: AA41618 , [content removed])
​[Debug] Message(MsgId: AA41615 , [content removed])
​[Debug] Message(MsgId: AA41579 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgs(): select_messagesNewestK.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgs(): select_messagesNewerThan.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgs(): select_messagesRange.sql
​[Debug] Message(MsgId: AA41693 , [content removed])
​[Debug] Message(MsgId: AA41691 , [content removed])
​[Debug] Message(MsgId: AA41643 , [content removed])
​[Debug] Message(MsgId: AA41619 , [content removed])
​[Debug] Message(MsgId: AA41618 , [content removed])
​[Debug] Message(MsgId: AA41615 , [content removed])
​[Debug] Message(MsgId: AA41579 , [content removed])
​[Debug] --------------------
​[Debug] requestAllMsgsFiltered(): select_messagesAll_filtered.sql
​[Debug] Message(MsgId: BB65216 , [content removed])
​[Debug] Message(MsgId: BB65215 , [content removed])
​[Debug] Message(MsgId: BB65214 , [content removed])
​[Debug] Message(MsgId: BB65213 , [content removed])
​[Debug] Message(MsgId: BB65212 , [content removed])
​[Debug] Message(MsgId: BB65210 , [content removed])
​[Debug] Message(MsgId: BB65209 , [content removed])
​[Debug] Message(MsgId: BB65207 , [content removed])
​[Debug] Message(MsgId: BB65206 , [content removed])
​[Debug] Message(MsgId: BB65204 , [content removed])
​[Debug] Message(MsgId: BB65203 , [content removed])
​[Debug] Message(MsgId: BB65201 , [content removed])
​[Debug] Message(MsgId: BB65200 , [content removed])
​[Debug] Message(MsgId: BB65199 , [content removed])
​[Debug] Message(MsgId: BB65198 , [content removed])
​[Debug] --------------------
​[Debug] requestAllMsgsFiltered(): select_messagesAllNew_filtered.sql
​[Debug] Message(MsgId: AA41714 , [content removed])
​[Debug] Message(MsgId: AA41713 , [content removed])
​[Debug] Message(MsgId: AA41712 , [content removed])
​[Debug] Message(MsgId: AA41710 , [content removed])
​[Debug] Message(MsgId: AA41707 , [content removed])
​[Debug] Message(MsgId: AA41705 , [content removed])
​[Debug] Message(MsgId: AA41704 , [content removed])
​[Debug] Message(MsgId: AA41700 , [content removed])
​[Debug] Message(MsgId: AA41698 , [content removed])
​[Debug] Message(MsgId: AA41697 , [content removed])
​[Debug] Message(MsgId: AA41695 , [content removed])
​[Debug] Message(MsgId: AA41693 , [content removed])
​[Debug] Message(MsgId: AA41692 , [content removed])
​[Debug] Message(MsgId: AA41691 , [content removed])
​[Debug] Message(MsgId: AA41689 , [content removed])
</pre>
</details>
</br>


**Qt 4, SQLite**
<details>
<summary><i>Qt 4 SQLite, v0.13</i></summary>
<pre>
​[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 
​[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 
​[Warn ] PostgreSQL driver plugin not available for Qt. Installed drivers: QSQLITE 
​[Info ] SQLite storage backend is ready. Schema version: 31 
​[Info ] Database authenticator is ready. 
​[Info ] Listening for GUI clients on IPv6 ::1 port 4242 using protocol version 10 
​[Info ] Listening for GUI clients on IPv4 127.0.0.1 port 4242 using protocol version 10 
​[Info ] Restoring previous core state... 
​[Debug] Message dumps, limit = 15 
​[Debug] -------------------- 
​[Debug] -------------------- 
​[Debug] requestMsgsFiltered(): select_messagesNewestK_filtered.sql 
​[Debug] -------------------- 
​[Debug] requestMsgsFiltered(): select_messagesNewerThan_filtered.sql 
​[Debug] -------------------- 
​[Debug] requestMsgsFiltered(): select_messagesRange_filtered.sql 
​[Debug] -------------------- 
​[Debug] requestMsgs(): select_messagesNewestK.sql 
​[Debug] -------------------- 
​[Debug] requestMsgs(): select_messagesNewerThan.sql 
​[Debug] -------------------- 
​[Debug] requestMsgs(): select_messagesRange.sql 
​[Debug] Message(MsgId: AA41693 , [content removed]) 
​[Debug] Message(MsgId: AA41691 , [content removed]) 
​[Debug] Message(MsgId: AA41643 , [content removed]) 
​[Debug] Message(MsgId: AA41619 , [content removed]) 
​[Debug] Message(MsgId: AA41618 , [content removed]) 
​[Debug] Message(MsgId: AA41615 , [content removed]) 
​[Debug] Message(MsgId: AA41579 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestAllMsgsFiltered(): select_messagesAll_filtered.sql 
​[Debug] -------------------- 
​[Debug] requestAllMsgsFiltered(): select_messagesAllNew_filtered.sql
</pre>
</details>
</br>

<details>
<summary><i>Qt 4 SQLite, this patch</i></summary>
<pre>
​[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 
​[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 
​[Warn ] PostgreSQL driver plugin not available for Qt. Installed drivers: QSQLITE 
​[Info ] SQLite storage backend is ready. Schema version: 31 
​[Info ] Database authenticator is ready. 
​[Info ] Listening for GUI clients on IPv6 ::1 port 4242 using protocol version 10 
​[Info ] Listening for GUI clients on IPv4 127.0.0.1 port 4242 using protocol version 10 
​[Info ] Restoring previous core state... 
​[Debug] Message dumps, limit = 15 
​[Debug] -------------------- 
​[Debug] -------------------- 
​[Debug] requestMsgsFiltered(): select_messagesNewestK_filtered.sql 
​[Debug] Message(MsgId: BB52660 , [content removed]) 
​[Debug] Message(MsgId: BB52634 , [content removed]) 
​[Debug] Message(MsgId: BB52629 , [content removed]) 
​[Debug] Message(MsgId: BB52589 , [content removed]) 
​[Debug] Message(MsgId: BB52573 , [content removed]) 
​[Debug] Message(MsgId: BB52520 , [content removed]) 
​[Debug] Message(MsgId: BB52517 , [content removed]) 
​[Debug] Message(MsgId: BB52479 , [content removed]) 
​[Debug] Message(MsgId: BB52469 , [content removed]) 
​[Debug] Message(MsgId: BB52184 , [content removed]) 
​[Debug] Message(MsgId: BB52182 , [content removed]) 
​[Debug] Message(MsgId: BB52180 , [content removed]) 
​[Debug] Message(MsgId: BB52177 , [content removed]) 
​[Debug] Message(MsgId: BB52170 , [content removed]) 
​[Debug] Message(MsgId: BB52162 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestMsgsFiltered(): select_messagesNewerThan_filtered.sql 
​[Debug] Message(MsgId: BB52660 , [content removed]) 
​[Debug] Message(MsgId: BB52634 , [content removed]) 
​[Debug] Message(MsgId: BB52629 , [content removed]) 
​[Debug] Message(MsgId: BB52589 , [content removed]) 
​[Debug] Message(MsgId: BB52573 , [content removed]) 
​[Debug] Message(MsgId: BB52520 , [content removed]) 
​[Debug] Message(MsgId: BB52517 , [content removed]) 
​[Debug] Message(MsgId: BB52479 , [content removed]) 
​[Debug] Message(MsgId: BB52469 , [content removed]) 
​[Debug] Message(MsgId: BB52184 , [content removed]) 
​[Debug] Message(MsgId: BB52182 , [content removed]) 
​[Debug] Message(MsgId: BB52180 , [content removed]) 
​[Debug] Message(MsgId: BB52177 , [content removed]) 
​[Debug] Message(MsgId: BB52170 , [content removed]) 
​[Debug] Message(MsgId: BB52162 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestMsgsFiltered(): select_messagesRange_filtered.sql 
​[Debug] Message(MsgId: AA41693 , [content removed]) 
​[Debug] Message(MsgId: AA41691 , [content removed]) 
​[Debug] Message(MsgId: AA41643 , [content removed]) 
​[Debug] Message(MsgId: AA41619 , [content removed]) 
​[Debug] Message(MsgId: AA41618 , [content removed]) 
​[Debug] Message(MsgId: AA41615 , [content removed]) 
​[Debug] Message(MsgId: AA41579 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestMsgs(): select_messagesNewestK.sql 
​[Debug] Message(MsgId: BB52660 , [content removed]) 
​[Debug] Message(MsgId: BB52634 , [content removed]) 
​[Debug] Message(MsgId: BB52629 , [content removed]) 
​[Debug] Message(MsgId: BB52589 , [content removed]) 
​[Debug] Message(MsgId: BB52573 , [content removed]) 
​[Debug] Message(MsgId: BB52520 , [content removed]) 
​[Debug] Message(MsgId: BB52517 , [content removed]) 
​[Debug] Message(MsgId: BB52479 , [content removed]) 
​[Debug] Message(MsgId: BB52469 , [content removed]) 
​[Debug] Message(MsgId: BB52184 , [content removed]) 
​[Debug] Message(MsgId: BB52182 , [content removed]) 
​[Debug] Message(MsgId: BB52180 , [content removed]) 
​[Debug] Message(MsgId: BB52177 , [content removed]) 
​[Debug] Message(MsgId: BB52170 , [content removed]) 
​[Debug] Message(MsgId: BB52162 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestMsgs(): select_messagesNewerThan.sql 
​[Debug] Message(MsgId: BB52660 , [content removed]) 
​[Debug] Message(MsgId: BB52634 , [content removed]) 
​[Debug] Message(MsgId: BB52629 , [content removed]) 
​[Debug] Message(MsgId: BB52589 , [content removed]) 
​[Debug] Message(MsgId: BB52573 , [content removed]) 
​[Debug] Message(MsgId: BB52520 , [content removed]) 
​[Debug] Message(MsgId: BB52517 , [content removed]) 
​[Debug] Message(MsgId: BB52479 , [content removed]) 
​[Debug] Message(MsgId: BB52469 , [content removed]) 
​[Debug] Message(MsgId: BB52184 , [content removed]) 
​[Debug] Message(MsgId: BB52182 , [content removed]) 
​[Debug] Message(MsgId: BB52180 , [content removed]) 
​[Debug] Message(MsgId: BB52177 , [content removed]) 
​[Debug] Message(MsgId: BB52170 , [content removed]) 
​[Debug] Message(MsgId: BB52162 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestMsgs(): select_messagesRange.sql 
​[Debug] Message(MsgId: AA41693 , [content removed]) 
​[Debug] Message(MsgId: AA41691 , [content removed]) 
​[Debug] Message(MsgId: AA41643 , [content removed]) 
​[Debug] Message(MsgId: AA41619 , [content removed]) 
​[Debug] Message(MsgId: AA41618 , [content removed]) 
​[Debug] Message(MsgId: AA41615 , [content removed]) 
​[Debug] Message(MsgId: AA41579 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestAllMsgsFiltered(): select_messagesAll_filtered.sql 
​[Debug] Message(MsgId: BB65216 , [content removed]) 
​[Debug] Message(MsgId: BB65215 , [content removed]) 
​[Debug] Message(MsgId: BB65214 , [content removed]) 
​[Debug] Message(MsgId: BB65213 , [content removed]) 
​[Debug] Message(MsgId: BB65212 , [content removed]) 
​[Debug] Message(MsgId: BB65210 , [content removed]) 
​[Debug] Message(MsgId: BB65209 , [content removed]) 
​[Debug] Message(MsgId: BB65207 , [content removed]) 
​[Debug] Message(MsgId: BB65206 , [content removed]) 
​[Debug] Message(MsgId: BB65204 , [content removed]) 
​[Debug] Message(MsgId: BB65203 , [content removed]) 
​[Debug] Message(MsgId: BB65201 , [content removed]) 
​[Debug] Message(MsgId: BB65200 , [content removed]) 
​[Debug] Message(MsgId: BB65199 , [content removed]) 
​[Debug] Message(MsgId: BB65198 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestAllMsgsFiltered(): select_messagesAllNew_filtered.sql 
​[Debug] Message(MsgId: AA41714 , [content removed]) 
​[Debug] Message(MsgId: AA41713 , [content removed]) 
​[Debug] Message(MsgId: AA41712 , [content removed]) 
​[Debug] Message(MsgId: AA41710 , [content removed]) 
​[Debug] Message(MsgId: AA41707 , [content removed]) 
​[Debug] Message(MsgId: AA41705 , [content removed]) 
​[Debug] Message(MsgId: AA41704 , [content removed]) 
​[Debug] Message(MsgId: AA41700 , [content removed]) 
​[Debug] Message(MsgId: AA41698 , [content removed]) 
​[Debug] Message(MsgId: AA41697 , [content removed]) 
​[Debug] Message(MsgId: AA41695 , [content removed]) 
​[Debug] Message(MsgId: AA41693 , [content removed]) 
​[Debug] Message(MsgId: AA41692 , [content removed]) 
​[Debug] Message(MsgId: AA41691 , [content removed]) 
​[Debug] Message(MsgId: AA41689 , [content removed])
</pre>
</details>
</br>


**Qt 5, PostgreSQL**
<details>
<summary><i>Qt 5 PostgreSQL, v0.13</i></summary>
<pre>
​[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 GMT 
​[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 GMT 
​[Warn ] The server version of this PostgreSQL is unknown, falling back to the client version.
​[Info ] PostgreSQL storage backend is ready. Schema version: 29 
​[Info ] Database authenticator is ready. 
​[Info ] Listening for GUI clients on IPv6 ::1 port 4242 using protocol version 10 
​[Info ] Listening for GUI clients on IPv4 127.0.0.1 port 4242 using protocol version 10 
​[Info ] Restoring previous core state... 
​[Debug] Message dumps, limit = 15
​[Debug] --------------------
​[Debug] --------------------
​[Debug] requestMsgsFiltered(): select_messagesNewestK_filtered.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgsFiltered(): select_messagesNewerThan_filtered.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgsFiltered(): select_messagesRange_filtered.sql
​[Debug] Message(MsgId: AA41693 , [content removed])
​[Debug] Message(MsgId: AA41691 , [content removed])
​[Debug] Message(MsgId: AA41643 , [content removed])
​[Debug] Message(MsgId: AA41619 , [content removed])
​[Debug] Message(MsgId: AA41618 , [content removed])
​[Debug] Message(MsgId: AA41615 , [content removed])
​[Debug] Message(MsgId: AA41579 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgs(): select_messagesNewestK.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgs(): select_messagesNewerThan.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgs(): select_messagesRange.sql
​[Debug] Message(MsgId: AA41693 , [content removed])
​[Debug] Message(MsgId: AA41691 , [content removed])
​[Debug] Message(MsgId: AA41643 , [content removed])
​[Debug] Message(MsgId: AA41619 , [content removed])
​[Debug] Message(MsgId: AA41618 , [content removed])
​[Debug] Message(MsgId: AA41615 , [content removed])
​[Debug] Message(MsgId: AA41579 , [content removed])
​[Debug] --------------------
​[Debug] requestAllMsgsFiltered(): select_messagesAll_filtered.sql
​[Debug] Message(MsgId: BB65216 , [content removed])
​[Debug] Message(MsgId: BB65215 , [content removed])
​[Debug] Message(MsgId: BB65214 , [content removed])
​[Debug] Message(MsgId: BB65213 , [content removed])
​[Debug] Message(MsgId: BB65212 , [content removed])
​[Debug] Message(MsgId: BB65210 , [content removed])
​[Debug] Message(MsgId: BB65209 , [content removed])
​[Debug] Message(MsgId: BB65207 , [content removed])
​[Debug] Message(MsgId: BB65206 , [content removed])
​[Debug] Message(MsgId: BB65204 , [content removed])
​[Debug] Message(MsgId: BB65203 , [content removed])
​[Debug] Message(MsgId: BB65201 , [content removed])
​[Debug] Message(MsgId: BB65200 , [content removed])
​[Debug] Message(MsgId: BB65199 , [content removed])
​[Debug] Message(MsgId: BB65198 , [content removed])
​[Debug] --------------------
​[Debug] requestAllMsgsFiltered(): select_messagesAllNew_filtered.sql
​[Debug] Message(MsgId: AA41714 , [content removed])
​[Debug] Message(MsgId: AA41713 , [content removed])
​[Debug] Message(MsgId: AA41712 , [content removed])
​[Debug] Message(MsgId: AA41710 , [content removed])
​[Debug] Message(MsgId: AA41707 , [content removed])
​[Debug] Message(MsgId: AA41705 , [content removed])
​[Debug] Message(MsgId: AA41704 , [content removed])
​[Debug] Message(MsgId: AA41700 , [content removed])
​[Debug] Message(MsgId: AA41698 , [content removed])
​[Debug] Message(MsgId: AA41697 , [content removed])
​[Debug] Message(MsgId: AA41695 , [content removed])
​[Debug] Message(MsgId: AA41693 , [content removed])
​[Debug] Message(MsgId: AA41692 , [content removed])
​[Debug] Message(MsgId: AA41691 , [content removed])
​[Debug] Message(MsgId: AA41689 , [content removed])
​[Warn ] The server version of this PostgreSQL is unknown, falling back to the client version.
</pre>
</details>
</br>

<details>
<summary><i>Qt 5 PostgreSQL, this patch</i></summary>
<pre>
​[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 GMT 
​[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 GMT 
​[Warn ] The server version of this PostgreSQL is unknown, falling back to the client version.
​[Info ] PostgreSQL storage backend is ready. Schema version: 29 
​[Info ] Database authenticator is ready. 
​[Info ] Listening for GUI clients on IPv6 ::1 port 4242 using protocol version 10 
​[Info ] Listening for GUI clients on IPv4 127.0.0.1 port 4242 using protocol version 10 
​[Info ] Restoring previous core state... 
​[Debug] Message dumps, limit = 15
​[Debug] --------------------
​[Debug] --------------------
​[Debug] requestMsgsFiltered(): select_messagesNewestK_filtered.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgsFiltered(): select_messagesNewerThan_filtered.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgsFiltered(): select_messagesRange_filtered.sql
​[Debug] Message(MsgId: AA41693 , [content removed])
​[Debug] Message(MsgId: AA41691 , [content removed])
​[Debug] Message(MsgId: AA41643 , [content removed])
​[Debug] Message(MsgId: AA41619 , [content removed])
​[Debug] Message(MsgId: AA41618 , [content removed])
​[Debug] Message(MsgId: AA41615 , [content removed])
​[Debug] Message(MsgId: AA41579 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgs(): select_messagesNewestK.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgs(): select_messagesNewerThan.sql
​[Debug] Message(MsgId: BB52660 , [content removed])
​[Debug] Message(MsgId: BB52634 , [content removed])
​[Debug] Message(MsgId: BB52629 , [content removed])
​[Debug] Message(MsgId: BB52589 , [content removed])
​[Debug] Message(MsgId: BB52573 , [content removed])
​[Debug] Message(MsgId: BB52520 , [content removed])
​[Debug] Message(MsgId: BB52517 , [content removed])
​[Debug] Message(MsgId: BB52479 , [content removed])
​[Debug] Message(MsgId: BB52469 , [content removed])
​[Debug] Message(MsgId: BB52184 , [content removed])
​[Debug] Message(MsgId: BB52182 , [content removed])
​[Debug] Message(MsgId: BB52180 , [content removed])
​[Debug] Message(MsgId: BB52177 , [content removed])
​[Debug] Message(MsgId: BB52170 , [content removed])
​[Debug] Message(MsgId: BB52162 , [content removed])
​[Debug] --------------------
​[Debug] requestMsgs(): select_messagesRange.sql
​[Debug] Message(MsgId: AA41693 , [content removed])
​[Debug] Message(MsgId: AA41691 , [content removed])
​[Debug] Message(MsgId: AA41643 , [content removed])
​[Debug] Message(MsgId: AA41619 , [content removed])
​[Debug] Message(MsgId: AA41618 , [content removed])
​[Debug] Message(MsgId: AA41615 , [content removed])
​[Debug] Message(MsgId: AA41579 , [content removed])
​[Debug] --------------------
​[Debug] requestAllMsgsFiltered(): select_messagesAll_filtered.sql
​[Debug] Message(MsgId: BB65216 , [content removed])
​[Debug] Message(MsgId: BB65215 , [content removed])
​[Debug] Message(MsgId: BB65214 , [content removed])
​[Debug] Message(MsgId: BB65213 , [content removed])
​[Debug] Message(MsgId: BB65212 , [content removed])
​[Debug] Message(MsgId: BB65210 , [content removed])
​[Debug] Message(MsgId: BB65209 , [content removed])
​[Debug] Message(MsgId: BB65207 , [content removed])
​[Debug] Message(MsgId: BB65206 , [content removed])
​[Debug] Message(MsgId: BB65204 , [content removed])
​[Debug] Message(MsgId: BB65203 , [content removed])
​[Debug] Message(MsgId: BB65201 , [content removed])
​[Debug] Message(MsgId: BB65200 , [content removed])
​[Debug] Message(MsgId: BB65199 , [content removed])
​[Debug] Message(MsgId: BB65198 , [content removed])
​[Debug] --------------------
​[Debug] requestAllMsgsFiltered(): select_messagesAllNew_filtered.sql
​[Debug] Message(MsgId: AA41714 , [content removed])
​[Debug] Message(MsgId: AA41713 , [content removed])
​[Debug] Message(MsgId: AA41712 , [content removed])
​[Debug] Message(MsgId: AA41710 , [content removed])
​[Debug] Message(MsgId: AA41707 , [content removed])
​[Debug] Message(MsgId: AA41705 , [content removed])
​[Debug] Message(MsgId: AA41704 , [content removed])
​[Debug] Message(MsgId: AA41700 , [content removed])
​[Debug] Message(MsgId: AA41698 , [content removed])
​[Debug] Message(MsgId: AA41697 , [content removed])
​[Debug] Message(MsgId: AA41695 , [content removed])
​[Debug] Message(MsgId: AA41693 , [content removed])
​[Debug] Message(MsgId: AA41692 , [content removed])
​[Debug] Message(MsgId: AA41691 , [content removed])
​[Debug] Message(MsgId: AA41689 , [content removed])
​[Warn ] The server version of this PostgreSQL is unknown, falling back to the client version.
</pre>
</details>
</br>


**Qt 4, PostgreSQL**
<details>
<summary><i>Qt 4 PostgreSQL, v0.13</i></summary>
<pre>
​[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 
​[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 
​[Warn ] The server version of this PostgreSQL is unknown, falling back to the client version.
​[Info ] PostgreSQL storage backend is ready. Schema version: 29 
​[Info ] Database authenticator is ready. 
​[Info ] Listening for GUI clients on IPv6 ::1 port 4242 using protocol version 10 
​[Info ] Listening for GUI clients on IPv4 127.0.0.1 port 4242 using protocol version 10 
​[Info ] Restoring previous core state... 
​[Debug] Message dumps, limit = 15 
​[Debug] -------------------- 
​[Debug] -------------------- 
​[Debug] requestMsgsFiltered(): select_messagesNewestK_filtered.sql 
​[Debug] -------------------- 
​[Debug] requestMsgsFiltered(): select_messagesNewerThan_filtered.sql 
​[Debug] -------------------- 
​[Debug] requestMsgsFiltered(): select_messagesRange_filtered.sql 
​[Debug] -------------------- 
​[Debug] requestMsgs(): select_messagesNewestK.sql 
​[Debug] Message(MsgId: BB52660 , [content removed]) 
​[Debug] Message(MsgId: BB52634 , [content removed]) 
​[Debug] Message(MsgId: BB52629 , [content removed]) 
​[Debug] Message(MsgId: BB52589 , [content removed]) 
​[Debug] Message(MsgId: BB52573 , [content removed]) 
​[Debug] Message(MsgId: BB52520 , [content removed]) 
​[Debug] Message(MsgId: BB52517 , [content removed]) 
​[Debug] Message(MsgId: BB52479 , [content removed]) 
​[Debug] Message(MsgId: BB52469 , [content removed]) 
​[Debug] Message(MsgId: BB52184 , [content removed]) 
​[Debug] Message(MsgId: BB52182 , [content removed]) 
​[Debug] Message(MsgId: BB52180 , [content removed]) 
​[Debug] Message(MsgId: BB52177 , [content removed]) 
​[Debug] Message(MsgId: BB52170 , [content removed]) 
​[Debug] Message(MsgId: BB52162 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestMsgs(): select_messagesNewerThan.sql 
​[Debug] Message(MsgId: BB52660 , [content removed]) 
​[Debug] Message(MsgId: BB52634 , [content removed]) 
​[Debug] Message(MsgId: BB52629 , [content removed]) 
​[Debug] Message(MsgId: BB52589 , [content removed]) 
​[Debug] Message(MsgId: BB52573 , [content removed]) 
​[Debug] Message(MsgId: BB52520 , [content removed]) 
​[Debug] Message(MsgId: BB52517 , [content removed]) 
​[Debug] Message(MsgId: BB52479 , [content removed]) 
​[Debug] Message(MsgId: BB52469 , [content removed]) 
​[Debug] Message(MsgId: BB52184 , [content removed]) 
​[Debug] Message(MsgId: BB52182 , [content removed]) 
​[Debug] Message(MsgId: BB52180 , [content removed]) 
​[Debug] Message(MsgId: BB52177 , [content removed]) 
​[Debug] Message(MsgId: BB52170 , [content removed]) 
​[Debug] Message(MsgId: BB52162 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestMsgs(): select_messagesRange.sql 
​[Debug] Message(MsgId: AA41693 , [content removed]) 
​[Debug] Message(MsgId: AA41691 , [content removed]) 
​[Debug] Message(MsgId: AA41643 , [content removed]) 
​[Debug] Message(MsgId: AA41619 , [content removed]) 
​[Debug] Message(MsgId: AA41618 , [content removed]) 
​[Debug] Message(MsgId: AA41615 , [content removed]) 
​[Debug] Message(MsgId: AA41579 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestAllMsgsFiltered(): select_messagesAll_filtered.sql 
​[Debug] -------------------- 
​[Debug] requestAllMsgsFiltered(): select_messagesAllNew_filtered.sql 
​[Warn ] The server version of this PostgreSQL is unknown, falling back to the client version.
</pre>
</details>
</br>

<details>
<summary><i>Qt 4 PostgreSQL, this patch</i></summary>
<pre>
​[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 
​[Warn ] SslServer: Certificate expired on Fri Jun 8 19:26:17 2018 
​[Warn ] The server version of this PostgreSQL is unknown, falling back to the client version.
​[Info ] PostgreSQL storage backend is ready. Schema version: 29 
​[Info ] Database authenticator is ready. 
​[Info ] Listening for GUI clients on IPv6 ::1 port 4242 using protocol version 10 
​[Info ] Listening for GUI clients on IPv4 127.0.0.1 port 4242 using protocol version 10 
​[Info ] Restoring previous core state... 
​[Debug] Message dumps, limit = 15 
​[Debug] -------------------- 
​[Debug] -------------------- 
​[Debug] requestMsgsFiltered(): select_messagesNewestK_filtered.sql 
​[Debug] Message(MsgId: BB52660 , [content removed]) 
​[Debug] Message(MsgId: BB52634 , [content removed]) 
​[Debug] Message(MsgId: BB52629 , [content removed]) 
​[Debug] Message(MsgId: BB52589 , [content removed]) 
​[Debug] Message(MsgId: BB52573 , [content removed]) 
​[Debug] Message(MsgId: BB52520 , [content removed]) 
​[Debug] Message(MsgId: BB52517 , [content removed]) 
​[Debug] Message(MsgId: BB52479 , [content removed]) 
​[Debug] Message(MsgId: BB52469 , [content removed]) 
​[Debug] Message(MsgId: BB52184 , [content removed]) 
​[Debug] Message(MsgId: BB52182 , [content removed]) 
​[Debug] Message(MsgId: BB52180 , [content removed]) 
​[Debug] Message(MsgId: BB52177 , [content removed]) 
​[Debug] Message(MsgId: BB52170 , [content removed]) 
​[Debug] Message(MsgId: BB52162 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestMsgsFiltered(): select_messagesNewerThan_filtered.sql 
​[Debug] Message(MsgId: BB52660 , [content removed]) 
​[Debug] Message(MsgId: BB52634 , [content removed]) 
​[Debug] Message(MsgId: BB52629 , [content removed]) 
​[Debug] Message(MsgId: BB52589 , [content removed]) 
​[Debug] Message(MsgId: BB52573 , [content removed]) 
​[Debug] Message(MsgId: BB52520 , [content removed]) 
​[Debug] Message(MsgId: BB52517 , [content removed]) 
​[Debug] Message(MsgId: BB52479 , [content removed]) 
​[Debug] Message(MsgId: BB52469 , [content removed]) 
​[Debug] Message(MsgId: BB52184 , [content removed]) 
​[Debug] Message(MsgId: BB52182 , [content removed]) 
​[Debug] Message(MsgId: BB52180 , [content removed]) 
​[Debug] Message(MsgId: BB52177 , [content removed]) 
​[Debug] Message(MsgId: BB52170 , [content removed]) 
​[Debug] Message(MsgId: BB52162 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestMsgsFiltered(): select_messagesRange_filtered.sql 
​[Debug] Message(MsgId: AA41693 , [content removed]) 
​[Debug] Message(MsgId: AA41691 , [content removed]) 
​[Debug] Message(MsgId: AA41643 , [content removed]) 
​[Debug] Message(MsgId: AA41619 , [content removed]) 
​[Debug] Message(MsgId: AA41618 , [content removed]) 
​[Debug] Message(MsgId: AA41615 , [content removed]) 
​[Debug] Message(MsgId: AA41579 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestMsgs(): select_messagesNewestK.sql 
​[Debug] Message(MsgId: BB52660 , [content removed]) 
​[Debug] Message(MsgId: BB52634 , [content removed]) 
​[Debug] Message(MsgId: BB52629 , [content removed]) 
​[Debug] Message(MsgId: BB52589 , [content removed]) 
​[Debug] Message(MsgId: BB52573 , [content removed]) 
​[Debug] Message(MsgId: BB52520 , [content removed]) 
​[Debug] Message(MsgId: BB52517 , [content removed]) 
​[Debug] Message(MsgId: BB52479 , [content removed]) 
​[Debug] Message(MsgId: BB52469 , [content removed]) 
​[Debug] Message(MsgId: BB52184 , [content removed]) 
​[Debug] Message(MsgId: BB52182 , [content removed]) 
​[Debug] Message(MsgId: BB52180 , [content removed]) 
​[Debug] Message(MsgId: BB52177 , [content removed]) 
​[Debug] Message(MsgId: BB52170 , [content removed]) 
​[Debug] Message(MsgId: BB52162 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestMsgs(): select_messagesNewerThan.sql 
​[Debug] Message(MsgId: BB52660 , [content removed]) 
​[Debug] Message(MsgId: BB52634 , [content removed]) 
​[Debug] Message(MsgId: BB52629 , [content removed]) 
​[Debug] Message(MsgId: BB52589 , [content removed]) 
​[Debug] Message(MsgId: BB52573 , [content removed]) 
​[Debug] Message(MsgId: BB52520 , [content removed]) 
​[Debug] Message(MsgId: BB52517 , [content removed]) 
​[Debug] Message(MsgId: BB52479 , [content removed]) 
​[Debug] Message(MsgId: BB52469 , [content removed]) 
​[Debug] Message(MsgId: BB52184 , [content removed]) 
​[Debug] Message(MsgId: BB52182 , [content removed]) 
​[Debug] Message(MsgId: BB52180 , [content removed]) 
​[Debug] Message(MsgId: BB52177 , [content removed]) 
​[Debug] Message(MsgId: BB52170 , [content removed]) 
​[Debug] Message(MsgId: BB52162 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestMsgs(): select_messagesRange.sql 
​[Debug] Message(MsgId: AA41693 , [content removed]) 
​[Debug] Message(MsgId: AA41691 , [content removed]) 
​[Debug] Message(MsgId: AA41643 , [content removed]) 
​[Debug] Message(MsgId: AA41619 , [content removed]) 
​[Debug] Message(MsgId: AA41618 , [content removed]) 
​[Debug] Message(MsgId: AA41615 , [content removed]) 
​[Debug] Message(MsgId: AA41579 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestAllMsgsFiltered(): select_messagesAll_filtered.sql 
​[Debug] Message(MsgId: BB65216 , [content removed]) 
​[Debug] Message(MsgId: BB65215 , [content removed]) 
​[Debug] Message(MsgId: BB65214 , [content removed]) 
​[Debug] Message(MsgId: BB65213 , [content removed]) 
​[Debug] Message(MsgId: BB65212 , [content removed]) 
​[Debug] Message(MsgId: BB65210 , [content removed]) 
​[Debug] Message(MsgId: BB65209 , [content removed]) 
​[Debug] Message(MsgId: BB65207 , [content removed]) 
​[Debug] Message(MsgId: BB65206 , [content removed]) 
​[Debug] Message(MsgId: BB65204 , [content removed]) 
​[Debug] Message(MsgId: BB65203 , [content removed]) 
​[Debug] Message(MsgId: BB65201 , [content removed]) 
​[Debug] Message(MsgId: BB65200 , [content removed]) 
​[Debug] Message(MsgId: BB65199 , [content removed]) 
​[Debug] Message(MsgId: BB65198 , [content removed]) 
​[Debug] -------------------- 
​[Debug] requestAllMsgsFiltered(): select_messagesAllNew_filtered.sql 
​[Debug] Message(MsgId: AA41714 , [content removed]) 
​[Debug] Message(MsgId: AA41713 , [content removed]) 
​[Debug] Message(MsgId: AA41712 , [content removed]) 
​[Debug] Message(MsgId: AA41710 , [content removed]) 
​[Debug] Message(MsgId: AA41707 , [content removed]) 
​[Debug] Message(MsgId: AA41705 , [content removed]) 
​[Debug] Message(MsgId: AA41704 , [content removed]) 
​[Debug] Message(MsgId: AA41700 , [content removed]) 
​[Debug] Message(MsgId: AA41698 , [content removed]) 
​[Debug] Message(MsgId: AA41697 , [content removed]) 
​[Debug] Message(MsgId: AA41695 , [content removed]) 
​[Debug] Message(MsgId: AA41693 , [content removed]) 
​[Debug] Message(MsgId: AA41692 , [content removed]) 
​[Debug] Message(MsgId: AA41691 , [content removed]) 
​[Debug] Message(MsgId: AA41689 , [content removed]) 
​[Warn ] The server version of this PostgreSQL is unknown, falling back to the client version.
</pre>
</details>
</br>

### Patch to `core.cpp`

*Place at the end of `void Core::init()`*

```cpp
    if (_configured) {
        UserId user(1);              // <-- MODIFY for your database!
        BufferId buffer(XXX);        // <-- MODIFY for your database!
        int limitSmall = 15;
        MsgId any(-1);
        MsgId first(AA41615 - 100);  // <-- MODIFY for your database!
        MsgId last(AA41615 + 100);   // <-- MODIFY for your database!
        qDebug() << "Message dumps, limit =" << limitSmall;
        qDebug() << "--------------------";
        qDebug() << "--------------------";
        qDebug() << "requestMsgsFiltered(): select_messagesNewestK_filtered.sql";
        foreach (const auto message, requestMsgsFiltered(user, buffer, any, any, limitSmall, Message::Type::Action | Message::Type::Plain, Message::Flag::None)) {
            qDebug() << message;
        }
        qDebug() << "--------------------";
        qDebug() << "requestMsgsFiltered(): select_messagesNewerThan_filtered.sql";
        foreach (const auto message, requestMsgsFiltered(user, buffer, first, any, limitSmall, Message::Type::Action | Message::Type::Plain, Message::Flag::None)) {
            qDebug() << message;
        }
        qDebug() << "--------------------";
        qDebug() << "requestMsgsFiltered(): select_messagesRange_filtered.sql";
        foreach (const auto message, requestMsgsFiltered(user, buffer, first, last, limitSmall, Message::Type::Action | Message::Type::Plain, Message::Flag::None)) {
            qDebug() << message;
        }
        qDebug() << "--------------------";
        qDebug() << "requestMsgs(): select_messagesNewestK.sql";
        foreach (const auto message, requestMsgs(user, buffer, any, any, limitSmall)) {
            qDebug() << message;
        }
        qDebug() << "--------------------";
        qDebug() << "requestMsgs(): select_messagesNewerThan.sql";
        foreach (const auto message, requestMsgs(user, buffer, first, any, limitSmall)) {
            qDebug() << message;
        }
        qDebug() << "--------------------";
        qDebug() << "requestMsgs(): select_messagesRange.sql";
        foreach (const auto message, requestMsgs(user, buffer, first, last, limitSmall)) {
            qDebug() << message;
        }
        qDebug() << "--------------------";
        qDebug() << "requestAllMsgsFiltered(): select_messagesAll_filtered.sql";
        foreach (const auto message, requestAllMsgsFiltered(user, first, any, limitSmall, Message::Type::Action | Message::Type::Plain, Message::Flag::None)) {
            qDebug() << message;
        }
        qDebug() << "--------------------";
        qDebug() << "requestAllMsgsFiltered(): select_messagesAllNew_filtered.sql";
        foreach (const auto message, requestAllMsgsFiltered(user, first, last, limitSmall, Message::Type::Action | Message::Type::Plain, Message::Flag::None)) {
            qDebug() << message;
        }
    }
```