### PR TITLE
Assorted cleanups and modernization

### DIFF
--- a/src/common/dccconfig.cpp
+++ b/src/common/dccconfig.cpp
@@ -37,22 +37,6 @@ DccConfig::DccConfig(QObject* parent)
     setAllowClientUpdates(true);
 }
 
-DccConfig& DccConfig::operator=(const DccConfig& other)
-{
-    if (this == &other)
-        return *this;
-
-    SyncableObject::operator=(other);
-
-    static auto propCount = staticMetaObject.propertyCount();
-    for (int i = 0; i < propCount; ++i) {
-        auto propName = staticMetaObject.property(i).name();
-        setProperty(propName, other.property(propName));
-    }
-
-    return *this;
-}
-
 bool DccConfig::operator==(const DccConfig& other)
 {
     // NOTE: We don't compare the SyncableObject attributes (isInitialized, clientUpdatesAllowed())

--- a/src/common/dccconfig.h
+++ b/src/common/dccconfig.h
@@ -89,16 +89,6 @@ public:
     DccConfig(QObject* parent = nullptr);
 
     /**
-     * Assignment operator.
-     *
-     * @note Only assigns properties relevant for config management!
-     *
-     * @param[in] other Right-hand side instance
-     * @returns The updated instance
-     */
-    DccConfig& operator=(const DccConfig& other);
-
-    /**
      * Equality operator.
      *
      * @note Only compares properties relevant for config management!

--- a/src/common/ignorelistmanager.cpp
+++ b/src/common/ignorelistmanager.cpp
@@ -22,7 +22,6 @@
 
 #include <QDebug>
 #include <QStringList>
-#include <QtCore>
 
 IgnoreListManager& IgnoreListManager::operator=(const IgnoreListManager& other)
 {

--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -183,13 +183,13 @@ QString AbstractSqlStorage::queryString(const QString& queryName, int version)
     return query.trimmed();
 }
 
-QList<AbstractSqlStorage::SqlQueryResource> AbstractSqlStorage::setupQueries()
+std::vector<AbstractSqlStorage::SqlQueryResource> AbstractSqlStorage::setupQueries()
 {
-    QList<SqlQueryResource> queries;
+    std::vector<SqlQueryResource> queries;
     // The current schema is stored in the root folder, including setup scripts.
     QDir dir = QDir(QString(":/SQL/%1/").arg(displayName()));
     foreach (QFileInfo fileInfo, dir.entryInfoList(QStringList() << "setup*", QDir::NoFilter, QDir::Name)) {
-        queries << SqlQueryResource(queryString(fileInfo.baseName()), fileInfo.baseName());
+        queries.emplace_back(queryString(fileInfo.baseName()), fileInfo.baseName());
     }
     return queries;
 }
@@ -221,13 +221,13 @@ bool AbstractSqlStorage::setup(const QVariantMap& settings, const QProcessEnviro
     return success;
 }
 
-QList<AbstractSqlStorage::SqlQueryResource> AbstractSqlStorage::upgradeQueries(int version)
+std::vector<AbstractSqlStorage::SqlQueryResource> AbstractSqlStorage::upgradeQueries(int version)
 {
-    QList<SqlQueryResource> queries;
+    std::vector<SqlQueryResource> queries;
     // Upgrade queries are stored in the 'version/##' subfolders.
     QDir dir = QDir(QString(":/SQL/%1/version/%2/").arg(displayName()).arg(version));
     foreach (QFileInfo fileInfo, dir.entryInfoList(QStringList() << "upgrade*", QDir::NoFilter, QDir::Name)) {
-        queries << SqlQueryResource(queryString(fileInfo.baseName(), version), fileInfo.baseName());
+        queries.emplace_back(queryString(fileInfo.baseName(), version), fileInfo.baseName());
     }
     return queries;
 }

--- a/src/core/abstractsqlstorage.cpp
+++ b/src/core/abstractsqlstorage.cpp
@@ -20,11 +20,14 @@
 
 #include "abstractsqlstorage.h"
 
+#include <QDir>
+#include <QFileInfo>
 #include <QMutexLocker>
 #include <QSqlDriver>
 #include <QSqlError>
 #include <QSqlField>
 #include <QSqlQuery>
+#include <QThread>
 
 #include "quassel.h"
 

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <QHash>
 #include <QMutex>
@@ -95,7 +96,7 @@ protected:
      *
      * @return List of SQL query strings and filenames
      */
-    QList<SqlQueryResource> setupQueries();
+    std::vector<SqlQueryResource> setupQueries();
 
     /**
      * Gets the collection of SQL upgrade queries and filenames for a given schema version
@@ -103,7 +104,7 @@ protected:
      * @param ver  SQL schema version
      * @return List of SQL query strings and filenames
      */
-    QList<SqlQueryResource> upgradeQueries(int ver);
+    std::vector<SqlQueryResource> upgradeQueries(int ver);
     bool upgradeDb();
 
     bool watchQuery(QSqlQuery& query);

--- a/src/core/abstractsqlstorage.h
+++ b/src/core/abstractsqlstorage.h
@@ -22,12 +22,15 @@
 
 #include <memory>
 
-#include <QList>
+#include <QHash>
+#include <QMutex>
 #include <QSqlDatabase>
 #include <QSqlError>
 #include <QSqlQuery>
 
 #include "storage.h"
+
+class QThread;
 
 class AbstractSqlMigrationReader;
 class AbstractSqlMigrationWriter;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -194,7 +194,7 @@ public:
 
     static void removeIdentity(UserId user, IdentityId identityId) { instance()->_storage->removeIdentity(user, identityId); }
 
-    static QList<CoreIdentity> identities(UserId user) { return instance()->_storage->identities(user); }
+    static std::vector<CoreIdentity> identities(UserId user) { return instance()->_storage->identities(user); }
 
     //! Create a Network in the Storage and store it's Id in the given NetworkInfo
     /** \note This method is thredsafe.
@@ -230,9 +230,9 @@ public:
     /** \note This method is thredsafe.
      *
      *  \param user        The core user
-     *  \return QList<NetworkInfo>.
+     *  \return std::vector<NetworkInfo>.
      */
-    static inline QList<NetworkInfo> networks(UserId user) { return instance()->_storage->networks(user); }
+    static inline std::vector<NetworkInfo> networks(UserId user) { return instance()->_storage->networks(user); }
 
     //! Get a list of Networks to restore
     /** Return a list of networks the user was connected at the time of core shutdown
@@ -240,7 +240,7 @@ public:
      *
      *  \param user  The User Id in question
      */
-    static inline QList<NetworkId> connectedNetworks(UserId user) { return instance()->_storage->connectedNetworks(user); }
+    static inline std::vector<NetworkId> connectedNetworks(UserId user) { return instance()->_storage->connectedNetworks(user); }
 
     //! Update the connected state of a network
     /** \note This method is threadsafe
@@ -407,7 +407,7 @@ public:
      *  \param limit    if != -1 limit the returned list to a max of \limit entries
      *  \return The requested list of messages
      */
-    static inline QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1)
+    static inline std::vector<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1)
     {
         return instance()->_storage->requestMsgs(user, bufferId, first, last, limit);
     }
