### PR TITLE
Implement support for the HAProxy proxy protocol

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(${TARGET} PRIVATE
     peerfactory.cpp
     presetnetworks.cpp
     quassel.cpp
+    proxyline.cpp
     remotepeer.cpp
     settings.cpp
     signalproxy.cpp

--- a/src/common/authhandler.h
+++ b/src/common/authhandler.h
@@ -37,7 +37,7 @@ public:
 
     QTcpSocket* socket() const;
 
-    bool isLocal() const;
+    virtual bool isLocal() const;
 
     virtual void handle(const Protocol::RegisterClient&) { invalidMessage(); }
     virtual void handle(const Protocol::ClientDenied&) { invalidMessage(); }

--- a/src/common/ircdecoder.cpp
+++ b/src/common/ircdecoder.cpp
@@ -63,16 +63,7 @@ QString IrcDecoder::parseTagValue(const QString& value)
     return result;
 }
 
-/**
- * Extracts a space-delimited fragment from an IRC message
- * @param raw Raw Message
- * @param start Current index into the message, will be advanced automatically
- * @param end End of fragment, if already known. Default is -1, in which case it will be set to the next whitespace
- * character or the end of the string
- * @param prefix Required prefix. Default is 0. If set, this only parses a fragment if it starts with the given prefix.
- * @return Fragment
- */
-QByteArray extractFragment(const QByteArray& raw, int& start, int end = -1, char prefix = 0)
+QByteArray IrcDecoder::extractFragment(const QByteArray& raw, int& start, int end, char prefix)
 {
     // Try to set find the end of the space-delimited fragment
     if (end == -1) {
@@ -100,12 +91,7 @@ QByteArray extractFragment(const QByteArray& raw, int& start, int end = -1, char
     return fragment;
 }
 
-/**
- * Skips empty parts in the message
- * @param raw Raw Message
- * @param start Current index into the message, will be advanced  automatically
- */
-void skipEmptyParts(const QByteArray& raw, int& start)
+void IrcDecoder::skipEmptyParts(const QByteArray& raw, int& start)
 {
     while (start < raw.length() && raw[start] == ' ') {
         start++;

--- a/src/common/ircdecoder.h
+++ b/src/common/ircdecoder.h
@@ -39,6 +39,24 @@ public:
      * @param parameters[out] Parsed list of parameters
      */
     static void parseMessage(const std::function<QString(const QByteArray&)>& decode, const QByteArray& raw, QHash<IrcTagKey, QString>& tags, QString& prefix, QString& command, QList<QByteArray>& parameters);
+
+    /**
+     * Extracts a space-delimited fragment from an IRC message
+     * @param raw Raw Message
+     * @param start Current index into the message, will be advanced automatically
+     * @param end End of fragment, if already known. Default is -1, in which case it will be set to the next whitespace
+     * character or the end of the string
+     * @param prefix Required prefix. Default is 0. If set, this only parses a fragment if it starts with the given prefix.
+     * @return Fragment
+     */
+    static QByteArray extractFragment(const QByteArray& raw, int& start, int end = -1, char prefix = 0);
+
+    /**
+     * Skips empty parts in the message
+     * @param raw Raw Message
+     * @param start Current index into the message, will be advanced  automatically
+     */
+    static void skipEmptyParts(const QByteArray& raw, int& start);
 private:
     /**
      * Parses an encoded IRCv3 message tag value

--- a/src/common/protocol.h
+++ b/src/common/protocol.h
@@ -32,6 +32,8 @@ namespace Protocol {
 
 const quint32 magic = 0x42b33f00;
 
+const quint32 proxyMagic = 0x50524f58;
+
 enum Type
 {
     InternalProtocol = 0x00,

--- a/src/common/protocols/legacy/legacypeer.cpp
+++ b/src/common/protocols/legacy/legacypeer.cpp
@@ -49,7 +49,7 @@ void LegacyPeer::setSignalProxy(::SignalProxy* proxy)
         // enable compression now if requested - the initial handshake is uncompressed in the legacy protocol!
         _useCompression = socket()->property("UseCompression").toBool();
         if (_useCompression)
-            qDebug() << "Using compression for peer:" << qPrintable(socket()->peerAddress().toString());
+            qDebug() << "Using compression for peer:" << qPrintable(address());
     }
 }
 

--- a/src/common/proxyline.cpp
+++ b/src/common/proxyline.cpp
@@ -1,0 +1,70 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2020 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include "proxyline.h"
+
+#include "ircdecoder.h"
+
+ProxyLine ProxyLine::parseProxyLine(const QByteArray& line)
+{
+    ProxyLine result;
+
+    int start = 0;
+    if (line.startsWith("PROXY")) {
+        start = 5;
+    }
+    IrcDecoder::skipEmptyParts(line, start);
+    QByteArray protocol = IrcDecoder::extractFragment(line, start);
+    if (protocol == "TCP4") {
+        result.protocol = QAbstractSocket::IPv4Protocol;
+    } else if (protocol == "TCP6") {
+        result.protocol = QAbstractSocket::IPv6Protocol;
+    } else {
+        result.protocol = QAbstractSocket::UnknownNetworkLayerProtocol;
+    }
+
+    if (result.protocol != QAbstractSocket::UnknownNetworkLayerProtocol) {
+        bool ok;
+        IrcDecoder::skipEmptyParts(line, start);
+        result.sourceHost = QHostAddress(QString::fromLatin1(IrcDecoder::extractFragment(line, start)));
+        IrcDecoder::skipEmptyParts(line, start);
+        result.sourcePort = QString::fromLatin1(IrcDecoder::extractFragment(line, start)).toUShort(&ok);
+        if (!ok) result.sourcePort = 0;
+        IrcDecoder::skipEmptyParts(line, start);
+        result.targetHost = QHostAddress(QString::fromLatin1(IrcDecoder::extractFragment(line, start)));
+        IrcDecoder::skipEmptyParts(line, start);
+        result.targetPort = QString::fromLatin1(IrcDecoder::extractFragment(line, start)).toUShort(&ok);
+        if (!ok) result.targetPort = 0;
+    }
+
+    return result;
+}
+
+
+QDebug operator<<(QDebug dbg, const ProxyLine& p) {
+    dbg.nospace();
+    dbg << "(protocol = " << p.protocol;
+    if (p.protocol == QAbstractSocket::UnknownNetworkLayerProtocol) {
+        dbg << ")";
+    } else {
+        dbg << ", sourceHost = " << p.sourceHost << ", sourcePort = " << p.sourcePort << ", targetHost = " << p.targetHost << ", targetPort = " << p.targetPort << ")";
+    }
+    return dbg.space();
+}

--- a/src/common/proxyline.h
+++ b/src/common/proxyline.h
@@ -18,63 +18,22 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef COREAUTHHANDLER_H
-#define COREAUTHHANDLER_H
+#pragma once
 
-#include "authhandler.h"
-#include "metricsserver.h"
-#include "peerfactory.h"
-#include "proxyline.h"
-#include "remotepeer.h"
-#include "types.h"
+#include <QAbstractSocket>
+#include <QByteArray>
+#include <QHostAddress>
 
-class CoreAuthHandler : public AuthHandler
+#include "common-export.h"
+
+struct COMMON_EXPORT ProxyLine
 {
-    Q_OBJECT
+    QAbstractSocket::NetworkLayerProtocol protocol = QAbstractSocket::UnknownNetworkLayerProtocol;
+    QHostAddress sourceHost;
+    uint16_t sourcePort;
+    QHostAddress targetHost;
+    uint16_t targetPort;
 
-public:
-    CoreAuthHandler(QTcpSocket* socket, QObject* parent = nullptr);
-
-    QHostAddress hostAddress() const;
-    bool isLocal() const override;
-
-signals:
-    void handshakeComplete(RemotePeer* peer, UserId uid);
-
-private:
-    using AuthHandler::handle;
-
-    void handle(const Protocol::RegisterClient& msg) override;
-    void handle(const Protocol::SetupData& msg) override;
-    void handle(const Protocol::Login& msg) override;
-
-    void setPeer(RemotePeer* peer);
-    void startSsl();
-
-    bool checkClientRegistered();
-
-private slots:
-    void onReadyRead();
-
-#ifdef HAVE_SSL
-    void onSslErrors();
-#endif
-
-    // only in legacy mode
-    void onProtocolVersionMismatch(int actual, int expected);
-
-private:
-    RemotePeer* _peer;
-    MetricsServer* _metricsServer;
-
-    bool _proxyReceived;
-    ProxyLine _proxyLine;
-    bool _useProxyLine;
-    bool _magicReceived;
-    bool _legacy;
-    bool _clientRegistered;
-    quint8 _connectionFeatures;
-    QVector<PeerFactory::ProtoDescriptor> _supportedProtos;
+    static ProxyLine parseProxyLine(const QByteArray& line);
+    friend COMMON_EXPORT QDebug operator<<(QDebug dbg, const ProxyLine& p);
 };
-
-#endif

--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -362,6 +362,7 @@ void Quassel::setupCliParser()
             {"ident-listen", tr("The address(es) quasselcore will listen on for ident requests. Same format as --listen."), tr("<address>[,...]"), "::1,127.0.0.1"},
             {"oidentd", tr("Enable oidentd integration. In most cases you should also enable --strict-ident.")},
             {"oidentd-conffile", tr("Set path to oidentd configuration file."), tr("file")},
+            {"proxy-cidr", tr("Set IP range from which proxy protocol definitions are allowed"), tr("<address>[,...]"), "::1,127.0.0.1"},
 #ifdef HAVE_SSL
             {"require-ssl", tr("Require SSL for remote (non-loopback) client connections.")},
             {"ssl-cert", tr("Specify the path to the SSL certificate."), tr("path"), "configdir/quasselCert.pem"},

--- a/src/common/remotepeer.h
+++ b/src/common/remotepeer.h
@@ -27,6 +27,7 @@
 #include "compressor.h"
 #include "peer.h"
 #include "protocol.h"
+#include "proxyline.h"
 #include "signalproxy.h"
 
 class QTimer;
@@ -46,11 +47,14 @@ public:
 
     void setSignalProxy(SignalProxy* proxy) override;
 
+    void setProxyLine(ProxyLine proxyLine);
+
     virtual QString protocolName() const = 0;
     QString description() const override;
     virtual quint16 enabledFeatures() const { return 0; }
 
     QString address() const override;
+    QHostAddress hostAddress() const;
     quint16 port() const override;
 
     bool isOpen() const override;
@@ -105,6 +109,8 @@ private:
     QTcpSocket* _socket;
     Compressor* _compressor;
     SignalProxy* _signalProxy;
+    ProxyLine _proxyLine;
+    bool _useProxyLine;
     QTimer* _heartBeatTimer;
     int _heartBeatCount;
     int _lag;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -730,7 +730,7 @@ void Core::incomingConnection()
         connect(handler, &AuthHandler::socketError, this, &Core::socketError);
         connect(handler, &CoreAuthHandler::handshakeComplete, this, &Core::setupClientSession);
 
-        qInfo() << qPrintable(tr("Client connected from")) << qPrintable(socket->peerAddress().toString());
+        qInfo() << qPrintable(tr("Client connected from")) << qPrintable(handler->hostAddress().toString());
 
         if (!_configured) {
             stopListening(tr("Closing server for basic setup."));
@@ -744,7 +744,7 @@ void Core::clientDisconnected()
     auto* handler = qobject_cast<CoreAuthHandler*>(sender());
     Q_ASSERT(handler);
 
-    qInfo() << qPrintable(tr("Non-authed client disconnected:")) << qPrintable(handler->socket()->peerAddress().toString());
+    qInfo() << qPrintable(tr("Non-authed client disconnected:")) << qPrintable(handler->hostAddress().toString());
     _connectingClients.remove(handler);
     handler->deleteLater();
 


### PR DESCRIPTION
## In Short

* Adds support for the HAProxy proxy protocol to the client-side auth handler
* Uses the forwarded IP information in the client list
* Adds a CLI option to specify which IP ranges are trusted proxies

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Allows deploying Quassel behind load balancers |
| Risk | ★★☆  _2/3_ | Affects main protocol initialization code |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to few rarely-touched classes, shouldn't interfere with other pull requests |

## Rationale

In cloud deployments, it’s common to deploy services behind load balancers or proxies. In such situations, it’s useful to still be able to show the original IP of the request.

Now that we show clients by IP in the client list, support for this protocol is useful.