### PR TITLE
[WIP] Allow peers to mark themselves or other peers as away

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -112,6 +112,8 @@ Client::Client(std::unique_ptr<AbstractUi> ui, QObject* parent)
     p->attachSignal(this, &Client::requestKickClient, SIGNAL(kickClient(int)));
     p->attachSlot(SIGNAL(disconnectFromCore()), this, &Client::disconnectFromCore);
 
+    p->attachSignal(this, &Client::requestMarkPeerAway, SIGNAL(markPeerAway(int,bool)));
+
     p->synchronize(backlogManager());
     p->synchronize(coreInfo());
     p->synchronize(_ircListHelper);
@@ -657,6 +659,11 @@ void Client::changePassword(const QString& oldPassword, const QString& newPasswo
 void Client::kickClient(int peerId)
 {
     emit instance()->requestKickClient(peerId);
+}
+
+void Client::markPeerAway(int peerId, bool away)
+{
+    emit instance()->requestMarkPeerAway(peerId, away);
 }
 
 void Client::corePasswordChanged(PeerPtr, bool success)

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -167,6 +167,7 @@ public:
 
     static void changePassword(const QString& oldPassword, const QString& newPassword);
     static void kickClient(int peerId);
+    static void markPeerAway(int peerId, bool away);
 
     void displayIgnoreList(QString ignoreRule) { emit showIgnoreList(ignoreRule); }
 
@@ -252,6 +253,7 @@ signals:
     void requestPasswordChange(PeerPtr peer, const QString& userName, const QString& oldPassword, const QString& newPassword);
 
     void requestKickClient(int peerId);
+    void requestMarkPeerAway(int peerId, bool away);
     void passwordChanged(bool success);
 
     //! Emitted when database schema upgrade starts or ends (only mono client)

--- a/src/client/clientuserinputhandler.cpp
+++ b/src/client/clientuserinputhandler.cpp
@@ -83,6 +83,13 @@ void ClientUserInputHandler::defaultHandler(const QString& cmd, const BufferInfo
     emit sendInput(bufferInfo, command);
 }
 
+void ClientUserInputHandler::handleClientaway(const BufferInfo& bufferInfo, const QString& text)
+{
+    Q_UNUSED(bufferInfo);
+
+    Client::markPeerAway(-1, text.toLower() == "true");
+}
+
 void ClientUserInputHandler::handleExec(const BufferInfo& bufferInfo, const QString& execString)
 {
     auto* exec = new ExecWrapper(this);  // gets suicidal when it's done

--- a/src/client/clientuserinputhandler.h
+++ b/src/client/clientuserinputhandler.h
@@ -47,6 +47,7 @@ private slots:
     void handleQuery(const BufferInfo& bufferInfo, const QString& text);
     void handleIgnore(const BufferInfo& bufferInfo, const QString& text);
     void handleList(const BufferInfo& bufferInfo, const QString& text);
+    void handleClientaway(const BufferInfo& bufferInfo, const QString& text);
     void defaultHandler(const QString& cmd, const BufferInfo& bufferInfo, const QString& text);
 
 private:

--- a/src/common/peer.cpp
+++ b/src/common/peer.cpp
@@ -85,6 +85,17 @@ void Peer::setId(int id)
     _id = id;
 }
 
+bool Peer::away() const
+{
+    return _away;
+}
+
+void Peer::setAway(bool away)
+{
+    _away = away;
+    emit awayStateChanged();
+}
+
 // PeerPtr is used in RPC signatures for enabling receivers to send replies
 // to a particular peer rather than broadcast to all connected ones.
 // To enable this, the SignalProxy transparently replaces the bogus value

--- a/src/common/peer.h
+++ b/src/common/peer.h
@@ -60,6 +60,9 @@ public:
     int id() const;
     void setId(int id);
 
+    bool away() const;
+    void setAway(bool away);
+
     AuthHandler* authHandler() const;
 
     virtual bool isOpen() const = 0;
@@ -94,6 +97,7 @@ public slots:
 
 signals:
     void disconnected();
+    void awayStateChanged();
     void secureStateChanged(bool secure = true);
     void lagUpdated(int msecs);
 
@@ -109,6 +113,8 @@ private:
     QString _buildDate;
     QString _clientVersion;
     Quassel::Features _features;
+
+    bool _away;
 
     int _id = -1;
 };

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -658,6 +658,7 @@ QVariantList SignalProxy::peerData()
     for (auto&& peer : _peerMap.values()) {
         QVariantMap data;
         data["id"] = peer->id();
+        data["away"] = peer->away();
         data["clientVersion"] = peer->clientVersion();
         // We explicitly rename this, as, due to the Debian reproducability changes, buildDate isn’t actually the build
         // date anymore, but on newer clients the date of the last git commit
@@ -670,6 +671,15 @@ QVariantList SignalProxy::peerData()
         result << data;
     }
     return result;
+}
+
+bool SignalProxy::peersAllAway()
+{
+    for (auto&& peer : _peerMap.values()) {
+        if (!peer->away())
+            return false;
+    }
+    return true;
 }
 
 Peer* SignalProxy::peerById(int peerId)

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -186,6 +186,11 @@ public:
     Peer* peerById(int peerId);
 
     /**
+     * @return If all currently connected peers are away
+     */
+    bool peersAllAway();
+
+    /**
      * @return If handling a signal, the Peer from which the current signal originates
      */
     Peer* sourcePeer();

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -151,6 +151,11 @@ public slots:
 
     void changePassword(PeerPtr peer, const QString& userName, const QString& oldPassword, const QString& newPassword);
 
+    /**
+     * Marks the own client as away
+     */
+    void markPeerAway(int peerId, bool away);
+
     void kickClient(int peerId);
 
     QHash<QString, QString> persistentChannels(NetworkId) const;
@@ -215,14 +220,15 @@ private slots:
 
     void scriptRequest(QString script);
 
-    void clientsConnected();
-    void clientsDisconnected();
+    void updateDetachAway();
 
     void updateIdentityBySender();
 
     void saveSessionState() const;
 
     void onNetworkDisconnected(NetworkId networkId);
+
+    void updatePeers();
 
 private:
     void processMessages();


### PR DESCRIPTION
## In Short

* adds a /clientaway command to the qtclient to allow users to mark a client as away, it will not be counted towards active clients for detachaway
* adds a sync call to allow clients to mark themselves or other clients as away
* updates detachaway once a client sets itself as away

## Impact

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Helps make detachaway work with always-connected mobile clients or bots |
| Risk | ★☆☆  _1/3_ | Does not touch any critical code |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to a few classes |

## Rationale

Detach away is a useful and nice feature, it’s just relatively useless in the age of always-connected clients such as Quasseldroid, or if users are using tools such as the pushbullet notifier or quassel bots. Therefore, this PR introduces a way for clients to mark themselves as away, in a way that enables detachaway if all clients are gone or away.