### PR TITLE
Add DesktopEntry to notifyrc

### DIFF
--- a/data/quassel.notifyrc
+++ b/data/quassel.notifyrc
@@ -1,5 +1,6 @@
 [Global]
 IconName=quassel
+DesktopEntry=quassel
 Comment=Quassel IRC
 Comment[ast]=Quassel IRC
 Comment[ca]=Xat IRC Quassel


### PR DESCRIPTION
This allows the new notification KCM to identify Quassel as an application