### PR TITLE
cmake: Don't needlessly sync translations

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -51,14 +51,14 @@ if (TARGET Qt5::lconvert)
             COMMAND $<TARGET_FILE:Qt5::lupdate> -silent ${CMAKE_SOURCE_DIR}/src -ts ${tsfiles}
             COMMAND ${CMAKE_COMMAND} -E touch tsfiles.done
             DEPENDS ${tsfiles}
-            OUTPUT tsfiles.depends
+            OUTPUT tsfiles.done
         )
 
         # Generate the final translation files (.qm) for use by Qt
         add_custom_command(VERBATIM
             COMMENT "Compressing translations"
             COMMAND $<TARGET_FILE:Qt5::lrelease> -silent ${tsfiles}
-            DEPENDS tsfiles.depends
+            DEPENDS tsfiles.done
             OUTPUT ${qmfiles}
         )
 


### PR DESCRIPTION
A mismatch in the stamp file name for syncing translations caused
the sync to be run for every make. Fix the naming so we don't
re-run the syncing needlessly.