### PR TITLE
core: Fix capability messages for repeat CAP LS

### DIFF
--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -1267,7 +1267,7 @@ void CoreNetwork::retryCapsIndividually()
 
 void CoreNetwork::beginCapNegotiation()
 {
-    if (!capNegotiationInProgress()) {
+    if (!capsPendingNegotiation()) {
         // No capabilities are queued for request, determine the reason why
         QString capStatusMsg;
         if (caps().empty()) {
@@ -1327,7 +1327,7 @@ void CoreNetwork::beginCapNegotiation()
 
 void CoreNetwork::sendNextCap()
 {
-    if (capNegotiationInProgress()) {
+    if (capsPendingNegotiation()) {
         // Request the next set of capabilities and remove them from the list
         putRawLine(serverEncode(QString("CAP REQ :%1").arg(takeQueuedCaps())));
     }

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -141,7 +141,7 @@ public:
      *
      * @returns True if in progress, otherwise false
      */
-    inline bool capNegotiationInProgress() const { return (!_capsQueuedIndividual.empty() || !_capsQueuedBundled.empty()); }
+    inline bool capsPendingNegotiation() const { return (!_capsQueuedIndividual.empty() || !_capsQueuedBundled.empty()); }
 
     /**
      * Queues a capability to be requested.


### PR DESCRIPTION
## In short

* Fix rare wrong messages for capability negotiation
  * Distinguish between `No capabilities available` and not supporting what's available
  * For `/CAP LS`, display the current status of capabilities, available and enabled
* Clarify name of `capNegotiationInProgress()`
  * Actually refers to whether or not any capabilities are pending negotiation

*Thanks to `Koragg` on `freenode` for reporting this!*

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes rare user-facing misinformation, easier IRCv3 debugging
Risk | ★☆☆ *1/3* | Information messages may be inaccurate
Intrusiveness | ★☆☆ *1/3* | Small, new strings, shouldn't interfere with other pull requests

## Examples

### Before
#### Supported capabilities found and enabled
```
[1:58:23 am] * Requesting capability list...
[1:58:23 am] * Ready to negotiate (found: cap-notify, away-notify, sasl, chghost, identify-msg, multi-prefix, tls, extended-join, account-notify)
[1:58:23 am] * Negotiating capabilities (requesting: account-notify, away-notify, cap-notify, chghost, extended-join, multi-prefix)...
[1:58:23 am] * Capability negotiation finished (enabled: account-notify, away-notify, cap-notify, chghost, extended-join, multi-prefix)
[...]
/CAP LS 302
[1:59:01 am] * No capabilities available
```

**The response to `/CAP LS` is incorrect**

#### No capabilities provided by server
```
[1:59:44 am] * Requesting capability list...
[1:59:44 am] * No capabilities available
[...]
/CAP LS 302
[2:00:04 am] * No capabilities available
```

*Quassel correctly notes no capabilities are available*

*To simulate this, `coresessioneventprocessor.cpp` modified to remove calls to `coreNet->addCap()`*

#### None of provided capabilities supported by Quassel
```
[2:00:51 am] * Requesting capability list...
[2:00:52 am] * No capabilities available
[...]
/CAP LS 302
[2:01:11 am] * No capabilities available
```

**Quassel fails to display the capabilities available that Quassel doesn't support**

*To simulate this, `coresessioneventprocessor.cpp` modified to remove calls to `coreNet->addCap()`, then call `coreNet->addCap("not-a-real-cap")`*

### After
#### Supported capabilities found and enabled
```
[12:40:24 am] * Requesting capability list...
[12:40:24 am] * Ready to negotiate (found: away-notify, sasl, account-notify, tls, identify-msg, multi-prefix, cap-notify, chghost, extended-join)
[12:40:24 am] * Negotiating capabilities (requesting: account-notify, away-notify, cap-notify, chghost, extended-join, multi-prefix)...
[12:40:24 am] * Capability negotiation finished (enabled: account-notify, away-notify, cap-notify, chghost, extended-join, multi-prefix)
[...]
/CAP LS 302
[12:41:02 am] * No additional capabilities are supported (found: away-notify, sasl, account-notify, tls, identify-msg, multi-prefix, cap-notify, chghost, extended-join; currently enabled: account-notify, away-notify, cap-notify, chghost, extended-join, multi-prefix)
```

*Quassel correctly responds to `/CAP LS`, indicating the current status of discovered and enabled capabilities*

*This should only trigger in response to the user specifically checking capabilities via `/CAP LS 302` or such.  If this should be converted into something with nicer formatting, and therefore more translations, let me know!*

#### No capabilities provided by server
```
[12:12:31 am] * Requesting capability list...
[12:12:31 am] * No capabilities available
[...]
/CAP LS 302
[12:30:53 am] * No capabilities available
```

*Quassel correctly notes no capabilities are available*

*To simulate this, `coresessioneventprocessor.cpp` modified to remove calls to `coreNet->addCap()`*

#### None of provided capabilities supported by Quassel
```
[12:34:18 am] * Requesting capability list...
[12:34:18 am] * None of the capabilities provided by the server are supported (found: not-a-real-cap)
[...]
/CAP LS 302
[12:35:36 am] * None of the capabilities provided by the server are supported (found: not-a-real-cap)
```

*Quassel correctly mentions the capabilities available that it doesn't support*

*To simulate this, `coresessioneventprocessor.cpp` modified to remove calls to `coreNet->addCap()`, then call `coreNet->addCap("not-a-real-cap")`*