### PR TITLE
Fix deprecation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,11 @@ endif()
 
 # The following options are not for end-user consumption, so don't list them in the feature summary
 option(FATAL_WARNINGS "Make compile warnings fatal (most useful for CI builds)" OFF)
+option(WARN_QT_DEPRECATION "Warn about deprecated Qt functionality" OFF)
+if (WARN_QT_DEPRECATION)
+    # Enable Qt deprecation warnings for Qt < 5.13 (on by default in newer versions)
+    add_definitions("-DQT_DEPRECATED_WARNINGS")
+endif()
 cmake_dependent_option(DEPLOY "Add required libs to bundle resources and create a dmg" OFF "APPLE" OFF)
 
 # List of authenticators and the cmake flags to build them

--- a/src/client/buffermodel.cpp
+++ b/src/client/buffermodel.cpp
@@ -138,7 +138,7 @@ void BufferModel::newBuffers(const QModelIndex& parent, int start, int end)
         return;
 
     for (int row = start; row <= end; row++) {
-        QModelIndex child = parent.child(row, 0);
+        QModelIndex child = parent.model()->index(row, 0, parent);
         newBuffer(child.data(NetworkModel::BufferIdRole).value<BufferId>());
     }
 }

--- a/src/client/clientbacklogmanager.cpp
+++ b/src/client/clientbacklogmanager.cpp
@@ -20,6 +20,7 @@
 
 #include "clientbacklogmanager.h"
 
+#include <algorithm>
 #include <ctime>
 
 #include <QDebug>

--- a/src/client/clientbacklogmanager.cpp
+++ b/src/client/clientbacklogmanager.cpp
@@ -164,7 +164,7 @@ void ClientBacklogManager::dispatchMessages(const MessageList& messages, bool so
 
     clock_t start_t = clock();
     if (sort)
-        qSort(msgs);
+        std::sort(msgs.begin(), msgs.end());
     Client::messageProcessor()->process(msgs);
     clock_t end_t = clock();
 

--- a/src/client/messagefilter.cpp
+++ b/src/client/messagefilter.cpp
@@ -115,7 +115,7 @@ QString MessageFilter::idString() const
         return "*";
 
     QList<BufferId> bufferIds = _validBuffers.toList();
-    qSort(bufferIds);
+    std::sort(bufferIds.begin(), bufferIds.end());
 
     QStringList bufferIdStrings;
     foreach (BufferId id, bufferIds)

--- a/src/client/messagemodel.cpp
+++ b/src/client/messagemodel.cpp
@@ -20,6 +20,8 @@
 
 #include "messagemodel.h"
 
+#include <algorithm>
+
 #include <QEvent>
 
 #include "backlogsettings.h"

--- a/src/client/messagemodel.cpp
+++ b/src/client/messagemodel.cpp
@@ -105,13 +105,13 @@ void MessageModel::insertMessages(const QList<Message>& msglist)
             else {
                 _messageBuffer = msglist.mid(processedMsgs);
             }
-            qSort(_messageBuffer);
+            std::sort(_messageBuffer.begin(), _messageBuffer.end());
             QCoreApplication::postEvent(this, new ProcessBufferEvent());
         }
     }
     else {
         _messageBuffer << msglist;
-        qSort(_messageBuffer);
+        std::sort(_messageBuffer.begin(), _messageBuffer.end());
     }
 }
 

--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -1605,7 +1605,7 @@ void NetworkModel::sortBufferIds(QList<BufferId>& bufferIds) const
             bufferItems << _bufferItemCache[bufferId];
     }
 