@@ -420,7 +420,7 @@ public:
      *  \param type     The Message::Types that should be returned
      *  \return The requested list of messages
      */
-    static inline QList<Message> requestMsgsFiltered(UserId user,
+    static inline std::vector<Message> requestMsgsFiltered(UserId user,
                                                      BufferId bufferId,
                                                      MsgId first = -1,
                                                      MsgId last = -1,
@@ -437,7 +437,7 @@ public:
      *  \param limit    Max amount of messages
      *  \return The requested list of messages
      */
-    static inline QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1)
+    static inline std::vector<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1)
     {
         return instance()->_storage->requestAllMsgs(user, first, last, limit);
     }
@@ -449,7 +449,7 @@ public:
      *  \param type     The Message::Types that should be returned
      *  \return The requested list of messages
      */
-    static inline QList<Message> requestAllMsgsFiltered(UserId user,
+    static inline std::vector<Message> requestAllMsgsFiltered(UserId user,
                                                         MsgId first = -1,
                                                         MsgId last = -1,
                                                         int limit = -1,
@@ -466,7 +466,7 @@ public:
      *  \param user  The user whose buffers we request
      *  \return A list of the BufferInfos for all buffers as requested
      */
-    static inline QList<BufferInfo> requestBuffers(UserId user) { return instance()->_storage->requestBuffers(user); }
+    static inline std::vector<BufferInfo> requestBuffers(UserId user) { return instance()->_storage->requestBuffers(user); }
 
     //! Request a list of BufferIds for a given NetworkId
     /** \note This method is threadsafe.
@@ -475,7 +475,7 @@ public:
      *  \param networkId  The NetworkId of the network in question
      *  \return List of BufferIds belonging to the Network
      */
-    static inline QList<BufferId> requestBufferIdsForNetwork(UserId user, NetworkId networkId)
+    static inline std::vector<BufferId> requestBufferIdsForNetwork(UserId user, NetworkId networkId)
     {
         return instance()->_storage->requestBufferIdsForNetwork(user, networkId);
     }

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -20,6 +20,8 @@
 
 #include "coreauthhandler.h"
 
+#include <QtEndian>
+
 #ifdef HAVE_SSL
 #    include <QSslSocket>
 #endif

--- a/src/core/coreidentity.cpp
+++ b/src/core/coreidentity.cpp
@@ -25,7 +25,7 @@
 CoreIdentity::CoreIdentity(IdentityId id, QObject* parent)
     : Identity(id, parent)
 #ifdef HAVE_SSL
-    , _certManager(*this)
+    , _certManager(this)
 #endif
 {
 #ifdef HAVE_SSL
@@ -37,7 +37,7 @@ CoreIdentity::CoreIdentity(IdentityId id, QObject* parent)
 CoreIdentity::CoreIdentity(const Identity& other, QObject* parent)
     : Identity(other, parent)
 #ifdef HAVE_SSL
-    , _certManager(*this)
+    , _certManager(this)
 #endif
 {
 #ifdef HAVE_SSL
@@ -51,7 +51,7 @@ CoreIdentity::CoreIdentity(const CoreIdentity& other, QObject* parent)
 #ifdef HAVE_SSL
     , _sslKey(other._sslKey)
     , _sslCert(other._sslCert)
-    , _certManager(*this)
+    , _certManager(this)
 #endif
 {
 #ifdef HAVE_SSL
@@ -91,9 +91,9 @@ void CoreIdentity::setSslCert(const QByteArray& encoded)
 //  CoreCertManager
 // ========================================
 
-CoreCertManager::CoreCertManager(CoreIdentity& identity)
-    : CertManager(identity.id())
-    , identity(identity)
+CoreCertManager::CoreCertManager(CoreIdentity* identity)
+    : CertManager(identity->id())
+    , _identity(identity)
 {
     setAllowClientUpdates(true);
 }
@@ -105,13 +105,13 @@ void CoreCertManager::setId(IdentityId id)
 
 void CoreCertManager::setSslKey(const QByteArray& encoded)
 {
-    identity.setSslKey(encoded);
+    _identity->setSslKey(encoded);
     CertManager::setSslKey(encoded);
 }
 
 void CoreCertManager::setSslCert(const QByteArray& encoded)
 {
-    identity.setSslCert(encoded);
+    _identity->setSslCert(encoded);
     CertManager::setSslCert(encoded);
 }
 

--- a/src/core/coreidentity.cpp
+++ b/src/core/coreidentity.cpp
@@ -86,16 +86,6 @@ void CoreIdentity::setSslCert(const QByteArray& encoded)
 
 #endif
 
-CoreIdentity& CoreIdentity::operator=(const CoreIdentity& identity)
-{
-    Identity::operator=(identity);
-#ifdef HAVE_SSL
-    _sslKey = identity._sslKey;
-    _sslCert = identity._sslCert;
-#endif
-    return *this;
-}
-
 #ifdef HAVE_SSL
 // ========================================
 //  CoreCertManager

--- a/src/core/coreidentity.h
+++ b/src/core/coreidentity.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "core-export.h"
+
 #include "identity.h"
 
 #ifdef HAVE_SSL
@@ -34,12 +36,12 @@ class SignalProxy;
 // ========================================
 #ifdef HAVE_SSL
 class CoreIdentity;
-class CoreCertManager : public CertManager
+class CORE_EXPORT CoreCertManager : public CertManager
 {
     Q_OBJECT
 
 public:
-    CoreCertManager(CoreIdentity& identity);
+    CoreCertManager(CoreIdentity* identity);
 
 #    ifdef HAVE_SSL
     const QSslKey& sslKey() const override;
@@ -53,7 +55,7 @@ public slots:
     void setId(IdentityId id);
 
 private:
-    CoreIdentity& identity;
+    CoreIdentity* _identity{nullptr};
 };
 
 #endif  // HAVE_SSL
@@ -61,7 +63,7 @@ private:
 // =========================================
 //  CoreIdentity
 // =========================================
-class CoreIdentity : public Identity
+class CORE_EXPORT CoreIdentity : public Identity
 {
     Q_OBJECT
 
@@ -93,12 +95,12 @@ private:
 #ifdef HAVE_SSL
 inline const QSslKey& CoreCertManager::sslKey() const
 {
-    return identity.sslKey();
+    return _identity->sslKey();
 }
 
 inline const QSslCertificate& CoreCertManager::sslCert() const
 {
-    return identity.sslCert();
+    return _identity->sslCert();
 }
 
 #endif

--- a/src/core/coreidentity.h
+++ b/src/core/coreidentity.h
@@ -81,8 +81,6 @@ public:
     void setSslCert(const QByteArray& encoded);
 #endif /* HAVE_SSL */
 
-    CoreIdentity& operator=(const CoreIdentity& identity);
-
 private:
 #ifdef HAVE_SSL
     QSslKey _sslKey;

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -22,6 +22,7 @@
 
 #include <QDebug>
 #include <QHostInfo>
+#include <QTextBoundaryFinder>
 
 #include "core.h"
 #include "coreidentity.h"

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <utility>
+#include <vector>
 
 #include <QHash>
 #include <QSet>
@@ -65,7 +66,7 @@ class CoreSession : public QObject
 public:
     CoreSession(UserId, bool restoreState, bool strictIdentEnabled, QObject* parent = nullptr);
 
-    QList<BufferInfo> buffers() const;
+    std::vector<BufferInfo> buffers() const;
     inline UserId user() const { return _user; }
     CoreNetwork* network(NetworkId) const;
     CoreIdentity* identity(IdentityId) const;

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -20,7 +20,10 @@
 
 #include "postgresqlstorage.h"
 
-#include <QtSql>
+#include <QByteArray>
+#include <QDataStream>
+#include <QSqlDriver>
+#include <QSqlField>
 
 #include "network.h"
 #include "quassel.h"

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -63,14 +63,14 @@ public slots:
     IdentityId createIdentity(UserId user, CoreIdentity& identity) override;
     bool updateIdentity(UserId user, const CoreIdentity& identity) override;
     void removeIdentity(UserId user, IdentityId identityId) override;
-    QList<CoreIdentity> identities(UserId user) override;
+    std::vector<CoreIdentity> identities(UserId user) override;
 
     /* Network handling */
     NetworkId createNetwork(UserId user, const NetworkInfo& info) override;
     bool updateNetwork(UserId user, const NetworkInfo& info) override;
     bool removeNetwork(UserId user, const NetworkId& networkId) override;
-    QList<NetworkInfo> networks(UserId user) override;
-    QList<NetworkId> connectedNetworks(UserId user) override;
+    std::vector<NetworkInfo> networks(UserId user) override;
+    std::vector<NetworkId> connectedNetworks(UserId user) override;
     void setNetworkConnected(UserId user, const NetworkId& networkId, bool isConnected) override;
 
     /* persistent channels */
@@ -87,8 +87,8 @@ public slots:
     /* Buffer handling */
     BufferInfo bufferInfo(UserId user, const NetworkId& networkId, BufferInfo::Type type, const QString& buffer = "", bool create = true) override;
     BufferInfo getBufferInfo(UserId user, const BufferId& bufferId) override;
-    QList<BufferInfo> requestBuffers(UserId user) override;
-    QList<BufferId> requestBufferIdsForNetwork(UserId user, NetworkId networkId) override;
+    std::vector<BufferInfo> requestBuffers(UserId user) override;
+    std::vector<BufferId> requestBufferIdsForNetwork(UserId user, NetworkId networkId) override;
     bool removeBuffer(const UserId& user, const BufferId& bufferId) override;
     bool renameBuffer(const UserId& user, const BufferId& bufferId, const QString& newName) override;
     bool mergeBuffersPermanently(const UserId& user, const BufferId& bufferId1, const BufferId& bufferId2) override;
@@ -108,21 +108,21 @@ public slots:
     /* Message handling */
     bool logMessage(Message& msg) override;
     bool logMessages(MessageList& msgs) override;
-    QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) override;
-    QList<Message> requestMsgsFiltered(UserId user,
-                                       BufferId bufferId,
-                                       MsgId first = -1,
-                                       MsgId last = -1,
-                                       int limit = -1,
-                                       Message::Types type = Message::Types{-1},
-                                       Message::Flags flags = Message::Flags{-1}) override;
-    QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
-    QList<Message> requestAllMsgsFiltered(UserId user,
-                                          MsgId first = -1,
-                                          MsgId last = -1,
-                                          int limit = -1,
-                                          Message::Types type = Message::Types{-1},
-                                          Message::Flags flags = Message::Flags{-1}) override;
+    std::vector<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) override;
+    std::vector<Message> requestMsgsFiltered(UserId user,
+                                             BufferId bufferId,
+                                             MsgId first = -1,
+                                             MsgId last = -1,
+                                             int limit = -1,
+                                             Message::Types type = Message::Types{-1},
+                                             Message::Flags flags = Message::Flags{-1}) override;
+    std::vector<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
+    std::vector<Message> requestAllMsgsFiltered(UserId user,
+                                                MsgId first = -1,
+                                                MsgId last = -1,
+                                                int limit = -1,
+                                                Message::Types type = Message::Types{-1},
+                                                Message::Flags flags = Message::Flags{-1}) override;
 
     /* Sysident handling */
     QMap<UserId, QString> getAllAuthUserNames() override;

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -20,9 +20,10 @@
 
 #include "sqlitestorage.h"
 
-#include <QtSql>
-
+#include <QByteArray>
+#include <QDataStream>
 #include <QLatin1String>
+#include <QVariant>
 
 #include "network.h"
 #include "quassel.h"

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#include <memory>
+
+#include <QReadWriteLock>
 #include <QSqlDatabase>
 
 #include "abstractsqlstorage.h"

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -67,14 +67,14 @@ public slots:
     IdentityId createIdentity(UserId user, CoreIdentity& identity) override;
     bool updateIdentity(UserId user, const CoreIdentity& identity) override;
     void removeIdentity(UserId user, IdentityId identityId) override;
-    QList<CoreIdentity> identities(UserId user) override;
+    std::vector<CoreIdentity> identities(UserId user) override;
 
     /* Network handling */
     NetworkId createNetwork(UserId user, const NetworkInfo& info) override;
     bool updateNetwork(UserId user, const NetworkInfo& info) override;
     bool removeNetwork(UserId user, const NetworkId& networkId) override;
-    QList<NetworkInfo> networks(UserId user) override;
-    QList<NetworkId> connectedNetworks(UserId user) override;
+    std::vector<NetworkInfo> networks(UserId user) override;
+    std::vector<NetworkId> connectedNetworks(UserId user) override;
     void setNetworkConnected(UserId user, const NetworkId& networkId, bool isConnected) override;
 
     /* persistent channels */
@@ -91,8 +91,8 @@ public slots:
     /* Buffer handling */
     BufferInfo bufferInfo(UserId user, const NetworkId& networkId, BufferInfo::Type type, const QString& buffer = "", bool create = true) override;
     BufferInfo getBufferInfo(UserId user, const BufferId& bufferId) override;
-    QList<BufferInfo> requestBuffers(UserId user) override;
-    QList<BufferId> requestBufferIdsForNetwork(UserId user, NetworkId networkId) override;
+    std::vector<BufferInfo> requestBuffers(UserId user) override;
+    std::vector<BufferId> requestBufferIdsForNetwork(UserId user, NetworkId networkId) override;
     bool removeBuffer(const UserId& user, const BufferId& bufferId) override;
     bool renameBuffer(const UserId& user, const BufferId& bufferId, const QString& newName) override;
     bool mergeBuffersPermanently(const UserId& user, const BufferId& bufferId1, const BufferId& bufferId2) override;
@@ -112,21 +112,21 @@ public slots:
     /* Message handling */
     bool logMessage(Message& msg) override;
     bool logMessages(MessageList& msgs) override;
-    QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) override;
-    QList<Message> requestMsgsFiltered(UserId user,
-                                       BufferId bufferId,
-                                       MsgId first = -1,
-                                       MsgId last = -1,
-                                       int limit = -1,
-                                       Message::Types type = Message::Types{-1},
-                                       Message::Flags flags = Message::Flags{-1}) override;
-    QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
-    QList<Message> requestAllMsgsFiltered(UserId user,
-                                          MsgId first = -1,
-                                          MsgId last = -1,
-                                          int limit = -1,
-                                          Message::Types type = Message::Types{-1},
-                                          Message::Flags flags = Message::Flags{-1}) override;
+    std::vector<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) override;
+    std::vector<Message> requestMsgsFiltered(UserId user,
+                                             BufferId bufferId,
+                                             MsgId first = -1,
+                                             MsgId last = -1,
+                                             int limit = -1,
+                                             Message::Types type = Message::Types{-1},
+                                             Message::Flags flags = Message::Flags{-1}) override;
+    std::vector<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) override;
+    std::vector<Message> requestAllMsgsFiltered(UserId user,
+                                                MsgId first = -1,
+                                                MsgId last = -1,
+                                                int limit = -1,
+                                                Message::Types type = Message::Types{-1},
+                                                Message::Flags flags = Message::Flags{-1}) override;
 
     /* Sysident handling */
     QMap<UserId, QString> getAllAuthUserNames() override;

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -20,7 +20,8 @@
 
 #pragma once
 
-#include <QList>
+#include <vector>
+
 #include <QMap>
 #include <QObject>
 #include <QProcessEnvironment>
@@ -199,7 +200,7 @@ public slots:
     virtual IdentityId createIdentity(UserId user, CoreIdentity& identity) = 0;
     virtual bool updateIdentity(UserId user, const CoreIdentity& identity) = 0;
     virtual void removeIdentity(UserId user, IdentityId identityId) = 0;
-    virtual QList<CoreIdentity> identities(UserId user) = 0;
+    virtual std::vector<CoreIdentity> identities(UserId user) = 0;
 
     /* Network handling */
 
@@ -233,7 +234,7 @@ public slots:
      *  \param user        The core user
      *  \return QList<NetworkInfo>.
      */
-    virtual QList<NetworkInfo> networks(UserId user) = 0;
+    virtual std::vector<NetworkInfo> networks(UserId user) = 0;
 
     //! Get a list of Networks to restore
     /** Return a list of networks the user was connected at the time of core shutdown
@@ -241,7 +242,7 @@ public slots:
      *
      *  \param user  The User Id in question
      */
-    virtual QList<NetworkId> connectedNetworks(UserId user) = 0;
+    virtual std::vector<NetworkId> connectedNetworks(UserId user) = 0;
 
     //! Update the connected state of a network
     /** \note This method is threadsafe
@@ -340,7 +341,7 @@ public slots:
      *  \param user  The user whose buffers we request
      *  \return A list of the BufferInfos for all buffers as requested
      */
-    virtual QList<BufferInfo> requestBuffers(UserId user) = 0;
+    virtual std::vector<BufferInfo> requestBuffers(UserId user) = 0;
 
     //! Request a list of BufferIds for a given NetworkId
     /** \note This method is threadsafe.
@@ -349,7 +350,7 @@ public slots:
      *  \param networkId  The NetworkId of the network in question
      *  \return List of BufferIds belonging to the Network
      */
-    virtual QList<BufferId> requestBufferIdsForNetwork(UserId user, NetworkId networkId) = 0;
+    virtual std::vector<BufferId> requestBufferIdsForNetwork(UserId user, NetworkId networkId) = 0;
 
     //! Remove permanently a buffer and it's content from the storage backend
     /** This call cannot be reverted!
@@ -503,7 +504,7 @@ public slots:
      *  \param limit    if != -1 limit the returned list to a max of \limit entries
      *  \return The requested list of messages
      */
-    virtual QList<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) = 0;
+    virtual std::vector<Message> requestMsgs(UserId user, BufferId bufferId, MsgId first = -1, MsgId last = -1, int limit = -1) = 0;
 
     //! Request a certain number messages stored in a given buffer, matching certain filters
     /** \param buffer   The buffer we request messages from
@@ -513,14 +514,13 @@ public slots:
      *  \param type     The Message::Types that should be returned
      *  \return The requested list of messages
      */
