### PR TITLE
multilineedit: handle unterminated mIRC codes

### DIFF
--- a/src/uisupport/multilineedit.cpp
+++ b/src/uisupport/multilineedit.cpp
@@ -601,6 +601,10 @@ QString MultiLineEdit::convertMircCodesToHtml(const QString& text)
         }
 
         posRight = text.indexOf(mircCode.cap(), posRight + 1);
+        if (posRight == -1) {
+            words << text.mid(posLeft);
+            break;  // unclosed color code; can't process
+        }
         words << text.mid(posLeft, posRight + 1 - posLeft);
         posLeft = posRight + 1;
     }


### PR DESCRIPTION
Currently, if an unterminated mIRC code is pasted into Quassel, trying to
go through input line history will cause a deadlock.  This breaks the loop
at the cost of possibly mangling the formatting of the line somewhat.
This is seen as more acceptable than locking up, and the line is invalid
anyway.

Reproducer:

```sh
printf '\00303,08HONK' | xclip -selection clipboard
```

Paste into Quassel, send, press Up arrow key.

Bug originally found by @sroracle, reported to Adélie Linux, patched by
yours truly.