### PR TITLE
Removed mozilla IRC network from networks.ini

### DIFF
--- a/data/networks.ini
+++ b/data/networks.ini
@@ -35,9 +35,6 @@ Servers=irc.gamesnet.net:6667
 [IRCnet]
 Servers=irc.ircnet.com:6667,open.ircnet.net:6666,irc.us.ircnet.net:6665,ircnet.netvision.net.il:6666,irc.tokyo.wide.ad.jp:6666,irc.freebsd.org.tw:6666,linz.irc.at:6666,vienna.irc.at:6666,ircnet.realroot.be:6666,irc.datacomm.ch:6664,irc.felk.cvut.cz:6667,random.ircd.de:6666,irc.dotsrc.org:6666,irc.ircnet.ee:6666,irc.cs.hut.fi:6667,ircnet.club-internet.fr:6666,atw.irc.hu:6667,irc.simnet.is:6660,irc.eutelia.it:6664,irc.eutelia.it:7000,irc.tin.it:6665,irc.apollo.lv:6666,irc.apollo.lv:7000,irc.uunet.nl:6660,irc.xs4all.nl:6660,irc.snt.utwente.nl:6660,irc.ifi.uio.no:6667,irc.pvv.ntnu.no:6667,lublin.irc.pl:6666,warszawa.irc.pl:6666,irc.ludd.luth.se:6661,irc.swipnet.se:6660,irc.swipnet.se:8000,irc.arnes.si:6666,irc.link.si:6666,irc.nextra.sk:6666,ircnet.demon.co.uk:6665,ircnet.eversible.com:6665,ircnet.choopa.net:6665
 
-[Mozilla]
-Servers=irc.mozilla.org:+6697,irc.mozilla.org:6667
-
 [OFTC]
 Servers=irc.oftc.net:+6697,irc.oftc.net:6667
 


### PR DESCRIPTION
Mozilla IRC has shut down this month. Mozilla moved their chat services to matrix. I am removing it from the default preset now.