### PR TITLE
Fix protocol spam on part/quit/disconnect

### DIFF
--- a/src/common/ircchannel.cpp
+++ b/src/common/ircchannel.cpp
@@ -231,7 +231,7 @@ void IrcChannel::part(IrcUser* ircuser)
             _userModes.clear();
             foreach (IrcUser* user, users) {
                 disconnect(user, nullptr, this, nullptr);
-                user->partChannel(this);
+                user->partChannel(this, true);
             }
             emit parted();
             network()->removeIrcChannel(this);

--- a/src/common/ircuser.cpp
+++ b/src/common/ircuser.cpp
@@ -291,16 +291,16 @@ void IrcUser::joinChannel(const QString& channelname)
     joinChannel(network()->newIrcChannel(channelname));
 }
 
-void IrcUser::partChannel(IrcChannel* channel)
+void IrcUser::partChannel(IrcChannel* channel, bool skip_sync)
 {
     if (_channels.contains(channel)) {
         _channels.remove(channel);
         disconnect(channel, nullptr, this, nullptr);
         channel->part(this);
         QString channelName = channel->name();
-        SYNC_OTHER(partChannel, ARG(channelName))
+        if (!skip_sync) SYNC_OTHER(partChannel, ARG(channelName))
         if (_channels.isEmpty() && !network()->isMe(this))
-            quit();
+            quit(skip_sync);
     }
 }
 
@@ -315,7 +315,7 @@ void IrcUser::partChannel(const QString& channelname)
     }
 }
 
-void IrcUser::quit()
+void IrcUser::quit(bool skip_sync)
 {
     QList<IrcChannel*> channels = _channels.toList();
     _channels.clear();
@@ -324,7 +324,7 @@ void IrcUser::quit()
         channel->part(this);
     }
     network()->removeIrcUser(this);
-    SYNC(NO_ARG)
+    if (!skip_sync) SYNC(NO_ARG)
     emit quited();
 }
 

--- a/src/common/ircuser.h
+++ b/src/common/ircuser.h
@@ -166,9 +166,9 @@ public slots:
      */
     void joinChannel(IrcChannel* channel, bool skip_channel_join = false);
     void joinChannel(const QString& channelname);
-    void partChannel(IrcChannel* channel);
+    void partChannel(IrcChannel* channel, bool skip_sync = false);
     void partChannel(const QString& channelname);
-    void quit();
+    void quit(bool skip_sync = false);
 
     void addUserModes(const QString& modes);
     void removeUserModes(const QString& modes);


### PR DESCRIPTION
## In Short
* Only transmit one message to part a channel instead of two per each user

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Reduces protocol spam, reducing the perceived latency of some operations |
| Risk | ★☆☆  _1/3_ | Could trigger bugs in older clients |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to few rarely-touched classes, shouldn't interfere with other pull requests |

## Rationale

When we leave a channel, we currently not only transmit the protocol message that we have left, but also a part (and potentially a quit) message for each user in that channel. Clients can synthesize these themselves, though, and already do.

As result, these messages get discarded by clients and only serve to fill the connection with spam.