-    virtual QList<Message> requestMsgsFiltered(UserId user,
-                                               BufferId bufferId,
-                                               MsgId first = -1,
-                                               MsgId last = -1,
-                                               int limit = -1,
-                                               Message::Types type = Message::Types{-1},
-                                               Message::Flags flags = Message::Flags{-1})
-        = 0;
+    virtual std::vector<Message> requestMsgsFiltered(UserId user,
+                                                     BufferId bufferId,
+                                                     MsgId first = -1,
+                                                     MsgId last = -1,
+                                                     int limit = -1,
+                                                     Message::Types type = Message::Types{-1},
+                                                     Message::Flags flags = Message::Flags{-1}) = 0;
 
     //! Request a certain number of messages across all buffers
     /** \param first    if != -1 return only messages with a MsgId >= first
@@ -528,7 +528,7 @@ public slots:
      *  \param limit    Max amount of messages
      *  \return The requested list of messages
      */
-    virtual QList<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) = 0;
+    virtual std::vector<Message> requestAllMsgs(UserId user, MsgId first = -1, MsgId last = -1, int limit = -1) = 0;
 
     //! Request a certain number of messages across all buffers, matching certain filters
     /** \param first    if != -1 return only messages with a MsgId >= first
@@ -537,13 +537,12 @@ public slots:
      *  \param type     The Message::Types that should be returned
      *  \return The requested list of messages
      */
