### PR TITLE
Minor cleanup of metrics server

### DIFF
--- a/src/core/metricsserver.cpp
+++ b/src/core/metricsserver.cpp
@@ -270,16 +270,6 @@ void MetricsServer::respond()
                     .toUtf8()
             );
         }
-        socket->write(
-                QString("quassel_login{successful=\"false\"} %1\n")
-                        .arg(QString::number((float) _loginFailed))
-                        .toUtf8()
-        );
-        socket->write(
-                QString("quassel_login{successful=\"true\"} %1\n")
-                        .arg(QString::number((float) _loginSuccessful))
-                        .toUtf8()
-        );
         socket->close();
     }
     else if (requestPath == "/healthz") {
@@ -352,7 +342,7 @@ void MetricsServer::addClient(UserId user)
 
 void MetricsServer::removeClient(UserId user)
 {
-    int count = _clientSessions.value(user, 0) - 1;
+    int32_t count = _clientSessions.value(user, 0) - 1;
     if (count <= 0) {
         _clientSessions.remove(user);
     }
@@ -368,7 +358,7 @@ void MetricsServer::addNetwork(UserId user)
 
 void MetricsServer::removeNetwork(UserId user)
 {
-    int count = _networkSessions.value(user, 0) - 1;
+    int32_t count = _networkSessions.value(user, 0) - 1;
     if (count <= 0) {
         _networkSessions.remove(user);
     }
@@ -395,14 +385,4 @@ void MetricsServer::messageQueue(UserId user, uint64_t size)
 void MetricsServer::setCertificateExpires(QDateTime expires)
 {
     _certificateExpires = std::move(expires);
-}
-
-void MetricsServer::loginSuccessful()
-{
-    _loginSuccessful++;
-}
-
-void MetricsServer::loginFailed()
-{
-    _loginFailed++;
 }

--- a/src/core/metricsserver.h
+++ b/src/core/metricsserver.h
@@ -52,9 +52,6 @@ public:
     void transmitDataNetwork(UserId user, uint64_t size);
     void receiveDataNetwork(UserId user, uint64_t size);
 
-    void loginSuccessful();
-    void loginFailed();
-
     void messageQueue(UserId user, uint64_t size);
 
     void setCertificateExpires(QDateTime expires);
@@ -71,16 +68,13 @@ private:
 
     QHash<UserId, QString> _sessions{};
 
-    QHash<UserId, int64_t> _clientSessions{};
-    QHash<UserId, int64_t> _networkSessions{};
+    QHash<UserId, int32_t> _clientSessions{};
+    QHash<UserId, int32_t> _networkSessions{};
 
     QHash<UserId, uint64_t> _networkDataTransmit{};
     QHash<UserId, uint64_t> _networkDataReceive{};
 
     QHash<UserId, uint64_t> _messageQueue{};
-
-    uint64_t _loginSuccessful{};
-    uint64_t _loginFailed{};
 
     QDateTime _certificateExpires{};
 };


### PR DESCRIPTION
## In Short
* Remove unused raw login metric
* We won't ever have more than 4 billion sessions at a time per user, use int32_t instead of int64_t

## Impact

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Removes a minor unnecessary metric, fixes a situation that’ll never happen but makes it cleaner |
| Risk | ★☆☆  _1/3_ | Might break existing prometheus dashboards for quassel |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to one class |

## Rationale

Just a tiny cleanup