### PR TITLE
Implement backend for notification settings and buffer mutes

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(${TARGET} PRIVATE
     network.cpp
     networkconfig.cpp
     networkevent.cpp
+    notificationmanager.cpp
     nickhighlightmatcher.cpp
     peer.cpp
     peerfactory.cpp

--- a/src/common/notificationmanager.cpp
+++ b/src/common/notificationmanager.cpp
@@ -1,0 +1,25 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2019 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include "notificationmanager.h"
+
+#include <QDebug>
+#include <QStringList>
+#include <QtCore>

--- a/src/common/notificationmanager.h
+++ b/src/common/notificationmanager.h
@@ -1,0 +1,91 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2019 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#pragma once
+
+#include "common-export.h"
+
+#include <utility>
+
+#include <QString>
+#include <QStringList>
+#include <QVariantList>
+#include <QVariantMap>
+
+#include "expressionmatch.h"
+#include "message.h"
+#include "nickhighlightmatcher.h"
+#include "syncableobject.h"
+
+class COMMON_EXPORT NotificationManager : public SyncableObject
+{
+    Q_OBJECT
+    SYNCABLE_OBJECT
+
+    Q_PROPERTY(int notificationSettingQuery READ notificationSettingQuery WRITE setNotificationSettingQuery)
+    Q_PROPERTY(int notificationSettingChannel READ notificationSettingChannel WRITE setNotificationSettingChannel)
+    Q_PROPERTY(int notificationSettingStatus READ notificationSettingStatus WRITE setNotificationSettingStatus)
+
+public:
+    enum NotificationSetting : int {
+        Default = 0x00,
+        None = 0x01,
+        Highlight = 0x02,
+        All = 0x03
+    };
+
+    inline NotificationManager(QObject* parent = nullptr)
+        : SyncableObject(parent)
+    {
+        setAllowClientUpdates(true);
+    }
+
+    inline int notificationSettingQuery() { return _notificationSettingQuery; }
+    inline int notificationSettingChannel() { return _notificationSettingChannel; }
+    inline int notificationSettingStatus() { return _notificationSettingStatus; }
+
+public slots:
+
+    virtual inline void requestSetNotificationSettingQuery(int notificationSetting) { REQUEST(ARG(notificationSetting)) }
+
+    inline void setNotificationSettingQuery(int notificationSetting)
+    {
+        _notificationSettingQuery = static_cast<NotificationManager::NotificationSetting>(notificationSetting);
+    }
+
+    virtual inline void requestSetNotificationSettingChannel(int notificationSetting) { REQUEST(ARG(notificationSetting)) }
+
+    inline void setNotificationSettingChannel(int notificationSetting)
+    {
+        _notificationSettingChannel = static_cast<NotificationManager::NotificationSetting>(notificationSetting);
+    }
+
+    virtual inline void requestSetNotificationSettingStatus(int notificationSetting) { REQUEST(ARG(notificationSetting)) }
+
+    inline void setNotificationSettingStatus(int notificationSetting)
+    {
+        _notificationSettingStatus = static_cast<NotificationManager::NotificationSetting>(notificationSetting);
+    }
+
+private:
+    NotificationSetting _notificationSettingQuery = NotificationSetting::All;
+    NotificationSetting _notificationSettingChannel = NotificationSetting::Highlight;
+    NotificationSetting _notificationSettingStatus = NotificationSetting::None;
+};

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(${TARGET} PRIVATE
     coreircuser.cpp
     corenetwork.cpp
     corenetworkconfig.cpp
+    corenotificationmanager.cpp
     coresession.cpp
     coresessioneventprocessor.cpp
     coresettings.cpp

--- a/src/core/SQL/PostgreSQL/migrate_write_buffer.sql
+++ b/src/core/SQL/PostgreSQL/migrate_write_buffer.sql
@@ -1,2 +1,2 @@
-INSERT INTO buffer (bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, highlightcount, key, joined, cipher)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO buffer (bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, highlightcount, notificationsetting, muteduntil, key, joined, cipher)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/src/core/SQL/PostgreSQL/select_buffer_muteduntil.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_muteduntil.sql
@@ -1,0 +1,3 @@
+SELECT bufferid, muteduntil
+FROM buffer
+WHERE userid = :userid

--- a/src/core/SQL/PostgreSQL/select_buffer_notificationsettings.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_notificationsettings.sql
@@ -1,0 +1,3 @@
+SELECT bufferid, notificationsetting
+FROM buffer
+WHERE userid = :userid

--- a/src/core/SQL/PostgreSQL/setup_050_buffer.sql
+++ b/src/core/SQL/PostgreSQL/setup_050_buffer.sql
@@ -11,6 +11,8 @@ create TABLE buffer (
 	markerlinemsgid bigint NOT NULL DEFAULT 0,
 	bufferactivity integer NOT NULL DEFAULT 0,
 	highlightcount integer NOT NULL DEFAULT 0,
+	notificationsetting integer NOT NULL DEFAULT 0,
+	muteduntil timestamp NOT NULL,
 	key varchar(128),
 	joined boolean NOT NULL DEFAULT FALSE, -- BOOL
 	cipher TEXT,

--- a/src/core/SQL/PostgreSQL/update_buffer_muteduntil.sql
+++ b/src/core/SQL/PostgreSQL/update_buffer_muteduntil.sql
@@ -1,0 +1,3 @@
+UPDATE buffer
+SET muteduntil = :muteduntil
+WHERE userid = :userid AND bufferid = :bufferid

--- a/src/core/SQL/PostgreSQL/update_buffer_notificationsetting.sql
+++ b/src/core/SQL/PostgreSQL/update_buffer_notificationsetting.sql
@@ -1,0 +1,3 @@
+UPDATE buffer
+SET notificationsetting = :notificationsetting
+WHERE userid = :userid AND bufferid = :bufferid

--- a/src/core/SQL/PostgreSQL/version/30/upgrade_000_alter_buffer_add_muteduntil.sql
+++ b/src/core/SQL/PostgreSQL/version/30/upgrade_000_alter_buffer_add_muteduntil.sql
@@ -1,0 +1,2 @@
+ALTER TABLE buffer
+ADD COLUMN muteduntil timestamp NOT NULL DEFAULT '1970-01-01 00:00'

--- a/src/core/SQL/PostgreSQL/version/30/upgrade_000_alter_buffer_add_notificationsetting.sql
+++ b/src/core/SQL/PostgreSQL/version/30/upgrade_000_alter_buffer_add_notificationsetting.sql
@@ -1,0 +1,2 @@
+ALTER TABLE buffer
+ADD COLUMN notificationsetting integer NOT NULL DEFAULT 0

--- a/src/core/SQL/SQLite/migrate_read_buffer.sql
+++ b/src/core/SQL/SQLite/migrate_read_buffer.sql
@@ -1,2 +1,2 @@
-SELECT bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, highlightcount, key, joined, cipher
+SELECT bufferid, userid, groupid, networkid, buffername, buffercname, buffertype, lastmsgid, lastseenmsgid, markerlinemsgid, bufferactivity, highlightcount, notificationsetting, muteduntil, key, joined, cipher
 FROM buffer

--- a/src/core/SQL/SQLite/select_buffer_muteduntil.sql
+++ b/src/core/SQL/SQLite/select_buffer_muteduntil.sql
@@ -1,0 +1,3 @@
+SELECT bufferid, muteduntil
+FROM buffer
+WHERE userid = :userid

--- a/src/core/SQL/SQLite/select_buffer_notificationsettings.sql
+++ b/src/core/SQL/SQLite/select_buffer_notificationsettings.sql
@@ -1,0 +1,3 @@
+SELECT bufferid, notificationsetting
+FROM buffer
+WHERE userid = :userid

--- a/src/core/SQL/SQLite/setup_030_buffer.sql
+++ b/src/core/SQL/SQLite/setup_030_buffer.sql
@@ -11,6 +11,8 @@ CREATE TABLE buffer (
 	markerlinemsgid INTEGER NOT NULL DEFAULT 0,
 	bufferactivity INTEGER NOT NULL DEFAULT 0,
 	highlightcount INTEGER NOT NULL DEFAULT 0,
+	notificationsetting INTEGER NOT NULL DEFAULT 0,
+	muteduntil INTEGER NOT NULL DEFAULT 0,
 	key TEXT,
 	joined INTEGER NOT NULL DEFAULT 0, -- BOOL
 	cipher TEXT,

--- a/src/core/SQL/SQLite/update_buffer_muteduntil.sql
+++ b/src/core/SQL/SQLite/update_buffer_muteduntil.sql
@@ -1,0 +1,3 @@
+UPDATE buffer
+SET muteduntil = :muteduntil
+WHERE userid = :userid AND bufferid = :bufferid

--- a/src/core/SQL/SQLite/update_buffer_notificationsetting.sql
+++ b/src/core/SQL/SQLite/update_buffer_notificationsetting.sql
@@ -1,0 +1,3 @@
+UPDATE buffer
+SET notificationsetting = :notificationsetting
+WHERE userid = :userid AND bufferid = :bufferid

--- a/src/core/SQL/SQLite/version/32/upgrade_000_alter_buffer_add_muteduntil.sql
+++ b/src/core/SQL/SQLite/version/32/upgrade_000_alter_buffer_add_muteduntil.sql
@@ -1,0 +1,2 @@
+ALTER TABLE buffer
+ADD COLUMN muteduntil integer NOT NULL DEFAULT 0

--- a/src/core/SQL/SQLite/version/32/upgrade_000_alter_buffer_add_notificationsetting.sql
+++ b/src/core/SQL/SQLite/version/32/upgrade_000_alter_buffer_add_notificationsetting.sql
@@ -1,0 +1,2 @@
+ALTER TABLE buffer
+ADD COLUMN notificationsetting integer NOT NULL DEFAULT 0

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -300,6 +300,8 @@ public:
         qint64 markerlinemsgid;
         int bufferactivity;
         int highlightcount;
+        int notificationSetting;
+        QDateTime mutedUntil;
         QString key;
         bool joined;
         QString cipher;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -42,6 +42,7 @@
 
 #include "authenticator.h"
 #include "bufferinfo.h"
+#include "buffersyncer.h"
 #include "deferredptr.h"
 #include "identserver.h"
 #include "message.h"
@@ -628,6 +629,48 @@ public:
     {
         return instance()->_storage->highlightCount(bufferId, lastSeenMsgId);
     }
+
+    //! Update the notification setting for a Buffer
+    /** This Method is used to make the notification setting of a Buffer persistent
+     *  \note This method is threadsafe.
+     *
+     * \param user                  The Owner of that Buffer
+     * \param bufferId              The buffer id
+     * \param notificationSetting   The notification setting for that buffer
+     */
+    static inline void setNotificationSetting(UserId user, BufferId bufferId, NotificationManager::NotificationSetting notificationSetting)
+    {
+        return instance()->_storage->setNotificationSetting(user, bufferId, notificationSetting);
+    }
+
+    //! Get a Hash of all notification settings
+    /** This Method is called when the Quassel Core is started to restore the notification settings
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of the buffers
+     */
+    static inline QHash<BufferId, NotificationManager::NotificationSetting> notificationSettings(UserId user) { return instance()->_storage->notificationSettings(user); }
+
+    //! Update the muted until state for a Buffer
+    /** This Method is used to make the muted until state of a Buffer persistent
+     *  \note This method is threadsafe.
+     *
+     * \param user          The Owner of that Buffer
+     * \param bufferId      The buffer id
+     * \param mutedUntil    The muted until state for that buffer
+     */
+    static inline void setMutedUntil(UserId user, BufferId bufferId, const QDateTime& mutedUntil)
+    {
+        return instance()->_storage->setMutedUntil(user, bufferId, mutedUntil);
+    }
+
+    //! Get a Hash of all muted until states
+    /** This Method is called when the Quassel Core is started to restore the muted until states
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of the buffers
+     */
+    static inline QHash<BufferId, QDateTime> mutedUntils(UserId user) { return instance()->_storage->mutedUntils(user); }
 
     static inline QDateTime startTime() { return instance()->_startTime; }
     static inline bool isConfigured() { return instance()->_configured; }

--- a/src/core/corebuffersyncer.cpp
+++ b/src/core/corebuffersyncer.cpp
@@ -38,6 +38,8 @@ CoreBufferSyncer::CoreBufferSyncer(CoreSession* parent)
                    Core::bufferMarkerLineMsgIds(parent->user()),
                    Core::bufferActivities(parent->user()),
                    Core::highlightCounts(parent->user()),
+                   Core::notificationSettings(parent->user()),
+                   Core::mutedUntils(parent->user()),
                    parent)
     , _coreSession(parent)
     , _purgeBuffers(false)
@@ -89,10 +91,20 @@ void CoreBufferSyncer::storeDirtyIds()
         Core::setHighlightCount(userId, bufferId, highlightCount(bufferId));
     }
 
+    for (BufferId bufferId : dirtyNotificationSettings) {
+        Core::setNotificationSetting(userId, bufferId, notificationSetting(bufferId));
+    }
+
+    for (BufferId bufferId : dirtyMutedUntil) {
+        Core::setMutedUntil(userId, bufferId, mutedUntil(bufferId));
+    }
+
     dirtyLastSeenBuffers.clear();
     dirtyMarkerLineBuffers.clear();
     dirtyActivities.clear();
     dirtyHighlights.clear();
+    dirtyNotificationSettings.clear();
+    dirtyMutedUntil.clear();
 }
 
 void CoreBufferSyncer::removeBuffer(BufferId bufferId)

--- a/src/core/corebuffersyncer.h
+++ b/src/core/corebuffersyncer.h
@@ -87,6 +87,8 @@ private:
     QSet<BufferId> dirtyMarkerLineBuffers;
     QSet<BufferId> dirtyActivities;
     QSet<BufferId> dirtyHighlights;
+    QSet<BufferId> dirtyNotificationSettings;
+    QSet<BufferId> dirtyMutedUntil;
 
     void purgeBufferIds();
 };

