### PR TITLE
qtui: Set desktop file name

### DIFF
--- a/src/main/monoapplication.cpp
+++ b/src/main/monoapplication.cpp
@@ -30,7 +30,11 @@ class InternalPeer;
 
 MonolithicApplication::MonolithicApplication(int& argc, char** argv)
     : QtUiApplication(argc, argv)
-{}
+{
+#if QT_VERSION >= 0x050700
+    QGuiApplication::setDesktopFileName(Quassel::buildInfo().applicationName);
+#endif
+}
 
 void MonolithicApplication::init()
 {

--- a/src/qtui/qtuiapplication.cpp
+++ b/src/qtui/qtuiapplication.cpp
@@ -36,6 +36,9 @@ QtUiApplication::QtUiApplication(int& argc, char** argv)
 #if QT_VERSION >= 0x050600
     QGuiApplication::setFallbackSessionManagementEnabled(false);
 #endif
+#if QT_VERSION >= 0x050700
+    QGuiApplication::setDesktopFileName(Quassel::buildInfo().clientApplicationName);
+#endif
 }
 
 void QtUiApplication::init()


### PR DESCRIPTION
The XCB platform plugin defaults the WM class to the executable name,
which already matches our desktop file name. Unfortunately, the Wayland
platform plugin prepends the inverted organization domain, resulting in
an app ID of "org.quassel-irc.quasselclient", thus breaking the
association.

Set the desktop file name explicitly so the Wayland platform doesn't get
confused.