### PR TITLE
Ignore ignored messages for highlights and buffer activity counts

### DIFF
--- a/src/common/message.cpp
+++ b/src/common/message.cpp
@@ -34,7 +34,8 @@ Message::Message(BufferInfo bufferInfo,
                  QString senderPrefixes,
                  QString realName,
                  QString avatarUrl,
-                 Flags flags)
+                 Flags flags,
+                 bool ignored)
     : _timestamp(QDateTime::currentDateTime().toUTC())
     , _bufferInfo(std::move(bufferInfo))
     , _contents(std::move(contents))
@@ -44,6 +45,7 @@ Message::Message(BufferInfo bufferInfo,
     , _avatarUrl(std::move(avatarUrl))
     , _type(type)
     , _flags(flags)
+    , _ignored(ignored)
 {}
 
 Message::Message(QDateTime ts,
@@ -54,7 +56,8 @@ Message::Message(QDateTime ts,
                  QString senderPrefixes,
                  QString realName,
                  QString avatarUrl,
-                 Flags flags)
+                 Flags flags,
+                 bool ignored)
     : _timestamp(std::move(ts))
     , _bufferInfo(std::move(bufferInfo))
     , _contents(std::move(contents))
@@ -64,6 +67,7 @@ Message::Message(QDateTime ts,
     , _avatarUrl(std::move(avatarUrl))
     , _type(type)
     , _flags(flags)
+    , _ignored(ignored)
 {}
 
 QDataStream& operator<<(QDataStream& out, const Message& msg)
@@ -161,6 +165,7 @@ QDebug operator<<(QDebug dbg, const Message& msg)
                   << qPrintable(QString(", RealName:")) << msg.realName()
                   << qPrintable(QString(", AvatarURL:")) << msg.avatarUrl()
                   << qPrintable(QString(", Flags:")) << msg.flags()
+                  << qPrintable(QString(", Ignored:")) << msg.ignored()
                   << qPrintable(QString(")"))
                   << msg.senderPrefixes() << msg.sender() << ":"
                   << msg.contents();

--- a/src/common/message.h
+++ b/src/common/message.h
@@ -77,7 +77,8 @@ public:
             QString senderPrefixes = {},
             QString realName = {},
             QString avatarUrl = {},
-            Flags flags = None);
+            Flags flags = None,
+            bool ignored = false);
     Message(QDateTime ts,
             BufferInfo buffer = BufferInfo(),
             Type type = Plain,
@@ -86,7 +87,8 @@ public:
             QString senderPrefixes = {},
             QString realName = {},
             QString avatarUrl = {},
-            Flags flags = None);
+            Flags flags = None,
+            bool ignored = false);
 
     inline static Message ChangeOfDay(const QDateTime& day) { return Message(day, BufferInfo(), DayChange); }
     inline const MsgId& msgId() const { return _msgId; }
@@ -103,6 +105,8 @@ public:
     inline Type type() const { return _type; }
     inline Flags flags() const { return _flags; }
     inline void setFlags(Flags flags) { _flags = flags; }
+    inline bool ignored() const { return _ignored; }
+    inline void setIgnored(bool ignored) { _ignored = ignored; }
     inline const QDateTime& timestamp() const { return _timestamp; }
 
     inline bool isValid() const { return _msgId.isValid(); }
@@ -120,6 +124,7 @@ private:
     QString _avatarUrl;
     Type _type;
     Flags _flags;
+    bool _ignored;
 
     friend QDataStream& operator>>(QDataStream& in, Message& msg);
 };

--- a/src/core/SQL/PostgreSQL/insert_message.sql
+++ b/src/core/SQL/PostgreSQL/insert_message.sql
@@ -1,3 +1,3 @@
-INSERT INTO backlog (time, bufferid, type, flags, senderid, senderprefixes, message)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+INSERT INTO backlog (time, bufferid, type, flags, ignored, senderid, senderprefixes, message)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 RETURNING messageid

