### PR TITLE
Update aliasmanager.cpp

### DIFF
--- a/src/common/aliasmanager.cpp
+++ b/src/common/aliasmanager.cpp
@@ -81,9 +81,9 @@ void AliasManager::addAlias(const QString& name, const QString& expansion)
 AliasManager::AliasList AliasManager::defaults()
 {
     AliasList aliases;
-    aliases << Alias("j", "/join $0") << Alias("ns", "/msg nickserv $0") << Alias("nickserv", "/msg nickserv $0")
-            << Alias("cs", "/msg chanserv $0") << Alias("chanserv", "/msg chanserv $0") << Alias("hs", "/msg hostserv $0")
-            << Alias("hostserv", "/msg hostserv $0") << Alias("wii", "/whois $0 $0") << Alias("back", "/quote away");
+    aliases << Alias("j", "/join $0") << Alias("ns", "/quote nickserv $0") << Alias("nickserv", "/quote nickserv $0")
+            << Alias("cs", "/quote chanserv $0") << Alias("chanserv", "/quote chanserv $0") << Alias("hs", "/quote hostserv $0")
+            << Alias("hostserv", "/quote hostserv $0") << Alias("wii", "/whois $0 $0") << Alias("back", "/quote away");
 
 #ifdef Q_OS_LINUX
     // let's add aliases for scripts that only run on linux


### PR DESCRIPTION
I propose to change the alias expanded format from `/msg` to `/quote` since this is probably the most widely used method by other IRC clients and will also make them work out of the box with DALnet that requires that commands to NickServ (as example) to be sent explicitly as `/msg NickServ@services.dal.net` to work.

I've tested this myself in DALnet, Freenode and some other networks with different IRCd flavours and all worked without any problems.

This change proposal shouldn't interfere with previous/future PRs and gives user a more consistent aliases examples.

Cheers