### PR TITLE
Adapt to changes in Qt 5.14

### DIFF
--- a/src/client/backlogrequester.cpp
+++ b/src/client/backlogrequester.cpp
@@ -35,36 +35,30 @@ BacklogRequester::BacklogRequester(bool buffering, RequesterType requesterType, 
     Q_ASSERT(backlogManager);
 }
 
-void BacklogRequester::setWaitingBuffers(const QSet<BufferId>& buffers)
+void BacklogRequester::setWaitingBuffers(const BufferIdList& buffers)
 {
-    _buffersWaiting = buffers;
-    _totalBuffers = _buffersWaiting.count();
-}
-
-void BacklogRequester::addWaitingBuffer(BufferId buffer)
-{
-    _buffersWaiting << buffer;
-    _totalBuffers++;
+    _buffersWaiting = {buffers.begin(), buffers.end()};
+    _totalBuffers = int(_buffersWaiting.size());
 }
 
 bool BacklogRequester::buffer(BufferId bufferId, const MessageList& messages)
 {
     _bufferedMessages << messages;
-    _buffersWaiting.remove(bufferId);
-    return !_buffersWaiting.isEmpty();
+    _buffersWaiting.erase(bufferId);
+    return !_buffersWaiting.empty();
 }
 
 BufferIdList BacklogRequester::allBufferIds() const
 {
     QSet<BufferId> bufferIds = Client::bufferViewOverlay()->bufferIds();
     bufferIds += Client::bufferViewOverlay()->tempRemovedBufferIds();
-    return bufferIds.toList();
+    return bufferIds.values();
 }
 
 void BacklogRequester::flushBuffer()
 {
-    if (!_buffersWaiting.isEmpty()) {
-        qWarning() << Q_FUNC_INFO << "was called before all backlog was received:" << _buffersWaiting.count() << "buffers are waiting.";
+    if (!_buffersWaiting.empty()) {
+        qWarning() << Q_FUNC_INFO << "was called before all backlog was received:" << _buffersWaiting.size() << "buffers are waiting.";
     }
     _bufferedMessages.clear();
     _totalBuffers = 0;

--- a/src/client/backlogrequester.h
+++ b/src/client/backlogrequester.h
@@ -18,8 +18,9 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef BACKLOGREQUESTER_H
-#define BACKLOGREQUESTER_H
+#pragma once
+
+#include <set>
 
 #include <QList>
 
@@ -48,7 +49,7 @@ public:
     inline RequesterType type() { return _requesterType; }
     inline const QList<Message>& bufferedMessages() { return _bufferedMessages; }
 
-    inline int buffersWaiting() const { return _buffersWaiting.count(); }
+    inline int buffersWaiting() const { return int(_buffersWaiting.size()); }
     inline int totalBuffers() const { return _totalBuffers; }
 
     bool buffer(BufferId bufferId, const MessageList& messages);  //! returns false if it was the last missing backlogpart
@@ -60,9 +61,7 @@ public:
 
 protected:
     BufferIdList allBufferIds() const;
-    inline void setWaitingBuffers(const QList<BufferId>& buffers) { setWaitingBuffers(buffers.toSet()); }
-    void setWaitingBuffers(const QSet<BufferId>& buffers);
-    void addWaitingBuffer(BufferId buffer);
+    void setWaitingBuffers(const BufferIdList& buffers);
 
     ClientBacklogManager* backlogManager;
 
@@ -71,7 +70,7 @@ private:
     RequesterType _requesterType;
     MessageList _bufferedMessages;
     int _totalBuffers;
-    QSet<BufferId> _buffersWaiting;
+    std::set<BufferId> _buffersWaiting;
 };
 
 // ========================================
@@ -115,5 +114,3 @@ private:
     int _limit;
     int _additional;
 };
-
-#endif  // BACKLOGREQUESTER_H

--- a/src/client/bufferviewoverlay.cpp
+++ b/src/client/bufferviewoverlay.cpp
@@ -27,6 +27,7 @@
 #include "clientbacklogmanager.h"
 #include "clientbufferviewmanager.h"
 #include "networkmodel.h"
+#include "util.h"
 
 const int BufferViewOverlay::_updateEventId = QEvent::registerEventType();
 
@@ -92,13 +93,13 @@ void BufferViewOverlay::addView(int viewId)
                     if (Client::networkModel()->networkId(bufferId) == config->networkId())
                         buffers << bufferId;
                 }
-                foreach (BufferId bufferId, config->temporarilyRemovedBuffers().toList()) {
+                for (BufferId bufferId : config->temporarilyRemovedBuffers()) {
                     if (Client::networkModel()->networkId(bufferId) == config->networkId())
                         buffers << bufferId;
                 }
             }
             else {
-                buffers = BufferIdList::fromSet(config->bufferList().toSet() + config->temporarilyRemovedBuffers());
+                buffers = (toQSet(config->bufferList()) + config->temporarilyRemovedBuffers()).values();
             }
             Client::backlogManager()->checkForBacklog(buffers);
         }
@@ -207,12 +208,12 @@ void BufferViewOverlay::updateHelper()
 
             // we have to apply several filters before we can add a buffer to a category (visible, removed, ...)
             buffers += filterBuffersByConfig(config->bufferList(), config);
-            tempRemovedBuffers += filterBuffersByConfig(config->temporarilyRemovedBuffers().toList(), config);
+            tempRemovedBuffers += filterBuffersByConfig(config->temporarilyRemovedBuffers().values(), config);
             removedBuffers += config->removedBuffers();
         }
 
         // prune the sets from overlap
-        QSet<BufferId> availableBuffers = Client::networkModel()->allBufferIds().toSet();
+        QSet<BufferId> availableBuffers = toQSet(Client::networkModel()->allBufferIds());
 
         buffers.intersect(availableBuffers);
 

