### PR TITLE
Fix builds for cosmic/disco/eoan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 
 # Define build matrix for Linux
 os: linux
+dist: bionic
 language: generic  # No host compilation
 
 env:


### PR DESCRIPTION
## Issue

Quassel builds for ubuntu cosmic, disco and eoan fail if running in docker on a xenial host

## Reason

Ubuntu cosmic, disco and eoan use Qt 5.11 and 5.12 respectively, which makes use of the new syscall statx (introduced in Qt 5.10, bionic and xenial are still on 5.9 and 5.5 respectively).

Ubuntu xenial supports statx, as does docker, which is up to date on these distros. but sadly libseccomp, which is used to filter syscalls, is too old on these distros.

So code sees that statx is available, tries to run it, and it returns with an error, which is considered file not existing

## Solution

Update the host for our build to at least bionic, where this issue doesn’t exist