-    qSort(bufferItems.begin(), bufferItems.end(), bufferItemLessThan);
+    std::sort(bufferItems.begin(), bufferItems.end(), bufferItemLessThan);
 
     bufferIds.clear();
     foreach (BufferItem* bufferItem, bufferItems) {

--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -20,6 +20,7 @@
 
 #include "networkmodel.h"
 
+#include <algorithm>
 #include <utility>
 
 #include <QAbstractItemView>

--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -1520,7 +1520,7 @@ void NetworkModel::checkForRemovedBuffers(const QModelIndex& parent, int start, 
         return;
 
     for (int row = start; row <= end; row++) {
-        _bufferItemCache.remove(parent.child(row, 0).data(BufferIdRole).value<BufferId>());
+        _bufferItemCache.remove(index(row, 0, parent).data(BufferIdRole).value<BufferId>());
     }
 }
 
@@ -1530,7 +1530,7 @@ void NetworkModel::checkForNewBuffers(const QModelIndex& parent, int start, int 
         return;
 
     for (int row = start; row <= end; row++) {
-        QModelIndex child = parent.child(row, 0);
+        QModelIndex child = parent.model()->index(row, 0, parent);
         _bufferItemCache[child.data(BufferIdRole).value<BufferId>()] = static_cast<BufferItem*>(child.internalPointer());
     }
 }

--- a/src/client/treemodel.cpp
+++ b/src/client/treemodel.cpp
@@ -571,7 +571,7 @@ void TreeModel::debug_rowsAboutToBeRemoved(const QModelIndex& parent, int start,
 
     QModelIndex child;
     for (int i = end; i >= start; i--) {
-        child = parent.child(i, 0);
+        child = parent.model()->index(i, 0, parent);
         Q_ASSERT(parentItem->child(i));
         qDebug() << ">>>" << i << child << child.data().toString();
     }
@@ -587,7 +587,7 @@ void TreeModel::debug_rowsInserted(const QModelIndex& parent, int start, int end
 
     QModelIndex child;
     for (int i = start; i <= end; i++) {
-        child = parent.child(i, 0);
+        child = parent.model()->index(i, 0, parent);
         Q_ASSERT(parentItem->child(i));
         qDebug() << "<<<" << i << child << child.data().toString();
     }

--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -384,7 +384,7 @@ bool AbstractSqlStorage::watchQuery(QSqlQuery& query)
             valueStrings << QString("%1=%2").arg(iter.key(), value);
         }
         qCritical() << "                bound Values:" << qPrintable(valueStrings.join(", "));
-        qCritical() << "                Error Number:" << query.lastError().number();
+        qCritical() << "                  Error Code:" << qPrintable(query.lastError().nativeErrorCode());
         qCritical() << "               Error Message:" << qPrintable(query.lastError().text());
         qCritical() << "              Driver Message:" << qPrintable(query.lastError().driverText());
         qCritical() << "                  DB Message:" << qPrintable(query.lastError().databaseText());
@@ -492,7 +492,7 @@ void AbstractSqlMigrator::dumpStatus()
     QList<QVariant> list = boundValues();
     for (int i = 0; i < list.size(); ++i)
         qWarning() << i << ": " << list.at(i).toString().toLatin1().data();
-    qWarning() << "  Error Number:" << lastError().number();
+    qWarning() << "  Error Code:" << qPrintable(lastError().nativeErrorCode());
     qWarning() << "  Error Message:" << lastError().text();
 }
 

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -1536,7 +1536,7 @@ void CoreSessionEventProcessor::handleCtcpClientinfo(CtcpEvent* e)
     QStringList supportedHandlers;
     for (const QString& handler : providesHandlers())
         supportedHandlers << handler.toUpper();
-    qSort(supportedHandlers);
+    std::sort(supportedHandlers.begin(), supportedHandlers.end());
     e->setReply(supportedHandlers.join(" "));
 }
 

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -20,6 +20,8 @@
 
 #include "coresessioneventprocessor.h"
 
+#include <algorithm>
+
 #include "coreirclisthelper.h"
 #include "corenetwork.h"
 #include "coresession.h"