-    virtual QList<Message> requestAllMsgsFiltered(UserId user,
-                                                  MsgId first = -1,
-                                                  MsgId last = -1,
-                                                  int limit = -1,
-                                                  Message::Types type = Message::Types{-1},
-                                                  Message::Flags flags = Message::Flags{-1})
-        = 0;
+    virtual std::vector<Message> requestAllMsgsFiltered(UserId user,
+                                                        MsgId first = -1,
+                                                        MsgId last = -1,
+                                                        int limit = -1,
+                                                        Message::Types type = Message::Types{-1},
+                                                        Message::Flags flags = Message::Flags{-1}) = 0;
 
     //! Fetch all authusernames
     /** \return      Map of all current UserIds to permitted idents

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -18,10 +18,15 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef STORAGE_H
-#define STORAGE_H
+#pragma once
 
-#include <QtCore>
+#include <QList>
+#include <QMap>
+#include <QObject>
+#include <QProcessEnvironment>
+#include <QString>
+#include <QVariant>
+#include <QVariantList>
 
 #include "coreidentity.h"
 #include "message.h"
@@ -572,5 +577,3 @@ private:
     bool checkHashedPasswordSha2_512(const QString& password, const QString& hashedPassword);
     QString sha2_512(const QString& input);
 };
-
-#endif

--- a/src/qtui/chatline.cpp
+++ b/src/qtui/chatline.cpp
@@ -20,10 +20,20 @@
 
 #include "chatline.h"
 
+#include <QAbstractItemModel>
 #include <QDateTime>
 #include <QGraphicsSceneMouseEvent>
+#include <QGraphicsSceneHoverEvent>
+#include <QPainter>
 #include <QString>
-#include <QtGui>
+#include <QStyleOptionGraphicsItem>
+#include <QTextCharFormat>
+
+class QAbstractItemModel;
+class QGraphicsSceneMouseEvent;
+class QGraphicsSceneHoverEvent;
+class QPainter;
+class QStyleOptionGraphicsItem;
 
 #include "bufferinfo.h"
 #include "buffersyncer.h"
@@ -47,9 +57,8 @@ ChatLine::ChatLine(int row,
                    const QPointF& contentsPos,
                    QGraphicsItem* parent)
     : QGraphicsItem(parent)
-    , _row(row)
-    ,  // needs to be set before the items
-    _model(model)
+    , _row(row) // needs to be set before the items
+    , _model(model)
     , _contentsItem(contentsPos, contentsWidth, this)
     , _senderItem(QRectF(senderPos, QSizeF(senderWidth, _contentsItem.height())), this)
     , _timestampItem(QRectF(0, 0, timestampWidth, _contentsItem.height()), this)

--- a/src/qtui/chatline.h
+++ b/src/qtui/chatline.h
@@ -18,14 +18,22 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef CHATLINE_H_
-#define CHATLINE_H_
+#pragma once
 
 #include <QGraphicsItem>
+#include <QModelIndex>
+#include <QRectF>
 
 #include "chatitem.h"
 #include "chatlinemodel.h"
 #include "chatscene.h"
+
+class QAbstractItemModel;
+class QEvent;
+class QGraphicsSceneMouseEvent;
+class QGraphicsSceneHoverEvent;
+class QPainter;
+class QStyleOptionGraphicsItem;
 
 class ChatLine : public QGraphicsItem
 {
@@ -122,5 +130,3 @@ private:
     ChatItem* _mouseGrabberItem;
     ChatItem* _hoverItem;
 };
-
-#endif


### PR DESCRIPTION
* Replace Qt module includes by class ones
* Use `std::vector` instead of `QList` in the storage API and related classes
* Clean up CoreIdentity
* Avoid some warnings new in GCC 9