### PR TITLE
Allow selecting the core account to connect to from CLI

### DIFF
--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -336,6 +336,7 @@ void Quassel::setupCliParser()
             {"icontheme", tr("Override the system icon theme ('breeze' is recommended)."), tr("theme")},
             {"qss", tr("Load a custom application stylesheet."), tr("file.qss")},
             {"hidewindow", tr("Start the client minimized to the system tray.")},
+            {"account", tr("Account id to connect to on startup."), tr("account"), "0"},
         };
     }
 

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -1195,7 +1195,8 @@ void MainWin::saveMainToolBarStatus(bool enabled)
 
 void MainWin::doAutoConnect()
 {
-    if (!Client::coreConnection()->connectToCore()) {
+    int accountId = Quassel::optionValue("account").toInt();
+    if (!Client::coreConnection()->connectToCore(accountId)) {
         // No autoconnect selected (or no accounts)
         showCoreConnectionDlg();
     }


### PR DESCRIPTION
## In Short

* adds new --account option
* if an account id is specified, connects to that account instead of asking or using any other defaults

## Impact

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Only usable by power users, won’t affect common users at all |
| Risk | ★★☆  _2/3_ | Touches autoconnect code, might break that |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to a few classes |