--- a/src/core/corenotificationmanager.cpp
+++ b/src/core/corenotificationmanager.cpp
@@ -1,0 +1,45 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2019 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include "corenotificationmanager.h"
+
+#include "core.h"
+#include "coresession.h"
+
+constexpr auto settingsKey = "CoreNotificationManager";
+
+CoreNotificationManager::CoreNotificationManager(CoreSession* session)
+    : NotificationManager(session)
+    , _coreSession{session}
+{
+    // Load config from database if it exists
+    auto configMap = Core::getUserSetting(session->user(), settingsKey).toMap();
+    if (!configMap.isEmpty())
+        update(configMap);
+    // Otherwise, we just use the defaults initialized in the base class
+
+    // We store our settings whenever they change
+    connect(this, &SyncableObject::updatedRemotely, this, &CoreNotificationManager::save);
+}
+
+void CoreNotificationManager::save()
+{
+    Core::setUserSetting(_coreSession->user(), settingsKey, toVariantMap());
+}

--- a/src/core/corenotificationmanager.h
+++ b/src/core/corenotificationmanager.h
@@ -1,0 +1,49 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2019 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#pragma once
+
+#include "notificationmanager.h"
+
+class CoreSession;
+
+class CoreNotificationManager : public NotificationManager
+{
+    Q_OBJECT
+
+public:
+    explicit CoreNotificationManager(CoreSession* parent);
+
+public slots:
+    inline void requestSetNotificationSettingQuery(int notificationSetting) override {
+        setNotificationSettingQuery(notificationSetting);
+    }
+    inline void requestSetNotificationSettingChannel(int notificationSetting) override {
+        setNotificationSettingChannel(notificationSetting);
+    }
+    inline void requestSetNotificationSettingStatus(int notificationSetting) override {
+        setNotificationSettingStatus(notificationSetting);
+    }
+
+    void save();
+
+private:
+    CoreSession* _coreSession;
+};

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -30,6 +30,7 @@
 #include "corealiasmanager.h"
 #include "corehighlightrulemanager.h"
 #include "coreignorelistmanager.h"
