### PR TITLE
[WIP] Implements Parsing for IRCv3 message-tags, handles IRCv3 server-time and echo-message

### DIFF
--- a/src/common/eventmanager.h
+++ b/src/common/eventmanager.h
@@ -113,6 +113,7 @@ public:
         IrcEventWallops,
         IrcEventRawPrivmsg,  ///< Undecoded privmsg (still needs CTCP parsing)
         IrcEventRawNotice,   ///< Undecoded notice (still needs CTCP parsing)
+        IrcEventSetname,
         IrcEventUnknown,     ///< Unknown non-numeric cmd
 
         IrcEventNumeric = 0x00031000,     /* needs 1000 (0x03e8) consecutive free values! */

--- a/src/common/irccap.h
+++ b/src/common/irccap.h
@@ -108,6 +108,13 @@ namespace IrcCap {
     const QString SERVER_TIME = "server-time";
 
     /**
+     * Server sending own message back
+     *
+     * https://ircv3.net/specs/extensions/echo-message-3.2.html
+     */
+    const QString ECHO_MESSAGE = "echo-message";
+
+    /**
      * Vendor-specific capabilities
      */
     namespace Vendor {
@@ -149,6 +156,7 @@ namespace IrcCap {
                                               SASL,
                                               USERHOST_IN_NAMES,
                                               SERVER_TIME,
+                                              ECHO_MESSAGE,
                                               Vendor::TWITCH_MEMBERSHIP,
                                               Vendor::ZNC_SELF_MESSAGE};
     // NOTE: If you modify the knownCaps list, update the constants above as needed.

--- a/src/common/irccap.h
+++ b/src/common/irccap.h
@@ -115,6 +115,20 @@ namespace IrcCap {
     const QString ECHO_MESSAGE = "echo-message";
 
     /**
+     * Draft capabilities
+     */
+    namespace Draft
+    {
+
+        /**
+         * Allows updating realname while being connected
+         *
+         * https://github.com/ircv3/ircv3-specifications/pull/361
+         */
+        const QString SETNAME = "draft/setname";
+    }
+
+    /**
      * Vendor-specific capabilities
      */
     namespace Vendor {
@@ -157,6 +171,7 @@ namespace IrcCap {
                                               USERHOST_IN_NAMES,
                                               SERVER_TIME,
                                               ECHO_MESSAGE,
+                                              Draft::SETNAME,
                                               Vendor::TWITCH_MEMBERSHIP,
                                               Vendor::ZNC_SELF_MESSAGE};
     // NOTE: If you modify the knownCaps list, update the constants above as needed.

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -791,6 +791,21 @@ void CoreSessionEventProcessor::processIrcEventError(IrcEvent* e)
     }
 }
 
+void CoreSessionEventProcessor::processIrcEventSetname(IrcEvent* e)
+{
+    if (checkParamCount(e, 1)) {
+        IrcUser* ircuser = e->network()->updateNickFromMask(e->prefix());
+        if (!ircuser) {
+            qWarning() << Q_FUNC_INFO << "Unknown IrcUser!";
+            return;
+        }
+
+        QString newname = e->params().at(0);
+        ircuser->setRealName(newname);
+    }
+}
+
+
 #ifdef HAVE_QCA2
 void CoreSessionEventProcessor::processKeyEvent(KeyEvent* e)
 {

--- a/src/core/coresessioneventprocessor.h
+++ b/src/core/coresessioneventprocessor.h
@@ -64,6 +64,7 @@ public:
     Q_INVOKABLE void lateProcessIrcEventQuit(IrcEvent* event);
     Q_INVOKABLE void processIrcEventTopic(IrcEvent* event);
     Q_INVOKABLE void processIrcEventError(IrcEvent* event);  /// ERROR message from server
+    Q_INVOKABLE void processIrcEventSetname(IrcEvent* event);
 #ifdef HAVE_QCA2
     Q_INVOKABLE void processKeyEvent(KeyEvent* event);
 #endif

--- a/src/core/coreuserinputhandler.cpp
+++ b/src/core/coreuserinputhandler.cpp
@@ -894,6 +894,12 @@ void CoreUserInputHandler::handleTopic(const BufferInfo& bufferInfo, const QStri
     emit putCmd("TOPIC", params);
 }
 
+void CoreUserInputHandler::handleSetname(const BufferInfo& bufferInfo, const QString& msg)
+{
+    Q_UNUSED(bufferInfo)
+    emit putCmd("SETNAME", serverEncode(msg));
+}
+
 void CoreUserInputHandler::handleVoice(const BufferInfo& bufferInfo, const QString& msg)
 {
     QStringList nicks = msg.split(' ', QString::SkipEmptyParts);

--- a/src/core/coreuserinputhandler.cpp
+++ b/src/core/coreuserinputhandler.cpp
@@ -183,14 +183,16 @@ void CoreUserInputHandler::handleCtcp(const BufferInfo& bufferInfo, const QStrin
 
     // FIXME make this a proper event
     coreNetwork()->coreSession()->ctcpParser()->query(coreNetwork(), nick, ctcpTag, message);
-    emit displayMsg(NetworkInternalMessage(
-        Message::Action,
-        BufferInfo::StatusBuffer,
-        "",
-        verboseMessage,
-        network()->myNick(),
-        Message::Flag::Self
-    ));
+    if (!network()->capEnabled(IrcCap::ECHO_MESSAGE)) {
+        emit displayMsg(NetworkInternalMessage(
+            Message::Action,
+            BufferInfo::StatusBuffer,
+            "",
+            verboseMessage,
+            network()->myNick(),
+            Message::Flag::Self
+        ));
+    }
 }
 
 void CoreUserInputHandler::handleDelkey(const BufferInfo& bufferInfo, const QString& msg)
@@ -510,14 +512,16 @@ void CoreUserInputHandler::handleMe(const BufferInfo& bufferInfo, const QString&
     for (const auto& message : messages) {
         // Handle each separated message independently
         coreNetwork()->coreSession()->ctcpParser()->query(coreNetwork(), bufferInfo.bufferName(), "ACTION", message);
-        emit displayMsg(NetworkInternalMessage(
-            Message::Action,
-            bufferInfo.type(),
-            bufferInfo.bufferName(),
-            message,
-            network()->myNick(),
-            Message::Self
-        ));
+        if (!network()->capEnabled(IrcCap::ECHO_MESSAGE)) {
+            emit displayMsg(NetworkInternalMessage(
+                Message::Action,
+                bufferInfo.type(),
+                bufferInfo.bufferName(),
+                message,
+                network()->myNick(),
+                Message::Self
+            ));
+        }
     }
 }
 
@@ -590,14 +594,16 @@ void CoreUserInputHandler::handleNotice(const BufferInfo& bufferInfo, const QStr
         params.clear();
         params << serverEncode(bufferName) << channelEncode(bufferInfo.bufferName(), message);
         emit putCmd("NOTICE", params);
-        emit displayMsg(NetworkInternalMessage(
-            Message::Notice,
-            typeByTarget(bufferName),
-            bufferName,
-            message,
-            network()->myNick(),
-            Message::Self
-        ));
+        if (!network()->capEnabled(IrcCap::ECHO_MESSAGE)) {
+            emit displayMsg(NetworkInternalMessage(
+                Message::Notice,
+                typeByTarget(bufferName),
+                bufferName,
+                message,
+                network()->myNick(),
+                Message::Self
+            ));
+        }
     }
 }
 
@@ -680,14 +686,16 @@ void CoreUserInputHandler::handleQuery(const BufferInfo& bufferInfo, const QStri
             // handleMsg is a no-op if message is empty
         }
         else {
-            emit displayMsg(NetworkInternalMessage(
-                Message::Plain,
-                BufferInfo::QueryBuffer,
-                target,
-                message,
-                network()->myNick(),
-                Message::Self
-            ));
+            if (!network()->capEnabled(IrcCap::ECHO_MESSAGE)) {
+                emit displayMsg(NetworkInternalMessage(
+                    Message::Plain,
+                    BufferInfo::QueryBuffer,
+                    target,
+                    message,
+                    network()->myNick(),
+                    Message::Self
+                ));
+            }
             // handleMsg needs the target specified at the beginning of the message
             handleMsg(bufferInfo, target + " " + message);
         }
@@ -731,14 +739,16 @@ void CoreUserInputHandler::handleSay(const BufferInfo& bufferInfo, const QString
 #else
         putPrivmsg(bufferInfo.bufferName(), message, encodeFunc);
 #endif
-        emit displayMsg(NetworkInternalMessage(
-            Message::Plain,
-            bufferInfo.type(),
-            bufferInfo.bufferName(),
-            message,
-            network()->myNick(),
-            Message::Self
-        ));
+        if (!network()->capEnabled(IrcCap::ECHO_MESSAGE)) {
+            emit displayMsg(NetworkInternalMessage(
+                Message::Plain,
+                bufferInfo.type(),
+                bufferInfo.bufferName(),
+                message,
+                network()->myNick(),
+                Message::Self
+            ));
+        }
     }
 }
 

--- a/src/core/coreuserinputhandler.h
+++ b/src/core/coreuserinputhandler.h
@@ -79,6 +79,7 @@ public slots:
     void handleQuote(const BufferInfo& bufferInfo, const QString& text);
     void handleSay(const BufferInfo& bufferInfo, const QString& text);
     void handleSetkey(const BufferInfo& bufferInfo, const QString& text);
+    void handleSetname(const BufferInfo& bufferInfo, const QString& text);
     void handleShowkey(const BufferInfo& bufferInfo, const QString& text);
     void handleTopic(const BufferInfo& bufferInfo, const QString& text);
     void handleVoice(const BufferInfo& bufferInfo, const QString& text);

--- a/src/core/ctcpparser.cpp
+++ b/src/core/ctcpparser.cpp
@@ -66,6 +66,9 @@ void CtcpParser::displayMsg(NetworkEvent* event,
         return;
 
     MessageEvent* msgEvent = new MessageEvent(msgType, event->network(), std::move(msg), std::move(sender), std::move(target), msgFlags, event->timestamp());
+    if (event->testFlag(EventManager::Self)) {
+        msgEvent->setFlag(EventManager::Self);
+    }
     emit newEvent(msgEvent);
 }
 
@@ -236,6 +239,9 @@ void CtcpParser::parseSimple(IrcEventRawMessage* e,
                                              ctcpparam,
                                              e->timestamp(),
                                              uuid);
+            if (e->testFlag(EventManager::Self)) {
+                event->setFlag(EventManager::Self);
+            }
             emit newEvent(event);
             CtcpEvent* flushEvent = new CtcpEvent(EventManager::CtcpEventFlush,
                                                   e->network(),
@@ -313,6 +319,9 @@ void CtcpParser::parseStandard(IrcEventRawMessage* e,
                                              ctcpparam,
                                              e->timestamp(),
                                              uuid);
+            if (e->testFlag(EventManager::Self)) {
+                event->setFlag(EventManager::Self);
+            }
             ctcpEvents << event;
         }
     }

--- a/src/core/eventstringifier.cpp
+++ b/src/core/eventstringifier.cpp
@@ -790,7 +790,12 @@ void EventStringifier::processCtcpEvent(CtcpEvent* e)
     if (e->type() != EventManager::CtcpEvent)
         return;
 
-    if (e->testFlag(EventManager::Self)) {
+    // Only stringify outgoing CTCP messages this way
+    if (e->testFlag(EventManager::Self) &&
+        // Only stringify CTCP queries this way
+        e->ctcpType() == CtcpEvent::CtcpType::Query &&
+        // Always handle ACTIONs as if they were sent from network, to properly handle echo-message
+        e->ctcpCmd() != "ACTION") {
         displayMsg(e,
                    Message::Action,
                    tr("sending CTCP-%1 request to %2").arg(e->ctcpCmd(), e->target()),
@@ -803,8 +808,7 @@ void EventStringifier::processCtcpEvent(CtcpEvent* e)
     handle(e->ctcpCmd(), Q_ARG(CtcpEvent*, e));
 }
 
-void EventStringifier::defaultHandler(const QString& ctcpCmd, CtcpEvent* e)
-{
+void EventStringifier::defaultHandler(const QString& ctcpCmd, CtcpEvent* e) {
     Q_UNUSED(ctcpCmd);
     if (e->ctcpType() == CtcpEvent::Query) {
         QString unknown;
@@ -812,14 +816,25 @@ void EventStringifier::defaultHandler(const QString& ctcpCmd, CtcpEvent* e)
             //: Optional "unknown" in "Received unknown CTCP-FOO request by bar"
             unknown = tr("unknown") + ' ';
         displayMsg(e, Message::Server, tr("Received %1CTCP-%2 request by %3").arg(unknown, e->ctcpCmd(), e->prefix()));
-        return;
+    } else {
+        // Ignore echo messages for our own answers
+        if (!e->testFlag(EventManager::Self)) {
+            displayMsg(e, Message::Server,
+                       tr("Received CTCP-%1 answer from %2: %3")
+                       .arg(e->ctcpCmd(), nickFromMask(e->prefix()),e->param()));
+        }
     }
-    displayMsg(e, Message::Server, tr("Received CTCP-%1 answer from %2: %3").arg(e->ctcpCmd(), nickFromMask(e->prefix()), e->param()));
 }
 
 void EventStringifier::handleCtcpAction(CtcpEvent* e)
 {
-    displayMsg(e, Message::Action, e->param(), e->prefix(), e->target());
+    Message::Flag msgFlags = Message::Flag::None;
+    if (e->testFlag(EventManager::Self)) {
+        // Mark the message as Self
+        msgFlags = Message::Self;
+    }
+
+    displayMsg(e, Message::Action, e->param(), e->prefix(), e->target(), msgFlags);
 }
 
 void EventStringifier::handleCtcpPing(CtcpEvent* e)


### PR DESCRIPTION
## In Short

* Replaces the parsing code with more efficient, more robust code to also handle IRCv3 message-tags
* Implements the IRCv3 server-time capability
* Implements the IRCv3 echo-message capability

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Improves IRC parsing for rare edge cases, adds minor functionality — the impact will come in follow-up PRs |
| Risk | ★★★  _3/3_ | Rewrites the entire IRC parsing, could break Quassel for some users |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to few rarely-touched classes, shouldn't interfere with other pull requests |

## Rationale

IRCv3 message-tags are becoming more and more important for new IRCv3 functionality, and for many of the future features we’ve been planning on implementing, we need to handle them.

At the same time, our current parsing code, due to splitting at `" :"` (which now also appears before the prefix, as the tags come first), can’t handle them at all.

Rewriting the parsing code also made sense to clean it up, make each part more explicit, and clean up the spaghetti code of interactions.

Server-Time allows us to display the exact moment a message was actually received by the IRCd.
Echo-Message additionally allows us to show the message the exact way other users saw it, including splits, potential color stripping, and other modifications the IRCd might do.

## Testing

I’ve tested this on the Oragono Testnet (testnet.oragono.io) and the InspIRCd Testnet (testnet.inspircd.org), and everything has been working. I’ve also tested it in normal usage on Freenode to prevent regressions.

Due to the potential impact, I’d prefer if we could do a lot more testing.