### PR TITLE
cmake: fix build on MSYS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,19 +207,23 @@ if (BUILD_GUI)
         PURPOSE     "Required for audio notifications"
     )
 
-    find_package(LibsnoreQt5 0.7.0 QUIET)
-    set_package_properties(LibsnoreQt5 PROPERTIES TYPE OPTIONAL
-        URL "https://projects.kde.org/projects/playground/libs/snorenotify"
-        DESCRIPTION "a cross-platform notification framework"
-        PURPOSE     "Enable support for the snorenotify framework"
-    )
-    if (LibsnoreQt5_FOUND)
-        find_package(LibsnoreSettingsQt5 QUIET)
-        set_package_properties(LibsnoreSettingsQt5 PROPERTIES TYPE OPTIONAL
+    # snorenotify segfaults on startup on msys2
+    # we don't check for just MSYS to support the Ninja generator
+    if(NOT (WIN32 AND (NOT $ENV{MSYSTEM} STREQUAL "")))
+        find_package(LibsnoreQt5 0.7.0 QUIET)
+        set_package_properties(LibsnoreQt5 PROPERTIES TYPE OPTIONAL
             URL "https://projects.kde.org/projects/playground/libs/snorenotify"
             DESCRIPTION "a cross-platform notification framework"
             PURPOSE     "Enable support for the snorenotify framework"
         )
+        if (LibsnoreQt5_FOUND)
+            find_package(LibsnoreSettingsQt5 QUIET)
+            set_package_properties(LibsnoreSettingsQt5 PROPERTIES TYPE OPTIONAL
+                URL "https://projects.kde.org/projects/playground/libs/snorenotify"
+                DESCRIPTION "a cross-platform notification framework"
+                PURPOSE     "Enable support for the snorenotify framework"
+            )
+        endif()
     endif()
 
     if (WITH_WEBENGINE)

--- a/cmake/QuasselCompileSettings.cmake
+++ b/cmake/QuasselCompileSettings.cmake
@@ -34,7 +34,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         -fdiagnostics-color=always
         -fexceptions
         -fno-common
-        -fstack-protector-strong
         -Wall
         -Wextra
         -Wcast-align
@@ -49,6 +48,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         -Wno-unknown-pragmas
         "$<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=2>"
     )
+
+    # ssp is currently very broken on MinGW
+    if(NOT MINGW)
+        add_compile_options(-fstack-protector-strong)
+    endif()
 
     # Check for and set linker flags
     check_and_set_linker_flag("-Wl,-z,relro"            RELRO            LINKER_FLAGS)

--- a/cmake/QuasselMacros.cmake
+++ b/cmake/QuasselMacros.cmake
@@ -20,9 +20,9 @@ include(QuasselCompileFeatures)
 #  - a library target named quassel_client with output name (lib)quassel-client(.so)
 #  - an alias target named Quassel::Client in global scope
 #
-# If the optional argument STATIC is given, a static library is built; otherwise, on
-# platforms other than Windows, a shared library is created. For shared libraries, also
-# an install rule is added.
+# If the optional argument STATIC is given, or the ENABLE_SHARED option is OFF,
+# a static library is built; otherwise a shared library is created. For shared
+# libraries, an install rule is also added.
 #
 # To generate an export header for the library, specify EXPORT. The header will be named
 # ${module}-export.h (where ${module} is the lower-case name of the module).
@@ -143,7 +143,7 @@ function(quassel_add_resource _name)
     #
     # On Windows, input redirection apparently doesn't work, however piping does. Use this for all platforms for
     # consistency, accommodating for the fact that the 'cat' equivalent on Windows is 'type'.
-    if (WIN32)
+    if (WIN32 AND NOT MSYS)
         set(cat_cmd type)
     else()
         set(cat_cmd cat)


### PR DESCRIPTION
Some minor changes to allow building easily on MSYS2:

- don't check for snorenotify on MSYS2 because it segfaults on startup

- don't use -fstack-protector-strong (libssp) on MinGW because it
currently causes segfaults during static initialization

https://sourceforge.net/p/mingw-w64/bugs/755/

- build libraries as static on Windows, the comments indicate that this
was the intention, but the check was not implemented

- use the `cat` command to read files when using the 'MSYS Makefiles'
generator, and not the cmd.exe `type` command

Tested to build correctly on MSYS2 with both the 'MSYS Makefiles'
generator and the Ninja generator using a native ninja.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>