### PR TITLE
Set default action on notification

### DIFF
--- a/src/qtui/knotificationbackend.cpp
+++ b/src/qtui/knotificationbackend.cpp
@@ -25,6 +25,7 @@
 
 #include <KNotifications/KNotification>
 #include <KNotifyConfig/KNotifyConfigWidget>
+#include <knotifications_version.h>
 
 #include "client.h"
 #include "icon.h"
@@ -73,7 +74,11 @@ void KNotificationBackend::notify(const Notification& n)
             selectOverload<uint>(&KNotification::activated),
             this,
             selectOverload<>(&KNotificationBackend::notificationActivated));
+#if KNOTIFICATIONS_VERSION >= QT_VERSION_CHECK(5,31,0)
     notification->setDefaultAction(tr("View"));
+#else
+    notification->setActions(QStringList{tr("View")});
+#endif
     notification->setProperty("notificationId", n.notificationId);
 
     _notifications.append(qMakePair(n.notificationId, QPointer<KNotification>(notification)));

--- a/src/qtui/knotificationbackend.cpp
+++ b/src/qtui/knotificationbackend.cpp
@@ -73,7 +73,7 @@ void KNotificationBackend::notify(const Notification& n)
             selectOverload<uint>(&KNotification::activated),
             this,
             selectOverload<>(&KNotificationBackend::notificationActivated));
-    notification->setActions(QStringList("View"));
+    notification->setDefaultAction(tr("View"));
     notification->setProperty("notificationId", n.notificationId);
 
     _notifications.append(qMakePair(n.notificationId, QPointer<KNotification>(notification)));


### PR DESCRIPTION
This makes the entire notification popup clickable.
Also, mark the text for translation.

I couldn't find a minimum version requirement of KDE Frameworks for Quassel
but this method was added in Frameworks 5.32 in Early 2017 and supported
since Plasma 5.10. For older versions a regular button should be shown as is
since they will just not know what "default" means and take that as a regular
button action ID.