--- a/src/client/clientbacklogmanager.cpp
+++ b/src/client/clientbacklogmanager.cpp
@@ -29,6 +29,7 @@
 #include "backlogrequester.h"
 #include "backlogsettings.h"
 #include "client.h"
+#include "util.h"
 
 ClientBacklogManager::ClientBacklogManager(QObject* parent)
     : BacklogManager(parent)
@@ -117,7 +118,7 @@ void ClientBacklogManager::requestInitialBacklog()
 BufferIdList ClientBacklogManager::filterNewBufferIds(const BufferIdList& bufferIds)
 {
     BufferIdList newBuffers;
-    QSet<BufferId> availableBuffers = Client::networkModel()->allBufferIds().toSet();
+    QSet<BufferId> availableBuffers = toQSet(Client::networkModel()->allBufferIds());
     foreach (BufferId bufferId, bufferIds) {
         if (_buffersRequested.contains(bufferId) || !availableBuffers.contains(bufferId))
             continue;

--- a/src/client/clientsettings.cpp
+++ b/src/client/clientsettings.cpp
@@ -161,7 +161,7 @@ void CoreAccountSettings::setJumpKeyMap(const QHash<int, BufferId>& keyMap)
     QVariantMap variants;
     QHash<int, BufferId>::const_iterator mapIter = keyMap.constBegin();
     while (mapIter != keyMap.constEnd()) {
-        variants[QString::number(mapIter.key())] = qVariantFromValue(mapIter.value());
+        variants[QString::number(mapIter.key())] = QVariant::fromValue(mapIter.value());
         ++mapIter;
     }
     setAccountValue("JumpKeyMap", variants);
@@ -183,7 +183,7 @@ void CoreAccountSettings::setBufferViewOverlay(const QSet<int>& viewIds)
 {
     QVariantList variants;
     foreach (int viewId, viewIds) {
-        variants << qVariantFromValue(viewId);
+        variants << QVariant::fromValue(viewId);
     }
     setAccountValue("BufferViewOverlay", variants);
 }

--- a/src/client/coreaccountmodel.cpp
+++ b/src/client/coreaccountmodel.cpp
@@ -98,7 +98,7 @@ QVariant CoreAccountModel::data(const QModelIndex& index, int role) const
     case Qt::DisplayRole:
         return acc.accountName();
     case AccountIdRole:
-        return QVariant::fromValue<AccountId>(acc.accountId());
+        return QVariant::fromValue(acc.accountId());
     case UuidRole:
         return acc.uuid().toString();
 

--- a/src/client/execwrapper.cpp
+++ b/src/client/execwrapper.cpp
@@ -34,7 +34,11 @@ ExecWrapper::ExecWrapper(QObject* parent)
     connect(&_process, &QProcess::readyReadStandardOutput, this, &ExecWrapper::processReadStdout);
     connect(&_process, &QProcess::readyReadStandardError, this, &ExecWrapper::processReadStderr);
     connect(&_process, selectOverload<int, QProcess::ExitStatus>(&QProcess::finished), this, &ExecWrapper::processFinished);
+#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
     connect(&_process, selectOverload<QProcess::ProcessError>(&QProcess::error), this, &ExecWrapper::processError);
+#else
+    connect(&_process, &QProcess::errorOccurred, this, &ExecWrapper::processError);
+#endif
 
     connect(this, &ExecWrapper::output, this, &ExecWrapper::postStdout);
     connect(this, &ExecWrapper::error, this, &ExecWrapper::postStderr);

--- a/src/client/messagefilter.cpp
+++ b/src/client/messagefilter.cpp
@@ -186,7 +186,7 @@ bool MessageFilter::filterAcceptsRow(int sourceRow, const QModelIndex& sourcePar
             if (!redirectedTo.isValid()) {
                 BufferId redirectedTo = Client::bufferModel()->currentIndex().data(NetworkModel::BufferIdRole).value<BufferId>();
                 if (redirectedTo.isValid())
-                    sourceModel()->setData(sourceIdx, QVariant::fromValue<BufferId>(redirectedTo), MessageModel::RedirectedToRole);
+                    sourceModel()->setData(sourceIdx, QVariant::fromValue(redirectedTo), MessageModel::RedirectedToRole);
             }
 
             if (_validBuffers.contains(redirectedTo))

--- a/src/client/messagefilter.cpp
+++ b/src/client/messagefilter.cpp
@@ -28,6 +28,7 @@
 #include "clientignorelistmanager.h"
 #include "messagemodel.h"
 #include "networkmodel.h"
+#include "util.h"
 
 MessageFilter::MessageFilter(QAbstractItemModel* source, QObject* parent)
     : QSortFilterProxyModel(parent)
@@ -39,7 +40,7 @@ MessageFilter::MessageFilter(QAbstractItemModel* source, QObject* parent)
 
 MessageFilter::MessageFilter(MessageModel* source, const QList<BufferId>& buffers, QObject* parent)
     : QSortFilterProxyModel(parent)
-    , _validBuffers(buffers.toSet())
+    , _validBuffers(toQSet(buffers))
     , _messageTypeFilter(0)
 {
     init();
@@ -114,7 +115,7 @@ QString MessageFilter::idString() const
     if (_validBuffers.isEmpty())
         return "*";
 
-    QList<BufferId> bufferIds = _validBuffers.toList();
+    QList<BufferId> bufferIds = _validBuffers.values();
     std::sort(bufferIds.begin(), bufferIds.end());
 
     QStringList bufferIdStrings;

--- a/src/client/messagemodel.cpp
+++ b/src/client/messagemodel.cpp
@@ -439,11 +439,11 @@ QVariant MessageModelItem::data(int column, int role) const
 
     switch (role) {
     case MessageModel::MessageRole:
-        return QVariant::fromValue<Message>(message());
+        return QVariant::fromValue(message());
     case MessageModel::MsgIdRole:
-        return QVariant::fromValue<MsgId>(msgId());
+        return QVariant::fromValue(msgId());
     case MessageModel::BufferIdRole:
-        return QVariant::fromValue<BufferId>(bufferId());
+        return QVariant::fromValue(bufferId());
     case MessageModel::TypeRole:
         return msgType();
     case MessageModel::FlagsRole:
@@ -451,9 +451,9 @@ QVariant MessageModelItem::data(int column, int role) const
     case MessageModel::TimestampRole:
         return timestamp();
     case MessageModel::RedirectedToRole:
-        return qVariantFromValue<BufferId>(_redirectedTo);
+        return QVariant::fromValue(_redirectedTo);
     default:
-        return QVariant();
+        return {};
     }
 }
 

--- a/src/client/networkmodel.cpp
+++ b/src/client/networkmodel.cpp
@@ -70,7 +70,7 @@ QVariant NetworkItem::data(int column, int role) const
         else
             return QVariant();
     case NetworkModel::NetworkIdRole:
-        return qVariantFromValue(_networkId);
+        return QVariant::fromValue(_networkId);
     case NetworkModel::ItemTypeRole:
         return NetworkModel::NetworkItemType;
     case NetworkModel::ItemActiveRole:
@@ -377,11 +377,11 @@ QVariant BufferItem::data(int column, int role) const
     case NetworkModel::ItemTypeRole:
         return NetworkModel::BufferItemType;
     case NetworkModel::BufferIdRole:
-        return qVariantFromValue(bufferInfo().bufferId());
+        return QVariant::fromValue(bufferInfo().bufferId());
     case NetworkModel::NetworkIdRole:
-        return qVariantFromValue(bufferInfo().networkId());
+        return QVariant::fromValue(bufferInfo().networkId());
     case NetworkModel::BufferInfoRole:
-        return qVariantFromValue(bufferInfo());
+        return QVariant::fromValue(bufferInfo());
     case NetworkModel::BufferTypeRole:
         return int(bufferType());
     case NetworkModel::ItemActiveRole:
@@ -389,9 +389,9 @@ QVariant BufferItem::data(int column, int role) const
     case NetworkModel::BufferActivityRole:
         return (int)activityLevel();
     case NetworkModel::BufferFirstUnreadMsgIdRole:
-        return qVariantFromValue(firstUnreadMsgId());
+        return QVariant::fromValue(firstUnreadMsgId());
     case NetworkModel::MarkerLineMsgIdRole:
-        return qVariantFromValue(markerLineMsgId());
+        return QVariant::fromValue(markerLineMsgId());
     default:
         return PropertyMapItem::data(column, role);
     }
@@ -483,7 +483,7 @@ QVariant QueryBufferItem::data(int column, int role) const
     case Qt::EditRole:
         return BufferItem::data(column, Qt::DisplayRole);
     case NetworkModel::IrcUserRole:
-        return QVariant::fromValue<QObject*>(_ircUser);
+        return QVariant::fromValue(_ircUser);
     case NetworkModel::UserAwayRole:
         return (bool)_ircUser ? _ircUser->isAway() : false;
     default:
@@ -696,7 +696,7 @@ QVariant ChannelBufferItem::data(int column, int role) const
 {
     switch (role) {
     case NetworkModel::IrcChannelRole:
-        return QVariant::fromValue<QObject*>(_ircChannel);
+        return QVariant::fromValue(_ircChannel);
     default:
         return BufferItem::data(column, role);
     }
@@ -1063,7 +1063,7 @@ QVariant IrcUserItem::data(int column, int role) const
     case NetworkModel::IrcChannelRole:
         return parent()->data(column, role);
     case NetworkModel::IrcUserRole:
-        return QVariant::fromValue<QObject*>(_ircUser.data());
+        return QVariant::fromValue(_ircUser.data());
     case NetworkModel::UserAwayRole:
         return (bool)_ircUser ? _ircUser->isAway() : false;
     default:

--- a/src/common/buffersyncer.cpp
+++ b/src/common/buffersyncer.cpp
@@ -82,7 +82,7 @@ QVariantList BufferSyncer::initLastSeenMsg() const
     QVariantList list;
     QHash<BufferId, MsgId>::const_iterator iter = _lastSeenMsg.constBegin();
     while (iter != _lastSeenMsg.constEnd()) {
-        list << QVariant::fromValue<BufferId>(iter.key()) << QVariant::fromValue<MsgId>(iter.value());
+        list << QVariant::fromValue(iter.key()) << QVariant::fromValue(iter.value());
         ++iter;
     }
     return list;
@@ -102,7 +102,7 @@ QVariantList BufferSyncer::initMarkerLines() const
     QVariantList list;
     QHash<BufferId, MsgId>::const_iterator iter = _markerLines.constBegin();
     while (iter != _markerLines.constEnd()) {
-        list << QVariant::fromValue<BufferId>(iter.key()) << QVariant::fromValue<MsgId>(iter.value());
+        list << QVariant::fromValue(iter.key()) << QVariant::fromValue(iter.value());
         ++iter;
     }
     return list;
@@ -122,7 +122,7 @@ QVariantList BufferSyncer::initActivities() const
     QVariantList list;
     auto iter = _bufferActivities.constBegin();
     while (iter != _bufferActivities.constEnd()) {
-        list << QVariant::fromValue<BufferId>(iter.key()) << QVariant::fromValue<int>((int)iter.value());
+        list << QVariant::fromValue(iter.key()) << QVariant::fromValue((int)iter.value());
         ++iter;
     }
     return list;
@@ -180,7 +180,7 @@ QVariantList BufferSyncer::initHighlightCounts() const
     QVariantList list;
     auto iter = _highlightCounts.constBegin();
     while (iter != _highlightCounts.constEnd()) {
-        list << QVariant::fromValue<BufferId>(iter.key()) << QVariant::fromValue<int>((int)iter.value());
+        list << QVariant::fromValue(iter.key()) << QVariant::fromValue((int)iter.value());
         ++iter;
     }
     return list;

--- a/src/common/bufferviewconfig.cpp
+++ b/src/common/bufferviewconfig.cpp
@@ -110,7 +110,7 @@ QVariantList BufferViewConfig::initBufferList() const
     QVariantList buffers;
 
     foreach (BufferId bufferId, _buffers) {
-        buffers << qVariantFromValue(bufferId);
+        buffers << QVariant::fromValue(bufferId);
     }
 
     return buffers;
@@ -132,7 +132,7 @@ QVariantList BufferViewConfig::initRemovedBuffers() const
     QVariantList removedBuffers;
 
     foreach (BufferId bufferId, _removedBuffers) {
-        removedBuffers << qVariantFromValue(bufferId);
+        removedBuffers << QVariant::fromValue(bufferId);
     }
 
     return removedBuffers;
@@ -152,7 +152,7 @@ QVariantList BufferViewConfig::initTemporarilyRemovedBuffers() const
     QVariantList temporarilyRemovedBuffers;
 
     foreach (BufferId bufferId, _temporarilyRemovedBuffers) {
-        temporarilyRemovedBuffers << qVariantFromValue(bufferId);
+        temporarilyRemovedBuffers << QVariant::fromValue(bufferId);
     }
 
     return temporarilyRemovedBuffers;

--- a/src/common/ircuser.cpp
+++ b/src/common/ircuser.cpp
@@ -317,7 +317,7 @@ void IrcUser::partChannel(const QString& channelname)
 
 void IrcUser::quit()
 {
-    QList<IrcChannel*> channels = _channels.toList();
+    QList<IrcChannel*> channels = _channels.values();
     _channels.clear();
     foreach (IrcChannel* channel, channels) {
         disconnect(channel, nullptr, this, nullptr);

--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -1156,8 +1156,8 @@ QDataStream& operator<<(QDataStream& out, const NetworkInfo& info)
     i["CodecForServer"]            = info.codecForServer;
     i["CodecForEncoding"]          = info.codecForEncoding;
     i["CodecForDecoding"]          = info.codecForDecoding;
-    i["NetworkId"]                 = QVariant::fromValue<NetworkId>(info.networkId);
-    i["Identity"]                  = QVariant::fromValue<IdentityId>(info.identity);
+    i["NetworkId"]                 = QVariant::fromValue(info.networkId);
+    i["Identity"]                  = QVariant::fromValue(info.identity);
     i["MessageRateBurstSize"]      = info.messageRateBurstSize;
     i["MessageRateDelay"]          = info.messageRateDelay;
     i["AutoReconnectInterval"]     = info.autoReconnectInterval;

--- a/src/common/serializers/serializers.cpp
+++ b/src/common/serializers/serializers.cpp
@@ -29,7 +29,7 @@ bool toVariant(QDataStream& stream, Quassel::Features features, QVariant& data)
     if (!Serializers::deserialize(stream, features, content)) {
         return false;
     }
-    data = QVariant::fromValue<T>(content);
+    data = QVariant::fromValue(content);
     return true;
 }
 

--- a/src/common/signalproxy.h
+++ b/src/common/signalproxy.h
@@ -333,7 +333,7 @@ bool SignalProxy::attachSignal(const typename FunctionTraits<Signal>::ClassType*
 
     // Upon signal emission, marshall the signal's arguments into a QVariantList and dispatch an RpcCall message
     connect(sender, signal, this, [this, signalName = std::move(name)](auto&&... args) {
-        this->dispatchSignal(std::move(signalName), {QVariant::fromValue<decltype(args)>(args)...});
+        this->dispatchSignal(std::move(signalName), {QVariant::fromValue(args)...});
     });
 
     return true;

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -140,7 +140,7 @@ struct UserId : public SignedId
     inline UserId(int _id = 0)
         : SignedId(_id)
     {}
-    // inline operator QVariant() const { return QVariant::fromValue<UserId>(*this); }  // no automatic conversion!
+    // inline operator QVariant() const { return QVariant::fromValue(*this); }  // no automatic conversion!
 };
 
 struct MsgId : public SignedId64
@@ -148,7 +148,7 @@ struct MsgId : public SignedId64
     inline MsgId(qint64 _id = 0)
         : SignedId64(_id)
     {}
-    // inline operator QVariant() const { return QVariant::fromValue<MsgId>(*this); }
+    // inline operator QVariant() const { return QVariant::fromValue(*this); }
 };
 
 struct BufferId : public SignedId
@@ -156,7 +156,7 @@ struct BufferId : public SignedId
     inline BufferId(int _id = 0)
         : SignedId(_id)
     {}
-    // inline operator QVariant() const { return QVariant::fromValue<BufferId>(*this); }
+    // inline operator QVariant() const { return QVariant::fromValue(*this); }
 };
 
 struct NetworkId : public SignedId
@@ -164,7 +164,7 @@ struct NetworkId : public SignedId
     inline NetworkId(int _id = 0)
         : SignedId(_id)
     {}
-    // inline operator QVariant() const { return QVariant::fromValue<NetworkId>(*this); }
+    // inline operator QVariant() const { return QVariant::fromValue(*this); }
 };
 
 struct IdentityId : public SignedId
@@ -172,7 +172,7 @@ struct IdentityId : public SignedId
     inline IdentityId(int _id = 0)
         : SignedId(_id)
     {}
-    // inline operator QVariant() const { return QVariant::fromValue<IdentityId>(*this); }
+    // inline operator QVariant() const { return QVariant::fromValue(*this); }
 };
 
 struct AccountId : public SignedId

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -195,6 +195,7 @@ Q_DECLARE_METATYPE(QHostAddress)
 using MsgIdList = QList<MsgId>;
 using BufferIdList = QList<BufferId>;
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 /**
  * Catch-all stream serialization operator for enum types.
  *
@@ -224,6 +225,7 @@ QDataStream& operator>>(QDataStream& in, T& value)
     value = static_cast<T>(v);
     return in;
 }
+#endif
 
 // STL-compliant hash functor for Qt types
 template<typename T>

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -55,7 +55,7 @@ QVariantList toVariantList(const QList<T>& list)
 {
     QVariantList variants;
     for (int i = 0; i < list.count(); i++) {
-        variants << QVariant::fromValue<T>(list[i]);
+        variants << QVariant::fromValue(list[i]);
     }
     return variants;
 }

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -23,6 +23,7 @@
 #include "common-export.h"
 
 #include <QList>
+#include <QSet>
 #include <QString>
 #include <QVariant>
 
@@ -49,6 +50,16 @@ COMMON_EXPORT QString secondsToString(int timeInSeconds);
 COMMON_EXPORT QString decodeString(const QByteArray& input, QTextCodec* codec = nullptr);
 
 COMMON_EXPORT uint editingDistance(const QString& s1, const QString& s2);
+
+template<typename T>
+QSet<T> toQSet(const QList<T>& list)
+{
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    return list.toSet();
+#else
+    return {list.begin(), list.end()};
+#endif
+}
 
 template<typename T>
 QVariantList toVariantList(const QList<T>& list)

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -302,7 +302,7 @@ void Core::saveState()
     if (_storage) {
         QVariantList activeSessions;
         for (auto&& user : instance()->_sessions.keys())
-            activeSessions << QVariant::fromValue<UserId>(user);
+            activeSessions << QVariant::fromValue(user);
         _storage->setCoreState(activeSessions);
     }
 }

--- a/src/core/corebuffersyncer.cpp
+++ b/src/core/corebuffersyncer.cpp
@@ -28,6 +28,7 @@
 #include "corenetwork.h"
 #include "coresession.h"
 #include "ircchannel.h"
+#include "util.h"
 
 class PurgeEvent : public QEvent
 {
@@ -193,7 +194,7 @@ void CoreBufferSyncer::purgeBufferIds()
     std::transform(bufferInfos.cbegin(), bufferInfos.cend(), std::inserter(actualBuffers, actualBuffers.end()),
                    [](auto&& bufferInfo) { return bufferInfo.bufferId(); });
 
-    QSet<BufferId> storedIds = lastSeenBufferIds().toSet() + markerLineBufferIds().toSet();
+    QSet<BufferId> storedIds = toQSet(lastSeenBufferIds()) + toQSet(markerLineBufferIds());
     foreach (BufferId bufferId, storedIds) {
         if (actualBuffers.find(bufferId) == actualBuffers.end()) {
             BufferSyncer::removeBuffer(bufferId);

--- a/src/core/coreirclisthelper.cpp
+++ b/src/core/coreirclisthelper.cpp
@@ -87,7 +87,7 @@ bool CoreIrcListHelper::endOfChannelList(const NetworkId& netId)
         foreach (ChannelDescription channel, _channelLists[netId]) {
             QVariantList channelVariant;
             channelVariant << channel.channelName << channel.userCount << channel.topic;
-            channelList << qVariantFromValue<QVariant>(channelVariant);
+            channelList << QVariant::fromValue<QVariant>(channelVariant);
         }
         _finishedChannelLists[netId] = channelList;
         _channelLists.remove(netId);

--- a/src/core/coreusersettings.cpp
+++ b/src/core/coreusersettings.cpp
@@ -45,7 +45,7 @@ QList<IdentityId> CoreUserSettings::identityIds() const
 
 void CoreUserSettings::storeIdentity(const Identity& identity)
 {
-    setLocalValue(QString("Identities/%1").arg(identity.id().toInt()), qVariantFromValue(identity));
+    setLocalValue(QString("Identities/%1").arg(identity.id().toInt()), QVariant::fromValue(identity));
 }
 
 void CoreUserSettings::removeIdentity(IdentityId id)

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -824,7 +824,7 @@ void ContentsChatItem::addActionsToMenu(QMenu* menu, const QPointF& pos)
         case Clickable::Url: {
             privateData()->activeClickable = click;
             auto action = new Action{icon::get("edit-copy"), tr("Copy Link Address"), menu, &_actionProxy, &ActionProxy::copyLinkToClipboard};
-            action->setData(QVariant::fromValue<void*>(this));
+            action->setData(QVariant::fromValue(static_cast<void*>(this)));
             menu->addAction(action);
             break;
         }

--- a/src/qtui/chatlinemodelitem.cpp
+++ b/src/qtui/chatlinemodelitem.cpp
@@ -76,7 +76,7 @@ bool ChatLineModelItem::setData(int column, const QVariant& value, int role)
 QVariant ChatLineModelItem::data(int column, int role) const
 {
     if (role == ChatLineModel::MsgLabelRole)
-        return QVariant::fromValue<UiStyle::MessageLabel>(messageLabel());
+        return QVariant::fromValue(messageLabel());
 
     QVariant variant;
     auto col = (MessageModel::ColumnType)column;
@@ -110,8 +110,8 @@ QVariant ChatLineModelItem::timestampData(int role) const
     case ChatLineModel::SelectedBackgroundRole:
         return backgroundBrush(UiStyle::FormatType::Timestamp, true);
     case ChatLineModel::FormatRole:
-        return QVariant::fromValue<UiStyle::FormatList>(
-            {std::make_pair(quint16{0}, UiStyle::Format{UiStyle::formatType(_styledMsg.type()) | UiStyle::FormatType::Timestamp, {}, {}})});
+        return QVariant::fromValue(UiStyle::FormatList{
+            std::make_pair(quint16{0}, UiStyle::Format{UiStyle::formatType(_styledMsg.type()) | UiStyle::FormatType::Timestamp, {}, {}})});
     }
     return QVariant();
 }
@@ -128,8 +128,8 @@ QVariant ChatLineModelItem::senderData(int role) const
     case ChatLineModel::SelectedBackgroundRole:
         return backgroundBrush(UiStyle::FormatType::Sender, true);
     case ChatLineModel::FormatRole:
-        return QVariant::fromValue<UiStyle::FormatList>(
-            {std::make_pair(quint16{0}, UiStyle::Format{UiStyle::formatType(_styledMsg.type()) | UiStyle::FormatType::Sender, {}, {}})});
+        return QVariant::fromValue(UiStyle::FormatList{
+            std::make_pair(quint16{0}, UiStyle::Format{UiStyle::formatType(_styledMsg.type()) | UiStyle::FormatType::Sender, {}, {}})});
     }
     return QVariant();
 }
@@ -145,11 +145,11 @@ QVariant ChatLineModelItem::contentsData(int role) const
     case ChatLineModel::SelectedBackgroundRole:
         return backgroundBrush(UiStyle::FormatType::Contents, true);
     case ChatLineModel::FormatRole:
-        return QVariant::fromValue<UiStyle::FormatList>(_styledMsg.contentsFormatList());
+        return QVariant::fromValue(_styledMsg.contentsFormatList());
     case ChatLineModel::WrapListRole:
         if (_wrapList.isEmpty())
             computeWrapList();
-        return QVariant::fromValue<ChatLineModel::WrapList>(_wrapList);
+        return QVariant::fromValue(_wrapList);
     }
     return QVariant();
 }
@@ -171,7 +171,7 @@ QVariant ChatLineModelItem::backgroundBrush(UiStyle::FormatType subelement, bool
     QTextCharFormat fmt = QtUi::style()->format({UiStyle::formatType(_styledMsg.type()) | subelement, {}, {}},
                                                 messageLabel() | (selected ? UiStyle::MessageLabel::Selected : UiStyle::MessageLabel::None));
     if (fmt.hasProperty(QTextFormat::BackgroundBrush))
-        return QVariant::fromValue<QBrush>(fmt.background());
+        return QVariant::fromValue(fmt.background());
     return QVariant();
 }
 

--- a/src/qtui/chatview.cpp
+++ b/src/qtui/chatview.cpp
@@ -35,6 +35,7 @@
 #include "messagefilter.h"
 #include "qtui.h"
 #include "qtuistyle.h"
+#include "util.h"
 
 ChatView::ChatView(BufferId bufferId, QWidget* parent)
     : QGraphicsView(parent)
@@ -293,7 +294,7 @@ QSet<ChatLine*> ChatView::visibleChatLines(Qt::ItemSelectionMode mode) const
 
 QList<ChatLine*> ChatView::visibleChatLinesSorted(Qt::ItemSelectionMode mode) const
 {
-    QList<ChatLine*> result = visibleChatLines(mode).toList();
+    QList<ChatLine*> result = visibleChatLines(mode).values();
     std::sort(result.begin(), result.end(), chatLinePtrLessThan);
     return result;
 }

--- a/src/qtui/chatviewsearchcontroller.cpp
+++ b/src/qtui/chatviewsearchcontroller.cpp
@@ -118,7 +118,7 @@ void ChatViewSearchController::updateHighlights(bool reuse)
             if (line)
                 chatLines << line;
         }
-        foreach (ChatLine* line, QList<ChatLine*>(chatLines.toList())) {
+        foreach (ChatLine* line, chatLines) {
             updateHighlights(line);
         }
     }
@@ -302,8 +302,7 @@ void ChatViewSearchController::repositionHighlights()
         if (line)
             chatLines << line;
     }
-    QList<ChatLine*> chatLineList(chatLines.toList());
-    foreach (ChatLine* line, chatLineList) {
+    foreach (ChatLine* line, chatLines) {
         repositionHighlights(line);
     }
 }

--- a/src/qtui/chatviewsettings.cpp
+++ b/src/qtui/chatviewsettings.cpp
@@ -70,7 +70,7 @@ void ChatViewSettings::setTimestampFormatString(const QString& format)
 UiStyle::SenderPrefixMode ChatViewSettings::senderPrefixDisplay() const
 {
     return static_cast<UiStyle::SenderPrefixMode>(
-        localValue("SenderPrefixMode", QVariant::fromValue<UiStyle::SenderPrefixMode>(UiStyle::SenderPrefixMode::HighestMode)).toInt());
+        localValue("SenderPrefixMode", QVariant::fromValue(UiStyle::SenderPrefixMode::HighestMode)).toInt());
     // Cast the QVariant to an integer, then cast that to the enum class.
     // .canConvert<UiStyle::SenderPrefixMode>() returned true, but
     // .value<UiStyle::SenderPrefixMode>(); always gave the default value 0.

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -1725,7 +1725,7 @@ void MainWin::clientNetworkCreated(NetworkId id)
     const Network* net = Client::network(id);
     auto* act = new QAction(net->networkName(), this);
     act->setObjectName(QString("NetworkAction-%1").arg(id.toInt()));
-    act->setData(QVariant::fromValue<NetworkId>(id));
+    act->setData(QVariant::fromValue(id));
     connect(net, &SyncableObject::updatedRemotely, this, &MainWin::clientNetworkUpdated);
     connect(act, &QAction::triggered, this, &MainWin::connectOrDisconnectFromNet);
 

--- a/src/qtui/settingsdlg.cpp
+++ b/src/qtui/settingsdlg.cpp
@@ -91,7 +91,7 @@ void SettingsDlg::registerSettingsPage(SettingsPage* sp)
     else
         item = new QTreeWidgetItem(cat, QStringList(sp->title()));
 
-    item->setData(0, SettingsPageRole, QVariant::fromValue<QObject*>(sp));
+    item->setData(0, SettingsPageRole, QVariant::fromValue(sp));
     pageIsLoaded[sp] = false;
     if (!ui.settingsTree->selectedItems().count())
         ui.settingsTree->setCurrentItem(item);

--- a/src/qtui/settingspages/bufferviewsettingspage.cpp
+++ b/src/qtui/settingspages/bufferviewsettingspage.cpp
@@ -126,12 +126,12 @@ void BufferViewSettingsPage::load()
     // load network selector
     ui.networkSelector->clear();
     ui.networkSelector->addItem(tr("All"));
-    ui.networkSelector->setItemData(0, qVariantFromValue<NetworkId>(NetworkId()));
+    ui.networkSelector->setItemData(0, QVariant::fromValue(NetworkId()));
     const Network* net;
     foreach (NetworkId netId, Client::networkIds()) {
         net = Client::network(netId);
         ui.networkSelector->addItem(net->networkName());
-        ui.networkSelector->setItemData(ui.networkSelector->count() - 1, qVariantFromValue<NetworkId>(net->networkId()));
+        ui.networkSelector->setItemData(ui.networkSelector->count() - 1, QVariant::fromValue(net->networkId()));
     }
     _ignoreWidgetChanges = false;
 
@@ -206,7 +206,7 @@ void BufferViewSettingsPage::coreConnectionStateChanged(bool state)
 void BufferViewSettingsPage::addBufferView(BufferViewConfig* config)
 {
     auto* item = new QListWidgetItem(config->bufferViewName(), ui.bufferViewList);
-    item->setData(Qt::UserRole, qVariantFromValue<QObject*>(qobject_cast<QObject*>(config)));
+    item->setData(Qt::UserRole, QVariant::fromValue(qobject_cast<QObject*>(config)));
     connect(config, &SyncableObject::updatedRemotely, this, &BufferViewSettingsPage::updateBufferView);
     connect(config, &QObject::destroyed, this, &BufferViewSettingsPage::bufferViewDeleted);
     ui.deleteBufferView->setEnabled(ui.bufferViewList->count() > 1);

--- a/src/qtui/settingspages/chatmonitorsettingspage.cpp
+++ b/src/qtui/settingspages/chatmonitorsettingspage.cpp
@@ -30,6 +30,7 @@
 #include "client.h"
 #include "icon.h"
 #include "networkmodel.h"
+#include "util.h"
 
 ChatMonitorSettingsPage::ChatMonitorSettingsPage(QWidget* parent)
     : SettingsPage(tr("Interface"), tr("Chat Monitor"), parent)
@@ -189,7 +190,7 @@ bool ChatMonitorSettingsPage::testHasChanged()
     if (_configActive->bufferList().count() != settings["Buffers"].toList().count())
         return true;
 
-    QSet<BufferId> uiBufs = _configActive->bufferList().toSet();
+    QSet<BufferId> uiBufs = toQSet(_configActive->bufferList());
     QSet<BufferId> settingsBufs;
     foreach (QVariant v, settings["Buffers"].toList())
         settingsBufs << v.value<BufferId>();

--- a/src/qtui/settingspages/chatmonitorsettingspage.cpp
+++ b/src/qtui/settingspages/chatmonitorsettingspage.cpp
@@ -156,7 +156,7 @@ void ChatMonitorSettingsPage::save()
     // save list of active buffers
     QVariantList saveableBufferIdList;
     foreach (BufferId id, _configActive->bufferList()) {
-        saveableBufferIdList << QVariant::fromValue<BufferId>(id);
+        saveableBufferIdList << QVariant::fromValue(id);
     }
 
     chatViewSettings.setValue("Buffers", saveableBufferIdList);

--- a/src/qtui/settingspages/networkssettingspage.cpp
+++ b/src/qtui/settingspages/networkssettingspage.cpp
@@ -556,7 +556,7 @@ QListWidgetItem* NetworksSettingsPage::insertNetwork(const NetworkInfo& info)
         if (!item)
             item = new QListWidgetItem(disconnectedIcon, info.networkName, ui.networkList);
     }
-    item->setData(Qt::UserRole, QVariant::fromValue<NetworkId>(info.networkId));
+    item->setData(Qt::UserRole, QVariant::fromValue(info.networkId));
     setItemState(info.networkId, item);
     widgetHasChanged();
     return item;

--- a/src/qtui/settingspages/shortcutsmodel.cpp
+++ b/src/qtui/settingspages/shortcutsmodel.cpp
@@ -149,7 +149,7 @@ QVariant ShortcutsModel::data(const QModelIndex& index, int role) const
         return QVariant();
 
     case ActionRole:
-        return QVariant::fromValue<QObject*>(action);
+        return QVariant::fromValue(action);
 
     case DefaultShortcutRole:
         return action->shortcut(Action::DefaultShortcut);

--- a/src/uisupport/actioncollection.cpp
+++ b/src/uisupport/actioncollection.cpp
@@ -78,7 +78,7 @@ QAction* ActionCollection::addAction(const QString& name, QAction* action)
     else
         action->setObjectName(indexName);
     if (indexName.isEmpty())
-        indexName = indexName.sprintf("unnamed-%p", (void*)action);
+        indexName = indexName.asprintf("unnamed-%p", (void*)action);
 
     // do we already have this action?
     if (_actionByName.value(indexName, 0) == action)

--- a/src/uisupport/bufferviewfilter.cpp
+++ b/src/uisupport/bufferviewfilter.cpp
@@ -32,6 +32,7 @@
 #include "graphicalui.h"
 #include "networkmodel.h"
 #include "uistyle.h"
+#include "util.h"
 
 /*****************************************
  * The Filter for the Tree View
@@ -141,7 +142,7 @@ void BufferViewFilter::enableEditMode(bool enable)
         return;
 
     if (enable == false) {
-        addBuffers(QList<BufferId>::fromSet(_toAdd));
+        addBuffers(_toAdd.values());
         QSet<BufferId>::const_iterator iter;
         for (iter = _toTempRemove.constBegin(); iter != _toTempRemove.constEnd(); ++iter) {
             if (config()->temporarilyRemovedBuffers().contains(*iter))

--- a/src/uisupport/networkmodelcontroller.cpp
+++ b/src/uisupport/networkmodelcontroller.cpp
@@ -564,7 +564,7 @@ NetworkModelController::JoinDlg::JoinDlg(const QModelIndex& index, QWidget* pare
     foreach (NetworkId id, Client::networkIds()) {
         const Network* net = Client::network(id);
         if (net->isConnected()) {
-            networks->addItem(net->networkName(), QVariant::fromValue<NetworkId>(id));
+            networks->addItem(net->networkName(), QVariant::fromValue(id));
         }
     }
 

--- a/src/uisupport/toolbaractionprovider.cpp
+++ b/src/uisupport/toolbaractionprovider.cpp
@@ -150,7 +150,7 @@ void ToolBarActionProvider::networkCreated(NetworkId id)
     Action* act = new Action(net->networkName(), this);
     _networkActions[id] = act;
     act->setObjectName(QString("NetworkAction-%1").arg(id.toInt()));
-    act->setData(QVariant::fromValue<NetworkId>(id));
+    act->setData(QVariant::fromValue(id));
     connect(net, &Network::updatedRemotely, this, [this]() { networkUpdated(); });
     connect(act, &QAction::triggered, this, &ToolBarActionProvider::connectOrDisconnectNet);
     networkUpdated(net);

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -11,4 +11,6 @@ quassel_add_test(SignalProxyTest
         Quassel::Test::Util
 )
 
+quassel_add_test(TypesTest)
+
 quassel_add_test(UtilTest)

--- a/tests/common/typestest.cpp
+++ b/tests/common/typestest.cpp
@@ -1,0 +1,79 @@
+/***************************************************************************
+ *   Copyright (C) 2005-2020 by the Quassel Project                        *
+ *   devel@quassel-irc.org                                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) version 3.                                           *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
+ ***************************************************************************/
+
+#include <cstdint>
+
+#include <QByteArray>
+#include <QDataStream>
+#include <QObject>
+
+#include "testglobal.h"
+#include "types.h"
+
+using namespace ::testing;
+
+class EnumHolder
+{
+    Q_GADGET
+
+public:
+    enum class Enum16 : uint16_t {};
+    enum class Enum32 : uint32_t {};
+
+    enum class EnumQt16 : uint16_t {};
+    Q_ENUM(EnumQt16)
+    enum class EnumQt32 : uint32_t {};
+    Q_ENUM(EnumQt32)
+};
+
+// Verify that enums are (de)serialized as their underlying type
+TEST(TypesTest, enumSerialization)
+{
+    QByteArray data;
+    QDataStream out(&data, QIODevice::WriteOnly);
+
+    // Serialize
+    out << EnumHolder::Enum16(0xabcd);
+    ASSERT_THAT(data.size(), Eq(2));
+    out << EnumHolder::Enum32(0x123456);
+    ASSERT_THAT(data.size(), Eq(6));
+    out << EnumHolder::EnumQt16(0x4321);
+    ASSERT_THAT(data.size(), Eq(8));
+    out << EnumHolder::Enum32(0xfedcba);
+    ASSERT_THAT(data.size(), Eq(12));
+    ASSERT_THAT(out.status(), Eq(QDataStream::Status::Ok));
+
+    // Deserialize
+    QDataStream in(data);
+    EnumHolder::Enum16 enum16;
+    EnumHolder::Enum32 enum32;
+    EnumHolder::EnumQt16 enumQt16;
+    EnumHolder::EnumQt32 enumQt32;
+    in >> enum16  >> enum32 >> enumQt16 >> enumQt32;
+    ASSERT_THAT(in.status(), Eq(QDataStream::Status::Ok));
+    EXPECT_TRUE(in.atEnd());
+
+    EXPECT_THAT((int)enum16, Eq(0xabcd));
+    EXPECT_THAT((int)enum32, Eq(0x123456));
+    EXPECT_THAT((int)enumQt16, Eq(0x4321));
+    EXPECT_THAT((int)enumQt32, Eq(0xfedcba));
+}
+
+#include "typestest.moc"


### PR DESCRIPTION
Qt 5.14 provides stream operators for enum types, which collide with the ones provided by Quassel. Qt 5.14 also deprecated a bunch of stuff, so fixes are necessary to compile without warnings.