+#include "corenotificationmanager.h"
 #include "coreinfo.h"
 #include "message.h"
 #include "peer.h"
@@ -245,6 +246,7 @@ private:
     CoreNetworkConfig* _networkConfig;
     CoreInfo* _coreInfo;
     CoreTransferManager* _transferManager;
+    CoreNotificationManager* _notificationManager;
 
     EventManager* _eventManager;
     EventStringifier* _eventStringifier;  // should eventually move into client

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -102,6 +102,10 @@ public slots:
     void setHighlightCount(UserId id, BufferId bufferId, int count) override;
     QHash<BufferId, int> highlightCounts(UserId id) override;
     int highlightCount(BufferId bufferId, MsgId lastSeenMsgId) override;
+    void setNotificationSetting(UserId id, BufferId bufferId, NotificationManager::NotificationSetting notificationSetting) override;
+    QHash<BufferId, NotificationManager::NotificationSetting> notificationSettings(UserId id) override;
+    void setMutedUntil(UserId id, BufferId bufferId, QDateTime mutedUntil) override;
+    QHash<BufferId, QDateTime> mutedUntils(UserId id) override;
     QHash<QString, QByteArray> bufferCiphers(UserId user, const NetworkId& networkId) override;
     void setBufferCipher(UserId user, const NetworkId& networkId, const QString& bufferName, const QByteArray& cipher) override;
 

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -103,6 +103,10 @@ public slots:
     void setHighlightCount(UserId id, BufferId bufferId, int count) override;
     QHash<BufferId, int> highlightCounts(UserId id) override;
     int highlightCount(BufferId bufferId, MsgId lastSeenMsgId) override;