--- a/src/core/oidentdconfiggenerator.cpp
+++ b/src/core/oidentdconfiggenerator.cpp
@@ -44,7 +44,7 @@ OidentdConfigGenerator::~OidentdConfigGenerator()
 
 bool OidentdConfigGenerator::init()
 {
-    _configDir = QDir::homePath();
+    _configDir.setPath(QDir::homePath());
     _configFileName = ".oidentd.conf";
 
     if (Quassel::isOptionSet("oidentd-conffile"))

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -22,6 +22,8 @@
 
 #include <QtSql>
 
+#include <QLatin1String>
+
 #include "network.h"
 #include "quassel.h"
 
@@ -192,7 +194,7 @@ UserId SqliteStorage::addUser(const QString& user, const QString& password, cons
         lockForWrite();
         safeExec(query);
         if (query.lastError().isValid()
-            && query.lastError().nativeErrorCode() == "19") {  // user already exists - sadly 19 seems to be the general constraint violation error...
+            && query.lastError().nativeErrorCode() == QLatin1String{"19"}) {  // user already exists - sadly 19 seems to be the general constraint violation error...
             db.rollback();
         }
         else {
@@ -1409,7 +1411,7 @@ bool SqliteStorage::renameBuffer(const UserId& user, const BufferId& bufferId, c
 
         error = query.lastError().isValid();
         // unexepcted error occured (19 == constraint violation)
-        if (error && query.lastError().nativeErrorCode() != "19") {
+        if (error && query.lastError().nativeErrorCode() != QLatin1String{"19"}) {
             watchQuery(query);
         }
         else {
@@ -1790,7 +1792,7 @@ bool SqliteStorage::logMessage(Message& msg)
 
         if (logMessageQuery.lastError().isValid()) {
             // constraint violation - must be NOT NULL constraint - probably the sender is missing...
-            if (logMessageQuery.lastError().nativeErrorCode() == "19") {
+            if (logMessageQuery.lastError().nativeErrorCode() == QLatin1String{"19"}) {
                 QSqlQuery addSenderQuery(db);
                 addSenderQuery.prepare(queryString("insert_sender"));
                 addSenderQuery.bindValue(":sender", msg.sender());
@@ -2223,7 +2225,7 @@ bool SqliteStorage::safeExec(QSqlQuery& query, int retryCount)
 
     // SQLITE_BUSY         5   /* The database file is locked */
     // SQLITE_LOCKED       6   /* A table in the database is locked */
-    if (nativeErrorCode == "5" || nativeErrorCode == "6") {
+    if (nativeErrorCode == QLatin1String{"5"} || nativeErrorCode == QLatin1String{"6"}) {
         if (retryCount < _maxRetryCount)
             return safeExec(query, retryCount + 1);
     }

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -142,11 +142,12 @@ void ChatItem::initLayoutHelper(QTextLayout* layout, QTextOption::WrapMode wrapM
     option.setAlignment(alignment);
     layout->setTextOption(option);
 
-    QList<QTextLayout::FormatRange> formatRanges = QtUi::style()
-                                                       ->toTextLayoutList(formatList(),
-                                                                          layout->text().length(),
-                                                                          data(ChatLineModel::MsgLabelRole).value<UiStyle::MessageLabel>());
-    layout->setAdditionalFormats(formatRanges);
+    UiStyle::FormatContainer formatRanges = QtUi::style()->toTextLayoutList(
+        formatList(),
+        layout->text().length(),
+        data(ChatLineModel::MsgLabelRole).value<UiStyle::MessageLabel>()
+    );
+    UiStyle::setTextLayoutFormats(*layout, formatRanges);
 }
 
 void ChatItem::initLayout(QTextLayout* layout) const
@@ -347,16 +348,16 @@ QVector<QTextLayout::FormatRange> ChatItem::additionalFormats() const
     }
 
     // Add all formats that have an extra label to the additionalFormats list
-    QList<QTextLayout::FormatRange> additionalFormats;
+    UiStyle::FormatContainer additionalFormats;
     for (size_t i = 0; i < labelFmtList.size() - 1; ++i) {
         if (labelFmtList[i].label != itemLabel) {
             additionalFormats << QtUi::style()->toTextLayoutList({std::make_pair(labelFmtList[i].offset, labelFmtList[i].format)},
-                                                                 labelFmtList[i + 1].offset,
-                                                                 labelFmtList[i].label);
+                                                                   labelFmtList[i + 1].offset,
+                                                                   labelFmtList[i].label);
         }
     }
 
-    return additionalFormats.toVector();
+    return UiStyle::containerToVector(additionalFormats);
 }
 
 bool ChatItem::hasSelection() const

--- a/src/qtui/chatlinemodelitem.cpp
+++ b/src/qtui/chatlinemodelitem.cpp
@@ -200,7 +200,7 @@ void ChatLineModelItem::computeWrapList() const
     option.setWrapMode(QTextOption::NoWrap);
     layout.setTextOption(option);
 
-    layout.setAdditionalFormats(QtUi::style()->toTextLayoutList(_styledMsg.contentsFormatList(), length, messageLabel()));
+    UiStyle::setTextLayoutFormats(layout, QtUi::style()->toTextLayoutList(_styledMsg.contentsFormatList(), length, messageLabel()));
     layout.beginLayout();
     QTextLine line = layout.createLine();
     line.setNumColumns(length);

--- a/src/qtui/chatview.cpp
+++ b/src/qtui/chatview.cpp
@@ -20,6 +20,8 @@
 
 #include "chatview.h"
 
+#include <algorithm>
+
 #include <QGraphicsTextItem>
 #include <QKeyEvent>
 #include <QMenu>

--- a/src/qtui/chatview.cpp
+++ b/src/qtui/chatview.cpp
@@ -292,7 +292,7 @@ QSet<ChatLine*> ChatView::visibleChatLines(Qt::ItemSelectionMode mode) const
 QList<ChatLine*> ChatView::visibleChatLinesSorted(Qt::ItemSelectionMode mode) const
 {
     QList<ChatLine*> result = visibleChatLines(mode).toList();
-    qSort(result.begin(), result.end(), chatLinePtrLessThan);
+    std::sort(result.begin(), result.end(), chatLinePtrLessThan);
     return result;
 }
 

--- a/src/qtui/chatviewsearchcontroller.cpp
+++ b/src/qtui/chatviewsearchcontroller.cpp
@@ -330,7 +330,7 @@ void ChatViewSearchController::repositionHighlights(ChatLine* line)
         }
     }
 
-    qSort(searchHighlights.begin(), searchHighlights.end(), SearchHighlightItem::firstInLine);
+    std::sort(searchHighlights.begin(), searchHighlights.end(), SearchHighlightItem::firstInLine);
 
     Q_ASSERT(wordPos.count() == searchHighlights.count());
     for (int i = 0; i < searchHighlights.count(); i++) {

--- a/src/qtui/chatviewsearchcontroller.cpp
+++ b/src/qtui/chatviewsearchcontroller.cpp
@@ -20,6 +20,8 @@
 
 #include "chatviewsearchcontroller.h"
 
+#include <algorithm>
+
 #include <QAbstractItemModel>
 #include <QPainter>
 

--- a/src/qtui/nicklistwidget.cpp
+++ b/src/qtui/nicklistwidget.cpp
@@ -177,7 +177,7 @@ void NickListWidget::rowsAboutToBeRemoved(const QModelIndex& parent, int start, 
     else {
         // check if there are explicitly buffers removed
         for (int i = start; i <= end; i++) {
-            QVariant variant = parent.child(i, 0).data(NetworkModel::BufferIdRole);
+            QVariant variant = parent.model()->index(i, 0, parent).data(NetworkModel::BufferIdRole);
             if (!variant.isValid())
                 continue;
 

--- a/src/qtui/settingspages/appearancesettingspage.cpp
+++ b/src/qtui/settingspages/appearancesettingspage.cpp
@@ -53,7 +53,7 @@ AppearanceSettingsPage::AppearanceSettingsPage(QWidget* parent)
     initIconThemeComboBox();
 
     foreach (QComboBox* comboBox, findChildren<QComboBox*>()) {
-        connect(comboBox, selectOverload<const QString&>(&QComboBox::currentIndexChanged), this, &AppearanceSettingsPage::widgetHasChanged);
+        connect(comboBox, &QComboBox::currentTextChanged, this, &AppearanceSettingsPage::widgetHasChanged);
     }
     foreach (QCheckBox* checkBox, findChildren<QCheckBox*>()) {
         connect(checkBox, &QAbstractButton::clicked, this, &AppearanceSettingsPage::widgetHasChanged);

--- a/src/qtui/settingspages/bufferviewsettingspage.cpp
+++ b/src/qtui/settingspages/bufferviewsettingspage.cpp
@@ -20,6 +20,7 @@
 
 #include "bufferviewsettingspage.h"
 
+#include <algorithm>
 #include <utility>
 
 #include <QMessageBox>

--- a/src/qtui/settingspages/bufferviewsettingspage.cpp
+++ b/src/qtui/settingspages/bufferviewsettingspage.cpp
@@ -248,7 +248,7 @@ void BufferViewSettingsPage::newBufferView(const QString& bufferViewName)
         }
         else {
             bufferIds = Client::networkModel()->allBufferIds();
-            qSort(bufferIds);
+            std::sort(bufferIds.begin(), bufferIds.end());
             config->setProperty("OriginalBufferList", toVariantList<BufferId>(bufferIds));
         }
     }

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -20,6 +20,8 @@
 
 #include "corehighlightsettingspage.h"
 
+#include <algorithm>
+
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QTableWidget>

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -420,7 +420,7 @@ void CoreHighlightSettingsPage::removeSelectedHighlightRows()
     for (auto selectedItem : selectedItemList) {
         selectedRows.append(selectedItem->row());
     }
-    qSort(selectedRows.begin(), selectedRows.end(), qGreater<int>());
+    std::sort(selectedRows.begin(), selectedRows.end(), std::greater<>());
     int lastRow = -1;
     for (auto row : selectedRows) {
         if (row != lastRow) {
@@ -438,7 +438,7 @@ void CoreHighlightSettingsPage::removeSelectedIgnoredRows()
     for (auto selectedItem : selectedItemList) {
         selectedRows.append(selectedItem->row());
     }
-    qSort(selectedRows.begin(), selectedRows.end(), qGreater<int>());
+    std::sort(selectedRows.begin(), selectedRows.end(), std::greater<>());
     int lastRow = -1;
     for (auto row : selectedRows) {
         if (row != lastRow) {

--- a/src/qtui/settingspages/highlightsettingspage.cpp
+++ b/src/qtui/settingspages/highlightsettingspage.cpp
@@ -197,7 +197,7 @@ void HighlightSettingsPage::removeSelectedRows()
     foreach (QTableWidgetItem* selectedItem, selectedItemList) {
         selectedRows.append(selectedItem->row());
     }
-    qSort(selectedRows.begin(), selectedRows.end(), qGreater<int>());
+    std::sort(selectedRows.begin(), selectedRows.end(), std::greater<>());
     int lastRow = -1;
     foreach (int row, selectedRows) {
         if (row != lastRow) {

--- a/src/qtui/settingspages/highlightsettingspage.cpp
+++ b/src/qtui/settingspages/highlightsettingspage.cpp
@@ -20,6 +20,8 @@
 
 #include "highlightsettingspage.h"
 
+#include <algorithm>
+
 #include <QHeaderView>
 #include <QMessageBox>
 

--- a/src/qtui/settingspages/itemviewsettingspage.cpp
+++ b/src/qtui/settingspages/itemviewsettingspage.cpp
@@ -28,7 +28,6 @@
 
 ItemViewSettingsPage::ItemViewSettingsPage(QWidget* parent)
     : SettingsPage(tr("Interface"), tr("Chat & Nick Lists"), parent)
-    , _mapper(new QSignalMapper(this))
 {
     ui.setupUi(this);
 
@@ -43,11 +42,11 @@ ItemViewSettingsPage::ItemViewSettingsPage(QWidget* parent)
 
     ui.bufferViewPreview->expandAll();
 
-    foreach (ColorButton* button, findChildren<ColorButton*>()) {
-        connect(button, &ColorButton::colorChanged, _mapper, selectOverload<>(&QSignalMapper::map));
-        _mapper->setMapping(button, button);
+    for (ColorButton* button : findChildren<ColorButton*>()) {
+        connect(button, &ColorButton::colorChanged, button, [this, button]() {
+            updateBufferViewPreview(button);
+        });
     }
-    connect(_mapper, selectOverload<QWidget*>(&QSignalMapper::mapped), this, &ItemViewSettingsPage::updateBufferViewPreview);
 
     initAutoWidgets();
 }

--- a/src/qtui/settingspages/itemviewsettingspage.h
+++ b/src/qtui/settingspages/itemviewsettingspage.h
@@ -46,7 +46,6 @@ private slots:
 
 private:
     Ui::ItemViewSettingsPage ui;
-    QSignalMapper* _mapper;
     QTreeWidgetItem *_networkItem, *_defaultBufferItem, *_inactiveBufferItem, *_activeBufferItem, *_unreadBufferItem, *_highlightedBufferItem;
 
     inline QString settingsKey() const override { return QString("ItemViews"); }

--- a/src/uisupport/abstractbuffercontainer.cpp
+++ b/src/uisupport/abstractbuffercontainer.cpp
@@ -47,7 +47,7 @@ void AbstractBufferContainer::rowsAboutToBeRemoved(const QModelIndex& parent, in
     else {
         // check if there are explicitly buffers removed
         for (int i = start; i <= end; i++) {
-            QVariant variant = parent.child(i, 0).data(NetworkModel::BufferIdRole);
+            QVariant variant = parent.model()->index(i, 0, parent).data(NetworkModel::BufferIdRole);
             if (!variant.isValid())
                 continue;
 

--- a/src/uisupport/bufferview.cpp
+++ b/src/uisupport/bufferview.cpp
@@ -494,13 +494,13 @@ void BufferView::changeBuffer(Direction direction)
             if (currentIndex.row() == 0)
                 newParent = lastNetIndex;
             if (model()->hasChildren(newParent))
-                resultingIndex = newParent.child(model()->rowCount(newParent) - 1, 0);
+                resultingIndex = newParent.model()->index(model()->rowCount(newParent) - 1, 0, newParent);
             else
                 resultingIndex = newParent;
         }
         else {
             if (model()->hasChildren(currentIndex))
-                resultingIndex = currentIndex.child(0, 0);
+                resultingIndex = currentIndex.model()->index(0, 0, currentIndex);
             else
                 resultingIndex = currentIndex.sibling(currentIndex.row() + 1, 0);
         }
@@ -510,7 +510,7 @@ void BufferView::changeBuffer(Direction direction)
         if (direction == Forward)
             resultingIndex = model()->index(0, 0, QModelIndex());
         else
-            resultingIndex = lastNetIndex.child(model()->rowCount(lastNetIndex) - 1, 0);
+            resultingIndex = lastNetIndex.model()->index(model()->rowCount(lastNetIndex) - 1, 0, lastNetIndex);
     }
 
     selectionModel()->setCurrentIndex(resultingIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);

--- a/src/uisupport/nickviewfilter.cpp
+++ b/src/uisupport/nickviewfilter.cpp
@@ -44,7 +44,7 @@ bool NickViewFilter::filterAcceptsRow(int source_row, const QModelIndex& source_
     if (!source_parent.isValid())
         return true;
 
-    QModelIndex source_child = source_parent.child(source_row, 0);
+    QModelIndex source_child = source_parent.model()->index(source_row, 0, source_parent);
     return (sourceModel()->data(source_child, NetworkModel::BufferIdRole).value<BufferId>() == _bufferId);
 }
 

--- a/src/uisupport/styledlabel.cpp
+++ b/src/uisupport/styledlabel.cpp
@@ -110,10 +110,8 @@ void StyledLabel::updateSizeHint()
 
 void StyledLabel::setText(const QString& text)
 {
-    UiStyle* style = GraphicalUi::uiStyle();
-
-    UiStyle::StyledString sstr = style->styleString(style->mircToInternal(text), UiStyle::FormatType::PlainMsg);
-    QList<QTextLayout::FormatRange> layoutList = style->toTextLayoutList(sstr.formatList, sstr.plainText.length(), UiStyle::MessageLabel::None);
+    UiStyle::StyledString sstr = UiStyle::styleString(UiStyle::mircToInternal(text), UiStyle::FormatType::PlainMsg);
+    UiStyle::FormatContainer layoutList = GraphicalUi::uiStyle()->toTextLayoutList(sstr.formatList, sstr.plainText.length(), UiStyle::MessageLabel::None);
 
     // Use default font rather than the style's
     QTextLayout::FormatRange fmtRange;
@@ -135,7 +133,7 @@ void StyledLabel::setText(const QString& text)
     }
 
     _layout.setText(sstr.plainText);
-    _layout.setAdditionalFormats(layoutList);
+    UiStyle::setTextLayoutFormats(_layout, layoutList);
 
     layout();
 

--- a/src/uisupport/uistyle.cpp
+++ b/src/uisupport/uistyle.cpp
@@ -583,9 +583,9 @@ QString UiStyle::formatCode(FormatType ftype)
     return _formatCodes.key(ftype);
 }
 
-QList<QTextLayout::FormatRange> UiStyle::toTextLayoutList(const FormatList& formatList, int textLength, MessageLabel messageLabel) const
+UiStyle::FormatContainer UiStyle::toTextLayoutList(const FormatList& formatList, int textLength, MessageLabel messageLabel) const
 {
-    QList<QTextLayout::FormatRange> formatRanges;
+    UiStyle::FormatContainer formatRanges;
     QTextLayout::FormatRange range;
     size_t i = 0;
     for (i = 0; i < formatList.size(); i++) {

--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -49,6 +49,28 @@ public:
     UiStyle(QObject* parent = nullptr);
     ~UiStyle() override;
 
+// For backwards compatibility with Qt 5.5, the setFormats method was introduced
+// in Qt 5.6, but the old setAdditionalFormats was deprecated in 5.6 as well.
+//
+// So we use the old one on Qt 5.5, and the new one everywhere else.
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    using FormatContainer = QVector<QTextLayout::FormatRange>;
+    static inline void setTextLayoutFormats(QTextLayout& layout, const FormatContainer& formats) {
+        layout.setFormats(formats);
+    }
+    static inline QVector<QTextLayout::FormatRange> containerToVector(const FormatContainer& container) {
+        return container;
+    }
+#else
+    using FormatContainer = QList<QTextLayout::FormatRange>;
+    static inline void setTextLayoutFormats(QTextLayout& layout, const FormatContainer& formats) {
+        layout.setAdditionalFormats(formats);
+    }
+    static inline QVector<QTextLayout::FormatRange> containerToVector(const FormatContainer& container) {
+        return container.toVector();
+    }
+#endif
+
     //! This enumerates the possible formats a text element may have. */
     /** These formats are ordered on increasing importance, in cases where a given property is specified
      *  by multiple active formats.
@@ -275,7 +297,7 @@ public:
     QTextCharFormat format(const Format& format, MessageLabel messageLabel) const;
     QFontMetricsF* fontMetrics(FormatType formatType, MessageLabel messageLabel) const;
 
-    QList<QTextLayout::FormatRange> toTextLayoutList(const FormatList&, int textLength, MessageLabel messageLabel) const;
+    FormatContainer toTextLayoutList(const FormatList&, int textLength, MessageLabel messageLabel) const;
 
     inline const QBrush& brush(ColorRole role) const { return _uiStylePalette.at((int)role); }
     inline void setBrush(ColorRole role, const QBrush& brush) { _uiStylePalette[(int)role] = brush; }


### PR DESCRIPTION
## In Short

* removes and updates lots of outdated and deprecated code
* fixes compiler warnings on Qt 5.13

## Impact

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Makes code more robust for future Qt versions |
| Risk | ★☆☆  _1/3_ | Code is not functionally different in any way |
| Intrusiveness | ★★★  _3/3_ | Changes throughout the whole codebase |

## Rationale

Our builds on Qt 5.13, as used on AppVeyor, fail currently entirely, leading to unreliable CI results. Additionally, using long-deprecated code is advised against.

This PR removes and replaces all deprecated code, making the codebase more robust for the future, as well as fixing compiler warnings