### PR TITLE
Simplify the time formatting used in formatDateTimeToISO

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -26,6 +26,7 @@
 
 #include <QCoreApplication>
 #include <QDateTime>
+#include <QTimeZone>
 #include <QDebug>
 #include <QTextCodec>
 #include <QVector>
@@ -357,32 +358,7 @@ QString formatDateTimeToOffsetISO(const QDateTime& dateTime)
     // See https://en.wikipedia.org/wiki/ISO_8601#cite_note-32
     // And https://www.ietf.org/rfc/rfc3339.txt
 
-#if 0
     // The expected way to get a UTC offset on ISO 8601 dates
     // Remove the "T" date/time separator
-    return dateTime.toTimeSpec(Qt::OffsetFromUTC).toString(Qt::ISODate).replace(10, 1, " ");
-#else
-    // Work around Qt bug that converts to UTC instead of including timezone information
-    // See https://bugreports.qt.io/browse/QTBUG-26161
-    //
-    // NOTE: Despite the bug report marking as fixed in Qt 5.2.0 (QT_VERSION >= 0x050200), this
-    // still appears broken in Qt 5.5.1.
-    //
-    // Credit to "user362638" for the solution below, modified to fit Quassel's needs
-    // https://stackoverflow.com/questions/18750569/qdatetime-isodate-with-timezone
-
-    // Get the local and UTC time
-    QDateTime local = QDateTime(dateTime);
-    QDateTime utc = local.toUTC();
-    utc.setTimeSpec(Qt::LocalTime);
-
-    // Find the UTC offset
-    int utcOffset = utc.secsTo(local);
-
-    // Force the local time to follow this offset
-    local.setUtcOffset(utcOffset);
-    // Now the output should be correct
-    // Remove the "T" date/time separator
-    return local.toString(Qt::ISODate).replace(10, 1, " ");
-#endif
+    return dateTime.toOffsetFromUtc(dateTime.offsetFromUtc()).toString(Qt::ISODate).replace(10, 1, " ");
 }

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -10,3 +10,5 @@ quassel_add_test(SignalProxyTest
     LIBRARIES
         Quassel::Test::Util
 )
+
+quassel_add_test(UtilTest)

--- a/tests/common/utiltest.cpp
+++ b/tests/common/utiltest.cpp
@@ -1,0 +1,38 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2019 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include "testglobal.h"
+#include "util.h"
+#include <QDebug>
+#include <QDateTime>
+#include <QTimeZone>
+
+TEST(UtilTest, formatDateTimeToOffsetISO) {
+    QDateTime dateTime{{2006, 01, 02}, {15, 04, 05}, QTimeZone{"UTC+01:00"}};
+
+    ASSERT_TRUE(dateTime.isValid());
+    ASSERT_FALSE(dateTime.isNull());
+
+    EXPECT_EQ(formatDateTimeToOffsetISO(dateTime), QString("2006-01-02 15:04:05+01:00"));
+    EXPECT_EQ(formatDateTimeToOffsetISO(dateTime.toUTC()), QString("2006-01-02 14:04:05Z"));
+    EXPECT_EQ(formatDateTimeToOffsetISO(dateTime.toOffsetFromUtc(0)), QString("2006-01-02 14:04:05Z"));
+    EXPECT_EQ(formatDateTimeToOffsetISO(dateTime.toOffsetFromUtc(7200)), QString("2006-01-02 16:04:05+02:00"));
+    EXPECT_EQ(formatDateTimeToOffsetISO(dateTime.toTimeZone(QTimeZone{"UTC"})), QString("2006-01-02 14:04:05Z"));
+}


### PR DESCRIPTION
## In Short

* Previously, a convoluted workaround using deprecated functionality was used to ensure we would format all types of QDateTime objects correctly
* A new workaround has been found which ensures this works reliably without using deprecated functionality

## Impact

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Does not have any noticeable changes, fixes a compiler warning |
| Risk | ★☆☆  _1/3_ | Touches time code, but has unit tests |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to a few classes |

## Rationale
Currently our builds for windows fail because of a compiler warning about using deprecated functionality in our previous workaround for time formatting.  
In the search for a way to fix this, this simpler workaround for the same issue has been found, and works reliably.

To ensure functionality remains the same, a unit test has been included. Please run it on various systems and versions of Qt to guarantee we won’t have any regressions.