### PR TITLE
Identd bugfixes and improvements

### DIFF
--- a/src/core/identserver.h
+++ b/src/core/identserver.h
@@ -35,6 +35,7 @@ struct Request
 {
     QPointer<QTcpSocket> socket;
     uint16_t localPort;
+    uint16_t remotePort;
     QString query;
     qint64 transactionId;
     qint64 requestId;
@@ -43,6 +44,8 @@ struct Request
 
     void respondSuccess(const QString& user);
     void respondError(const QString& error);
+
+    const static int DISCONNECTION_TIMEOUT = 500;
 };
 
 class IdentServer : public QObject


### PR DESCRIPTION
## In Short
* Adds debug output for identd
* Improves compatibility and performance, cleans up identd response code
* Improves compatibility with certain networks

## Impact

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Fixes identd on few smaller networks |
| Risk | ★☆☆  _1/3_ | Only affects edge cases where other software misinterprets the standard |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to a few classes |

## Rationale

Currently, our internal identd fails *sometimes* when connecting to irc.darkscience.net. This has been fixed by giving the other side some time to handle the response before closing the socket, which previously caused issues with outdated IRCds on FreeBSD.

We didn’t entirely implement the spec strictly with this solution as many other projects only base their implementations on the examples, not the spec, which are both incompatible.