--- a/src/core/SQL/PostgreSQL/migrate_write_backlog.sql
+++ b/src/core/SQL/PostgreSQL/migrate_write_backlog.sql
@@ -1,2 +1,2 @@
-INSERT INTO backlog (messageid, time, bufferid, type, flags, senderid, senderprefixes, message)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO backlog (messageid, time, bufferid, type, flags, ignored, senderid, senderprefixes, message)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/src/core/SQL/PostgreSQL/select_buffer_bufferactivity.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_bufferactivity.sql
@@ -4,4 +4,5 @@ FROM
    FROM backlog
    WHERE bufferid = :bufferid
      AND flags & 1 = 0
+     AND ignored != true
      AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
@@ -4,4 +4,5 @@ FROM
    WHERE bufferid = :bufferid
      AND flags & 2 != 0
      AND flags & 1 = 0
+     AND ignored != true
      AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/PostgreSQL/setup_060_backlog.sql
+++ b/src/core/SQL/PostgreSQL/setup_060_backlog.sql
@@ -4,6 +4,7 @@ CREATE TABLE backlog (
 	bufferid integer NOT NULL REFERENCES buffer (bufferid) ON DELETE CASCADE,
 	type integer NOT NULL,
 	flags integer NOT NULL,
+	ignored boolean NOT NULL,
 	senderid bigint NOT NULL REFERENCES sender (senderid) ON DELETE SET NULL,
 	senderprefixes TEXT,
 	message TEXT

--- a/src/core/SQL/PostgreSQL/version/30/upgrade_000_update_backlog_add_ignored.sql
+++ b/src/core/SQL/PostgreSQL/version/30/upgrade_000_update_backlog_add_ignored.sql
@@ -1,0 +1,2 @@
+ALTER TABLE backlog
+ADD COLUMN ignored boolean NOT NULL DEFAULT false

--- a/src/core/SQL/SQLite/insert_message.sql
+++ b/src/core/SQL/SQLite/insert_message.sql
@@ -1,5 +1,6 @@
-INSERT INTO backlog (time, bufferid, type, flags, senderid, senderprefixes, message)
+INSERT INTO backlog (time, bufferid, type, flags, ignored, senderid, senderprefixes, message)
 VALUES (:time, :bufferid, :type, :flags,
+    :ignored,
 	(SELECT senderid FROM sender WHERE sender = :sender AND coalesce(realname, '') = coalesce(:realname, '') AND coalesce(avatarurl, '') = coalesce(:avatarurl, '')),
 	:senderprefixes, :message
 )

--- a/src/core/SQL/SQLite/migrate_read_backlog.sql
+++ b/src/core/SQL/SQLite/migrate_read_backlog.sql
@@ -1,4 +1,4 @@
-SELECT messageid, time, bufferid, type, flags, senderid, senderprefixes, message
+SELECT messageid, time, bufferid, type, flags, ignored, senderid, senderprefixes, message
 FROM backlog
 WHERE messageid > ? AND messageid <= ?
 ORDER BY messageid ASC

--- a/src/core/SQL/SQLite/select_buffer_bufferactivity.sql
+++ b/src/core/SQL/SQLite/select_buffer_bufferactivity.sql
@@ -4,4 +4,5 @@ FROM
    FROM backlog
    WHERE bufferid = :bufferid
      AND flags & 1 = 0
+     AND ignored != true
      AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/SQLite/select_buffer_highlightcount.sql
+++ b/src/core/SQL/SQLite/select_buffer_highlightcount.sql
@@ -4,4 +4,5 @@ FROM
    WHERE bufferid = :bufferid
      AND flags & 2 != 0
      AND flags & 1 = 0
+     AND ignored != true
      AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/SQLite/setup_060_backlog.sql
+++ b/src/core/SQL/SQLite/setup_060_backlog.sql
@@ -4,6 +4,7 @@ CREATE TABLE backlog (
 	bufferid INTEGER NOT NULL,
 	type INTEGER NOT NULL,
 	flags INTEGER NOT NULL,
+    ignored boolean NOT NULL,
 	senderid INTEGER NOT NULL,
 	senderprefixes TEXT,
 	message TEXT

--- a/src/core/SQL/SQLite/version/32/upgrade_000_update_backlog_add_ignored.sql
+++ b/src/core/SQL/SQLite/version/32/upgrade_000_update_backlog_add_ignored.sql
@@ -1,0 +1,2 @@
+ALTER TABLE backlog
+ADD COLUMN ignored boolean NOT NULL DEFAULT false

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -312,6 +312,7 @@ public:
         BufferId bufferid;
         int type;
         int flags;
+        bool ignored;
         qint64 senderid;
         QString senderprefixes;
         QString message;

--- a/src/core/corebuffersyncer.h
+++ b/src/core/corebuffersyncer.h
@@ -40,17 +40,21 @@ public slots:
 
     void addBufferActivity(const Message& message)
     {
-        auto oldActivity = activity(message.bufferId());
-        if (!oldActivity.testFlag(message.type())) {
-            setBufferActivity(message.bufferId(), (int)(oldActivity | message.type()));
+        if (!message.ignored()) {
+            auto oldActivity = activity(message.bufferId());
+            if (!oldActivity.testFlag(message.type())) {
+                setBufferActivity(message.bufferId(), (int) (oldActivity | message.type()));
+            }
         }
     }
 
     void addCoreHighlight(const Message& message)
     {
-        auto oldHighlightCount = highlightCount(message.bufferId());
-        if (message.flags().testFlag(Message::Flag::Highlight) && !message.flags().testFlag(Message::Flag::Self)) {
-            setHighlightCount(message.bufferId(), oldHighlightCount + 1);
+        if (!message.ignored()) {
+            auto oldHighlightCount = highlightCount(message.bufferId());
+            if (message.flags().testFlag(Message::Flag::Highlight) && !message.flags().testFlag(Message::Flag::Self)) {
+                setHighlightCount(message.bufferId(), oldHighlightCount + 1);
+            }
         }
     }
 

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -314,6 +314,7 @@ struct RawMessage
     QString text;
     QString sender;
     Message::Flags flags;
+    bool ignored;
 
     RawMessage(QDateTime timestamp,
                NetworkId networkId,
@@ -322,7 +323,8 @@ struct RawMessage
                QString target,
                QString text,
                QString sender,
-               Message::Flags flags)
+               Message::Flags flags,
+               bool ignored)
         : timestamp(std::move(timestamp))
         , networkId(networkId)
         , type(type)
@@ -331,6 +333,7 @@ struct RawMessage
         , text(std::move(text))
         , sender(std::move(sender))
         , flags(flags)
+        , ignored(ignored)
     {}
 
     RawMessage(NetworkId networkId,
@@ -343,5 +346,6 @@ struct RawMessage
         , text(msg.text)
         , sender(msg.sender)
         , flags(msg.flags)
+        , ignored(false)
     {}
 };

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1647,7 +1647,7 @@ bool PostgreSqlStorage::logMessage(Message& msg)
     QVariantList params;
     // PostgreSQL handles QDateTime()'s serialized format by default, and QDateTime() serializes
     // to a 64-bit time compatible format by default.
-    params << msg.timestamp() << msg.bufferInfo().bufferId().toInt() << msg.type() << (int)msg.flags() << senderId << msg.senderPrefixes()
+    params << msg.timestamp() << msg.bufferInfo().bufferId().toInt() << msg.type() << (int)msg.flags() << msg.ignored() << senderId << msg.senderPrefixes()
            << msg.contents();
     QSqlQuery logMessageQuery = executePreparedQuery("insert_message", params, db);
 
@@ -1726,7 +1726,7 @@ bool PostgreSqlStorage::logMessages(MessageList& msgs)
         QVariantList params;
         // PostgreSQL handles QDateTime()'s serialized format by default, and QDateTime() serializes
         // to a 64-bit time compatible format by default.
-        params << msg.timestamp() << msg.bufferInfo().bufferId().toInt() << msg.type() << (int)msg.flags() << senderIdList.at(i)
+        params << msg.timestamp() << msg.bufferInfo().bufferId().toInt() << msg.type() << (int)msg.flags() << msg.ignored() << senderIdList.at(i)
                << msg.senderPrefixes() << msg.contents();
         QSqlQuery logMessageQuery = executePreparedQuery("insert_message", params, db);
         if (!watchQuery(logMessageQuery)) {
@@ -2360,9 +2360,10 @@ bool PostgreSqlMigrationWriter::writeMo(const BacklogMO& backlog)
     bindValue(2, backlog.bufferid.toInt());
     bindValue(3, backlog.type);
     bindValue(4, (int)backlog.flags);
-    bindValue(5, backlog.senderid);
-    bindValue(6, backlog.senderprefixes);
-    bindValue(7, backlog.message);
+    bindValue(5, backlog.ignored);
+    bindValue(6, backlog.senderid);
+    bindValue(7, backlog.senderprefixes);
+    bindValue(8, backlog.message);
     return exec();
 }
 

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1779,6 +1779,7 @@ bool SqliteStorage::logMessage(Message& msg)
         logMessageQuery.bindValue(":bufferid", msg.bufferInfo().bufferId().toInt());
         logMessageQuery.bindValue(":type", msg.type());
         logMessageQuery.bindValue(":flags", (int)msg.flags());
+        logMessageQuery.bindValue(":ignored", msg.ignored());
         logMessageQuery.bindValue(":sender", msg.sender());
         logMessageQuery.bindValue(":realname", msg.realName());
         logMessageQuery.bindValue(":avatarurl", msg.avatarUrl());
@@ -1862,6 +1863,7 @@ bool SqliteStorage::logMessages(MessageList& msgs)
             logMessageQuery.bindValue(":bufferid", msg.bufferInfo().bufferId().toInt());
             logMessageQuery.bindValue(":type", msg.type());
             logMessageQuery.bindValue(":flags", (int)msg.flags());
+            logMessageQuery.bindValue(":ignored", msg.ignored());
             logMessageQuery.bindValue(":sender", msg.sender());
             logMessageQuery.bindValue(":realname", msg.realName());
             logMessageQuery.bindValue(":avatarurl", msg.avatarUrl());
@@ -2461,9 +2463,10 @@ bool SqliteMigrationReader::readMo(BacklogMO& backlog)
     backlog.bufferid = value(2).toInt();
     backlog.type = value(3).toInt();
     backlog.flags = value(4).toInt();
-    backlog.senderid = value(5).toLongLong();
-    backlog.senderprefixes = value(6).toString();
-    backlog.message = value(7).toString();
+    backlog.ignored = value(5).toInt();
+    backlog.senderid = value(6).toLongLong();
+    backlog.senderprefixes = value(7).toString();
+    backlog.message = value(8).toString();
     return true;
 }
 


### PR DESCRIPTION
## In Short

* Adds an "ignored" flag to messages in the database
* Sets it if the message is ignored
* Ignore such messages for highlightCount and bufferActivity

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Fixes slightly wrong activity/highlight displays |
| Risk | ★★☆  _2/3_ | Could accidentally introduce protocol incompatibilities, includes a migration |
| Intrusiveness | ★★☆  _2/3_ | Includes a database migration |

## Rationale

Previously, we didn’t store on the core if a message was ignored, due to that we couldn’t include this information while compiling highlight counts and buffer activities on the core.

This has been fixed and highlight count and buffer activity information are now more accurate.