### PR TITLE
Sync last msgid

### DIFF
--- a/src/common/buffersyncer.cpp
+++ b/src/common/buffersyncer.cpp
@@ -158,6 +158,9 @@ void BufferSyncer::removeBuffer(BufferId buffer)
 
 void BufferSyncer::mergeBuffersPermanently(BufferId buffer1, BufferId buffer2)
 {
+    setBufferActivity(buffer1, _bufferActivities[buffer1] | _bufferActivities[buffer2]);
+    setHighlightCount(buffer1, _highlightCounts[buffer1] + _highlightCounts[buffer2]);
+
     if (_lastSeenMsg.contains(buffer2))
         _lastSeenMsg.remove(buffer2);
     if (_markerLines.contains(buffer2))

--- a/src/core/SQL/PostgreSQL/select_buffer_last_messages.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_last_messages.sql
@@ -1,0 +1,3 @@
+SELECT bufferid, lastmsgid
+FROM buffer
+WHERE userid = :userid

--- a/src/core/SQL/SQLite/select_buffer_last_messages.sql
+++ b/src/core/SQL/SQLite/select_buffer_last_messages.sql
@@ -1,0 +1,3 @@
+SELECT bufferid, lastmsgid
+FROM buffer
+WHERE userid = :userid

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -515,6 +515,14 @@ public:
      */
     QString strictSysIdent(UserId user) const;
 
+    //! Get a Hash of all last message ids
+    /** This Method is called when the Quassel Core is started to restore the lastMsgIds
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of the buffers
+     */
+    static inline QHash<BufferId, MsgId> bufferLastMsgIds(UserId user) { return instance()->_storage->bufferLastMsgIds(user); }
+
     //! Get a Hash of all last seen message ids
     /** This Method is called when the Quassel Core is started to restore the lastSeenMsgIds
      *  \note This method is threadsafe.

--- a/src/core/corebuffersyncer.cpp
+++ b/src/core/corebuffersyncer.cpp
@@ -34,7 +34,8 @@ public:
 };
 
 CoreBufferSyncer::CoreBufferSyncer(CoreSession* parent)
-    : BufferSyncer(Core::bufferLastSeenMsgIds(parent->user()),
+    : BufferSyncer(Core::bufferLastMsgIds(parent->user()),
+                   Core::bufferLastSeenMsgIds(parent->user()),
                    Core::bufferMarkerLineMsgIds(parent->user()),
                    Core::bufferActivities(parent->user()),
                    Core::highlightCounts(parent->user()),

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -92,6 +92,7 @@ public slots:
     bool removeBuffer(const UserId& user, const BufferId& bufferId) override;
     bool renameBuffer(const UserId& user, const BufferId& bufferId, const QString& newName) override;
     bool mergeBuffersPermanently(const UserId& user, const BufferId& bufferId1, const BufferId& bufferId2) override;
+    QHash<BufferId, MsgId> bufferLastMsgIds(UserId user) override;
     void setBufferLastSeenMsg(UserId user, const BufferId& bufferId, const MsgId& msgId) override;
     QHash<BufferId, MsgId> bufferLastSeenMsgIds(UserId user) override;
     void setBufferMarkerLineMsg(UserId user, const BufferId& bufferId, const MsgId& msgId) override;

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1482,6 +1482,34 @@ bool SqliteStorage::mergeBuffersPermanently(const UserId& user, const BufferId& 
     return !error;
 }
 
+QHash<BufferId, MsgId> SqliteStorage::bufferLastMsgIds(UserId user)
+{
+    QHash<BufferId, MsgId> lastMsgHash;
+
+    QSqlDatabase db = logDb();
+    db.transaction();
+
+    bool error = false;
+    {
+        QSqlQuery query(db);
+        query.prepare(queryString("select_buffer_last_messages"));
+        query.bindValue(":userid", user.toInt());
+
+        lockForRead();
+        safeExec(query);
+        error = !watchQuery(query);
+        if (!error) {
+            while (query.next()) {
+                lastMsgHash[query.value(0).toInt()] = query.value(1).toLongLong();
+            }
+        }
+    }
+
+    db.commit();
+    unlock();
+    return lastMsgHash;
+}
+
 void SqliteStorage::setBufferLastSeenMsg(UserId user, const BufferId& bufferId, const MsgId& msgId)
 {
     QSqlDatabase db = logDb();

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -93,6 +93,7 @@ public slots:
     bool removeBuffer(const UserId& user, const BufferId& bufferId) override;
     bool renameBuffer(const UserId& user, const BufferId& bufferId, const QString& newName) override;
     bool mergeBuffersPermanently(const UserId& user, const BufferId& bufferId1, const BufferId& bufferId2) override;
+    QHash<BufferId, MsgId> bufferLastMsgIds(UserId user) override;
     void setBufferLastSeenMsg(UserId user, const BufferId& bufferId, const MsgId& msgId) override;
     QHash<BufferId, MsgId> bufferLastSeenMsgIds(UserId user) override;
     void setBufferMarkerLineMsg(UserId user, const BufferId& bufferId, const MsgId& msgId) override;

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -380,6 +380,12 @@ public slots:
      */
     virtual void setBufferLastSeenMsg(UserId user, const BufferId& bufferId, const MsgId& msgId) = 0;
 
+    //! Get a Hash of all last message ids
+    /** This Method is called when the Quassel Core is started to restore the lastMsgIds
+     * \param user      The Owner of the buffers
+     */
+    virtual QHash<BufferId, MsgId> bufferLastMsgIds(UserId user) = 0;
+
     //! Get a Hash of all last seen message ids
     /** This Method is called when the Quassel Core is started to restore the lastSeenMsgIds
      * \param user      The Owner of the buffers


### PR DESCRIPTION
## In Short

* Fixes an issue where permanently merged buffers had wrong buffer activities / highlight counts
* Syncs the last message id per buffer via the buffersyncer

## Impact

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Fixes slightly wrong activity/highlight displays and allows quasseldroid to provide new features |
| Risk | ★☆☆  _1/3_ | Does not touch any critical code |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to a few classes |

## Rationale

In the future, we plan to resume chat wherever the user was in quasseldroid, also allowing users to jump to arbitrary points in the history (e.g. for fast-scrolling to a certain day, for jumping to search results or notifications).

To allow this, not only do we have to have bidirectional backlog requesting (which will come soon), but we also have to know where the currently last message id is (so that, once we actually have that latest message loaded, we stop dropping displayMsg calls, deactivate the archive UI, and automatically scroll chat again)