+    void setNotificationSetting(UserId id, BufferId bufferId, NotificationManager::NotificationSetting notificationSetting) override;
+    QHash<BufferId, NotificationManager::NotificationSetting> notificationSettings(UserId id) override;
+    void setMutedUntil(UserId id, BufferId bufferId, QDateTime mutedUntil) override;
+    QHash<BufferId, QDateTime> mutedUntils(UserId id) override;
     QHash<QString, QByteArray> bufferCiphers(UserId user, const NetworkId& networkId) override;
     void setBufferCipher(UserId user, const NetworkId& networkId, const QString& bufferName, const QByteArray& cipher) override;
 

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -23,6 +23,7 @@
 
 #include <QtCore>
 
+#include "buffersyncer.h"
 #include "coreidentity.h"
 #include "message.h"
 #include "network.h"
@@ -476,6 +477,42 @@ public slots:
      * \param lastSeenMsgId     The last seen message
      */
     virtual int highlightCount(BufferId bufferId, MsgId lastSeenMsgId) = 0;
+
+    //! Update the notification setting for a Buffer
+    /** This Method is used to make the notification setting of a Buffer persistent
+     *  \note This method is threadsafe.
+     *
+     * \param user                  The Owner of that Buffer
+     * \param bufferId              The buffer id
+     * \param notificationSetting   The notification setting for that buffer
+     */
+    virtual void setNotificationSetting(UserId id, BufferId bufferId, NotificationManager::NotificationSetting notificationSetting) = 0;
+
+    //! Get a Hash of all notification settings
+    /** This Method is called when the Quassel Core is started to restore the notification settings
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of the buffers
+     */
+    virtual QHash<BufferId, NotificationManager::NotificationSetting> notificationSettings(UserId id) = 0;
+
+    //! Update the muted until state for a Buffer
+    /** This Method is used to make the muted until state of a Buffer persistent
+     *  \note This method is threadsafe.
+     *
+     * \param user          The Owner of that Buffer
+     * \param bufferId      The buffer id
+     * \param mutedUntil    The muted until state for that buffer
+     */
+    virtual void setMutedUntil(UserId id, BufferId bufferId, QDateTime mutedUntil) = 0;
+
+    //! Get a Hash of all muted until states
+    /** This Method is called when the Quassel Core is started to restore the muted until states
+     *  \note This method is threadsafe.
+     *
+     * \param user      The Owner of the buffers
+     */
+    virtual QHash<BufferId, QDateTime> mutedUntils(UserId id) = 0;
 
     /* Message handling */
 


### PR DESCRIPTION
## In Short

* allows setting a buffer separately to notify on all/highlighted/no messages, or to use the default for that buffer type
* allows muting a buffer until a certain timestamp
* allows setting a default for queries, channels and status buffers

## TODO
* [ ] Add a utility function to the class to determine if a message should cause a notification or not, to handle this consistently between core and client (for future core-side notifications)
* [ ] Make the Qt client filter notifications based on these settings
* [ ] Add UI to the Qt client to configure notification settings and mute duration

## Impact

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Improves situations where notifications for specific buffers could not be turned off separately |
| Risk | ★☆☆  _1/3_ | Does not touch any critical code |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to a few classes |

## Rationale

Being able to set certain levels of notification settings is a relatively important feature, as users might like to be notified on all messages in a channel without having them highlighted, or might like to mute a chat for a certain time, or disable notifications entirely for a certain bot (e.g. the quite annoying Q bot on Quakenet).

This adds a functionality which is common already in most other chat clients, and is one of the most popular feature requests and support topics in Quasseldroid