### PR TITLE
Require SSL support in Qt, and remove fallback code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,25 @@ set_package_properties(Qt5 PROPERTIES TYPE REQUIRED
 )
 message(STATUS "Found Qt ${Qt5Core_VERSION}")
 
+# Check for SSL support in Qt
+cmake_push_check_state(RESET)
+set(CMAKE_REQUIRED_LIBRARIES Qt5::Core)
+check_cxx_source_compiles("
+    #include \"qglobal.h\"
+    #if defined QT_NO_SSL
+    #  error \"No SSL support\"
+    #endif
+    int main() {}"
+    HAVE_SSL)
+cmake_pop_check_state()
+
+if (NOT HAVE_SSL)
+    message(FATAL_ERROR "Quassel requires SSL support, but Qt is built with QT_NO_SSL")
+endif()
+
+# Compat until fallback code paths have been disabled
+add_definitions(-DHAVE_SSL)
+
 # Optional Qt components
 
 find_package(Qt5LinguistTools QUIET)
@@ -398,25 +417,6 @@ if (BUILD_TESTING)
     # GTest messes with CMAKE_CXX_FLAGS, so process them again
     process_cmake_cxx_flags()
 endif()
-
-# Check for SSL support in Qt
-#####################################################################
-
-cmake_push_check_state(RESET)
-set(CMAKE_REQUIRED_LIBRARIES Qt5::Core)
-check_cxx_source_compiles("
-    #include \"qglobal.h\"
-    #if defined QT_NO_SSL
-    #  error \"No SSL support\"
-    #endif
-    int main() {}"
-    HAVE_SSL)
-cmake_pop_check_state()
-
-if (HAVE_SSL)
-    add_definitions(-DHAVE_SSL)
-endif()
-add_feature_info("SSL support in Qt" HAVE_SSL "Use secure network connections")
 
 # Setup support for KDE Frameworks
 #####################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,9 +195,6 @@ if (NOT HAVE_SSL)
     message(FATAL_ERROR "Quassel requires SSL support, but Qt is built with QT_NO_SSL")
 endif()
 
-# Compat until fallback code paths have been disabled
-add_definitions(-DHAVE_SSL)
-
 # Optional Qt components
 
 find_package(Qt5LinguistTools QUIET)

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -241,10 +241,8 @@ const Identity* Client::identity(IdentityId id)
 void Client::createIdentity(const CertIdentity& id)
 {
     QVariantMap additional;
-#ifdef HAVE_SSL
     additional["KeyPem"] = id.sslKey().toPem();
     additional["CertPem"] = id.sslCert().toPem();
-#endif
     emit instance()->requestCreateIdentity(id, additional);
 }
 

--- a/src/client/clientauthhandler.h
+++ b/src/client/clientauthhandler.h
@@ -67,9 +67,7 @@ signals:
     void userAuthenticationRequired(CoreAccount* account, bool* valid, const QString& errorMessage = QString());
     void handleNoSslInClient(bool* accepted);
     void handleNoSslInCore(bool* accepted);
-#ifdef HAVE_SSL
     void handleSslErrors(const QSslSocket* socket, bool* accepted, bool* permanently);
-#endif
 
     void encrypted(bool isEncrypted = true);
     void startCoreSetup(const QVariantList& backendInfo, const QVariantList& authenticatorInfo);
@@ -98,10 +96,8 @@ private slots:
     void onSocketDisconnected() override;
     void onReadyRead();
 
-#ifdef HAVE_SSL
     void onSslSocketEncrypted();
     void onSslErrors();
-#endif
 
     void onProtocolVersionMismatch(int actual, int expected);
 

--- a/src/client/clientidentity.cpp
+++ b/src/client/clientidentity.cpp
@@ -33,14 +33,11 @@ CertIdentity::CertIdentity(const Identity& other, QObject* parent)
 
 CertIdentity::CertIdentity(const CertIdentity& other, QObject* parent)
     : Identity(other, parent)
-#ifdef HAVE_SSL
     , _isDirty(other._isDirty)
     , _sslKey(other._sslKey)
     , _sslCert(other._sslCert)
-#endif
 {}
 
-#ifdef HAVE_SSL
 void CertIdentity::enableEditSsl(bool enable)
 {
     if (!enable || _certManager)
@@ -101,5 +98,3 @@ void ClientCertManager::setSslCert(const QByteArray& encoded)
 {
     _certIdentity->setSslCert(QSslCertificate(encoded));
 }
-
-#endif  // HAVE_SSL

--- a/src/client/clientidentity.h
+++ b/src/client/clientidentity.h
@@ -35,13 +35,8 @@ public:
     CertIdentity(const Identity& other, QObject* parent = nullptr);
     CertIdentity(const CertIdentity& other, QObject* parent = nullptr);
 
-#ifdef HAVE_SSL
     inline bool isDirty() const { return _isDirty; }
-#else
-    inline bool isDirty() const { return false; }
-#endif
 
-#ifdef HAVE_SSL
     void enableEditSsl(bool enable = true);
     inline const QSslKey& sslKey() const { return _sslKey; }
     inline const QSslCertificate& sslCert() const { return _sslCert; }
@@ -63,13 +58,11 @@ private:
     bool _isDirty{false};
     QSslKey _sslKey;
     QSslCertificate _sslCert;
-#endif  // HAVE_SSL
 };
 
 // ========================================
 //  ClientCertManager
 // ========================================
-#ifdef HAVE_SSL
 
 class ClientCertManager : public CertManager
 {
@@ -92,4 +85,3 @@ private:
     CertIdentity* _certIdentity;
 };
 
-#endif  // HAVE_SSL

--- a/src/client/clientsettings.cpp
+++ b/src/client/clientsettings.cpp
@@ -23,10 +23,8 @@
 #include <utility>
 
 #include <QHostAddress>
+#include <QSslSocket>
 #include <QStringList>
-#ifdef HAVE_SSL
-#    include <QSslSocket>
-#endif
 
 #include "client.h"
 #include "quassel.h"

--- a/src/client/coreaccount.cpp
+++ b/src/client/coreaccount.cpp
@@ -26,7 +26,6 @@ CoreAccount::CoreAccount(AccountId accountId)
     _internal = false;
     _port = 4242;
     _storePassword = false;
-    _useSsl = true;
     _proxyType = QNetworkProxy::DefaultProxy;
     _proxyPort = 8080;
 }
@@ -76,11 +75,6 @@ void CoreAccount::setPort(uint port)
     _port = port;
 }
 
-void CoreAccount::setUseSsl(bool useSsl)
-{
-    _useSsl = useSsl;
-}
-
 void CoreAccount::setProxyType(QNetworkProxy::ProxyType type)
 {
     _proxyType = type;
@@ -121,7 +115,6 @@ QVariantMap CoreAccount::toVariantMap(bool forcePassword) const
     v["StorePassword"] = storePassword();
     v["HostName"] = hostName();
     v["Port"] = port();
-    v["UseSSL"] = useSsl();
     v["ProxyType"] = proxyType();
     v["ProxyUser"] = proxyUser();
     v["ProxyPassword"] = proxyPassword();
@@ -141,7 +134,6 @@ void CoreAccount::fromVariantMap(const QVariantMap& v)
     setStorePassword(v.value("StorePassword").toBool());
     setHostName(v.value("HostName").toString());
     setPort(v.value("Port").toUInt());
-    setUseSsl(v.value("UseSSL").toBool());
     setProxyType((QNetworkProxy::ProxyType)v.value("ProxyType").toInt());
     setProxyUser(v.value("ProxyUser").toString());
     setProxyPassword(v.value("ProxyPassword").toString());
@@ -172,7 +164,6 @@ QDebug operator<<(QDebug dbg, const CoreAccount& acc)
                   << qPrintable(QString(", StorePassword:")) << acc.storePassword()
                   << qPrintable(QString(", HostName:")) << acc.hostName()
                   << qPrintable(QString(", Port:")) << acc.port()
-                  << qPrintable(QString(", UseSSL:")) << acc.useSsl()
                   << qPrintable(QString(", ProxyType:")) << acc.proxyType()
                   << qPrintable(QString(", ProxyUser:")) << acc.proxyUser()
                   << qPrintable(QString(", ProxyPassword:")) << acc.proxyPassword()

--- a/src/client/coreaccount.h
+++ b/src/client/coreaccount.h
@@ -48,7 +48,6 @@ public:
     inline bool storePassword() const { return _storePassword; }
     inline QString hostName() const { return _hostName; }
     inline uint port() const { return _port; }
-    inline bool useSsl() const { return _useSsl; }
 
     inline QNetworkProxy::ProxyType proxyType() const { return _proxyType; }
     inline QString proxyUser() const { return _proxyUser; }
@@ -64,7 +63,6 @@ public:
     void setStorePassword(bool);
     void setHostName(const QString& hostname);
     void setPort(uint port);
-    void setUseSsl(bool);
 
     void setProxyType(QNetworkProxy::ProxyType);
     void setProxyUser(const QString&);
@@ -90,7 +88,7 @@ private:
     bool _internal;
     QString _user, _password, _hostName;
     uint _port;
-    bool _storePassword, _useSsl;
+    bool _storePassword{};
     QNetworkProxy::ProxyType _proxyType;
     QString _proxyUser, _proxyPassword, _proxyHostName;
     uint _proxyPort;

--- a/src/client/coreconnection.cpp
+++ b/src/client/coreconnection.cpp
@@ -381,9 +381,7 @@ void CoreConnection::connectToCurrentAccount()
     connect(_authHandler, &ClientAuthHandler::userAuthenticationRequired, this, &CoreConnection::userAuthenticationRequired);
     connect(_authHandler, &ClientAuthHandler::handleNoSslInClient, this, &CoreConnection::handleNoSslInClient);
     connect(_authHandler, &ClientAuthHandler::handleNoSslInCore, this, &CoreConnection::handleNoSslInCore);
-#ifdef HAVE_SSL
     connect(_authHandler, &ClientAuthHandler::handleSslErrors, this, &CoreConnection::handleSslErrors);
-#endif
     connect(_authHandler, &ClientAuthHandler::loginSuccessful, this, &CoreConnection::onLoginSuccessful);
     connect(_authHandler, &ClientAuthHandler::handshakeComplete, this, &CoreConnection::onHandshakeComplete);
 

--- a/src/client/coreconnection.h
+++ b/src/client/coreconnection.h
@@ -24,13 +24,8 @@
 
 #include <QNetworkConfigurationManager>
 #include <QPointer>
+#include <QSslSocket>
 #include <QTimer>
-
-#ifdef HAVE_SSL
-#    include <QSslSocket>
-#else
-#    include <QTcpSocket>
-#endif
 
 #include "coreaccount.h"
 #include "remotepeer.h"
@@ -111,9 +106,7 @@ signals:
     void userAuthenticationRequired(CoreAccount*, bool* valid, const QString& errorMessage = QString());
     void handleNoSslInClient(bool* accepted);
     void handleNoSslInCore(bool* accepted);
-#ifdef HAVE_SSL
     void handleSslErrors(const QSslSocket* socket, bool* accepted, bool* permanently);
-#endif
 
 private slots:
     void connectToCurrentAccount();

--- a/src/common/authhandler.cpp
+++ b/src/common/authhandler.cpp
@@ -28,12 +28,12 @@ AuthHandler::AuthHandler(QObject* parent)
     : QObject(parent)
 {}
 
-QTcpSocket* AuthHandler::socket() const
+QSslSocket* AuthHandler::socket() const
 {
     return _socket;
 }
 
-void AuthHandler::setSocket(QTcpSocket* socket)
+void AuthHandler::setSocket(QSslSocket* socket)
 {
     _socket = socket;
     connect(socket, selectOverload<QAbstractSocket::SocketError>(&QTcpSocket::error), this, &AuthHandler::onSocketError);

--- a/src/common/authhandler.h
+++ b/src/common/authhandler.h
@@ -22,7 +22,7 @@
 
 #include "common-export.h"
 
-#include <QTcpSocket>
+#include <QSslSocket>
 
 #include "protocol.h"
 
@@ -35,7 +35,7 @@ class COMMON_EXPORT AuthHandler : public QObject
 public:
     AuthHandler(QObject* parent = nullptr);
 
-    QTcpSocket* socket() const;
+    QSslSocket* socket() const;
 
     virtual bool isLocal() const;
 
@@ -65,7 +65,7 @@ signals:
     void socketError(QAbstractSocket::SocketError error, const QString& errorString);
 
 protected:
-    void setSocket(QTcpSocket* socket);
+    void setSocket(QSslSocket* socket);
 
 protected slots:
     virtual void onSocketError(QAbstractSocket::SocketError error);
@@ -74,6 +74,6 @@ protected slots:
 private:
     void invalidMessage();
 
-    QTcpSocket* _socket{nullptr};  // FIXME: should be a QSharedPointer? -> premature disconnect before the peer has taken over
+    QSslSocket* _socket{nullptr};  // FIXME: should be a QSharedPointer? -> premature disconnect before the peer has taken over
     bool _disconnectedSent{false};
 };

--- a/src/common/identity.h
+++ b/src/common/identity.h
@@ -25,6 +25,8 @@
 #include <QByteArray>
 #include <QDataStream>
 #include <QMetaType>
+#include <QSslCertificate>
+#include <QSslKey>
 #include <QString>
 #include <QStringList>
 
@@ -160,10 +162,6 @@ QDataStream& operator>>(QDataStream& in, Identity& identity);
 
 Q_DECLARE_METATYPE(Identity)
 
-#ifdef HAVE_SSL
-#    include <QSslCertificate>
-#    include <QSslKey>
-
 class COMMON_EXPORT CertManager : public SyncableObject
 {
     Q_OBJECT
@@ -186,5 +184,3 @@ public slots:
     inline virtual void setSslKey(const QByteArray& encoded) { SYNC(ARG(encoded)) }
     inline virtual void setSslCert(const QByteArray& encoded) { SYNC(ARG(encoded)) }
 };
-
-#endif  // HAVE_SSL

--- a/src/common/protocols/legacy/legacypeer.cpp
+++ b/src/common/protocols/legacy/legacypeer.cpp
@@ -237,7 +237,7 @@ void LegacyPeer::dispatch(const RegisterClient& msg)
 
     // FIXME only in compat mode
     m["ProtocolVersion"] = protocolVersion;
-    m["UseSsl"] = msg.sslSupported;
+    m["UseSsl"] = true;
 #ifndef QT_NO_COMPRESS
     m["UseCompression"] = true;
 #else

--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -363,14 +363,12 @@ void Quassel::setupCliParser()
             {"oidentd", tr("Enable oidentd integration. In most cases you should also enable --strict-ident.")},
             {"oidentd-conffile", tr("Set path to oidentd configuration file."), tr("file")},
             {"proxy-cidr", tr("Set IP range from which proxy protocol definitions are allowed"), tr("<address>[,...]"), "::1,127.0.0.1"},
-#ifdef HAVE_SSL
             {"require-ssl", tr("Require SSL for remote (non-loopback) client connections.")},
             {"ssl-cert", tr("Specify the path to the SSL certificate."), tr("path"), "configdir/quasselCert.pem"},
             {"ssl-key", tr("Specify the path to the SSL key."), tr("path"), "ssl-cert-path"},
             {"metrics-daemon", tr("Enable metrics API.")},
             {"metrics-port", tr("The port quasselcore will listen at for metrics requests. Only meaningful with --metrics-daemon."), tr("port"), "9558"},
             {"metrics-listen", tr("The address(es) quasselcore will listen on for metrics requests. Same format as --listen."), tr("<address>[,...]"), "::1,127.0.0.1"}
-#endif
         };
     }
 

--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -25,11 +25,8 @@
 #include <QHostAddress>
 #include <QMetaMethod>
 #include <QMetaProperty>
+#include <QSslSocket>
 #include <QThread>
-
-#ifdef HAVE_SSL
-#    include <QSslSocket>
-#endif
 
 #include "peer.h"
 #include "protocol.h"

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(${TARGET} PRIVATE
     sessionthread.cpp
     sqlauthenticator.cpp
     sqlitestorage.cpp
+    sslserver.cpp
     storage.cpp
 
     # needed for automoc
@@ -55,10 +56,6 @@ target_link_libraries(${TARGET}
 
 if (HAVE_UMASK)
     set_property(SOURCE oidentdconfiggenerator.cpp APPEND PROPERTY COMPILE_DEFINITIONS HAVE_UMASK)
-endif()
-
-if (HAVE_SSL)
-    target_sources(${TARGET} PRIVATE sslserver.cpp)
 endif()
 
 if (Ldap_FOUND)

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -215,10 +215,8 @@ void Core::init()
 
         if (Quassel::isOptionSet("metrics-daemon")) {
             _metricsServer = new MetricsServer(this);
-#ifdef HAVE_SSL
             _server.setMetricsServer(_metricsServer);
             _v6server.setMetricsServer(_metricsServer);
-#endif
         }
 
         Quassel::registerReloadHandler([]() {
@@ -574,17 +572,12 @@ bool Core::initAuthenticator(
 
 bool Core::sslSupported()
 {
-#ifdef HAVE_SSL
     auto* sslServer = qobject_cast<SslServer*>(&instance()->_server);
     return sslServer && sslServer->isCertValid();
-#else
-    return false;
-#endif
 }
 
 bool Core::reloadCerts()
 {
-#ifdef HAVE_SSL
     auto* sslServerv4 = qobject_cast<SslServer*>(&_server);
     bool retv4 = sslServerv4->reloadCerts();
 
@@ -592,10 +585,6 @@ bool Core::reloadCerts()
     bool retv6 = sslServerv6->reloadCerts();
 
     return retv4 && retv6;
-#else
-    // SSL not supported, don't mark configuration reload as failed
-    return true;
-#endif
 }
 
 void Core::cacheSysIdent()

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -27,18 +27,10 @@
 
 #include <QDateTime>
 #include <QPointer>
+#include <QSslSocket>
 #include <QString>
 #include <QTimer>
 #include <QVariant>
-
-#ifdef HAVE_SSL
-#    include <QSslSocket>
-
-#    include "sslserver.h"
-#else
-#    include <QTcpServer>
-#    include <QTcpSocket>
-#endif
 
 #include "authenticator.h"
 #include "bufferinfo.h"
@@ -49,6 +41,7 @@
 #include "oidentdconfiggenerator.h"
 #include "sessionthread.h"
 #include "singleton.h"
+#include "sslserver.h"
 #include "storage.h"
 #include "types.h"
 
@@ -781,11 +774,7 @@ private:
 
     QTimer _storageSyncTimer;
 
-#ifdef HAVE_SSL
     SslServer _server, _v6server;
-#else
-    QTcpServer _server, _v6server;
-#endif
 
     OidentdConfigGenerator* _oidentdConfigGenerator{nullptr};
 

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -22,9 +22,7 @@
 
 #include <QtEndian>
 
-#ifdef HAVE_SSL
-#    include <QSslSocket>
-#endif
+#include <QSslSocket>
 
 #include "core.h"
 
@@ -336,7 +334,6 @@ bool CoreAuthHandler::isLocal() const
 
 void CoreAuthHandler::startSsl()
 {
-#ifdef HAVE_SSL
     auto* sslSocket = qobject_cast<QSslSocket*>(socket());
     Q_ASSERT(sslSocket);
 
@@ -344,14 +341,11 @@ void CoreAuthHandler::startSsl()
     connect(sslSocket, selectOverload<const QList<QSslError>&>(&QSslSocket::sslErrors), this, &CoreAuthHandler::onSslErrors);
     sslSocket->flush();  // ensure that the write cache is flushed before we switch to ssl (bug 682)
     sslSocket->startServerEncryption();
-#endif /* HAVE_SSL */
 }
 
-#ifdef HAVE_SSL
 void CoreAuthHandler::onSslErrors()
 {
     auto* sslSocket = qobject_cast<QSslSocket*>(socket());
     Q_ASSERT(sslSocket);
     sslSocket->ignoreSslErrors();
 }
-#endif

--- a/src/core/coreauthhandler.cpp
+++ b/src/core/coreauthhandler.cpp
@@ -26,7 +26,7 @@
 
 #include "core.h"
 
-CoreAuthHandler::CoreAuthHandler(QTcpSocket* socket, QObject* parent)
+CoreAuthHandler::CoreAuthHandler(QSslSocket* socket, QObject* parent)
     : AuthHandler(parent)
     , _peer(nullptr)
     , _metricsServer(Core::instance()->metricsServer())
@@ -334,18 +334,13 @@ bool CoreAuthHandler::isLocal() const
 
 void CoreAuthHandler::startSsl()
 {
-    auto* sslSocket = qobject_cast<QSslSocket*>(socket());
-    Q_ASSERT(sslSocket);
-
     qDebug() << qPrintable(tr("Starting encryption for Client:")) << _peer->description();
-    connect(sslSocket, selectOverload<const QList<QSslError>&>(&QSslSocket::sslErrors), this, &CoreAuthHandler::onSslErrors);
-    sslSocket->flush();  // ensure that the write cache is flushed before we switch to ssl (bug 682)
-    sslSocket->startServerEncryption();
+    connect(socket(), selectOverload<const QList<QSslError>&>(&QSslSocket::sslErrors), this, &CoreAuthHandler::onSslErrors);
+    socket()->flush();  // ensure that the write cache is flushed before we switch to ssl (bug 682)
+    socket()->startServerEncryption();
 }
 
 void CoreAuthHandler::onSslErrors()
 {
-    auto* sslSocket = qobject_cast<QSslSocket*>(socket());
-    Q_ASSERT(sslSocket);
-    sslSocket->ignoreSslErrors();
+    socket()->ignoreSslErrors();
 }

--- a/src/core/coreauthhandler.h
+++ b/src/core/coreauthhandler.h
@@ -18,8 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef COREAUTHHANDLER_H
-#define COREAUTHHANDLER_H
+#pragma once
 
 #include "authhandler.h"
 #include "metricsserver.h"
@@ -33,7 +32,7 @@ class CoreAuthHandler : public AuthHandler
     Q_OBJECT
 
 public:
-    CoreAuthHandler(QTcpSocket* socket, QObject* parent = nullptr);
+    CoreAuthHandler(QSslSocket* socket, QObject* parent = nullptr);
 
     QHostAddress hostAddress() const;
     bool isLocal() const override;
@@ -74,5 +73,3 @@ private:
     quint8 _connectionFeatures;
     QVector<PeerFactory::ProtoDescriptor> _supportedProtos;
 };
-
-#endif

--- a/src/core/coreauthhandler.h
+++ b/src/core/coreauthhandler.h
@@ -56,9 +56,7 @@ private:
 private slots:
     void onReadyRead();
 
-#ifdef HAVE_SSL
     void onSslErrors();
-#endif
 
     // only in legacy mode
     void onProtocolVersionMismatch(int actual, int expected);

--- a/src/core/coreidentity.cpp
+++ b/src/core/coreidentity.cpp
@@ -24,51 +24,36 @@
 
 CoreIdentity::CoreIdentity(IdentityId id, QObject* parent)
     : Identity(id, parent)
-#ifdef HAVE_SSL
     , _certManager(this)
-#endif
 {
-#ifdef HAVE_SSL
     connect(this, &Identity::idSet, &_certManager, &CoreCertManager::setId);
     connect(&_certManager, &SyncableObject::updated, this, &SyncableObject::updated);
-#endif
 }
 
 CoreIdentity::CoreIdentity(const Identity& other, QObject* parent)
     : Identity(other, parent)
-#ifdef HAVE_SSL
     , _certManager(this)
-#endif
 {
-#ifdef HAVE_SSL
     connect(this, &Identity::idSet, &_certManager, &CoreCertManager::setId);
     connect(&_certManager, &SyncableObject::updated, this, &SyncableObject::updated);
-#endif
 }
 
 CoreIdentity::CoreIdentity(const CoreIdentity& other, QObject* parent)
     : Identity(other, parent)
-#ifdef HAVE_SSL
     , _sslKey(other._sslKey)
     , _sslCert(other._sslCert)
     , _certManager(this)
-#endif
 {
-#ifdef HAVE_SSL
     connect(this, &Identity::idSet, &_certManager, &CoreCertManager::setId);
     connect(&_certManager, &SyncableObject::updated, this, &SyncableObject::updated);
-#endif
 }
 
 void CoreIdentity::synchronize(SignalProxy* proxy)
 {
     proxy->synchronize(this);
-#ifdef HAVE_SSL
     proxy->synchronize(&_certManager);
-#endif
 }
 
-#ifdef HAVE_SSL
 void CoreIdentity::setSslKey(const QByteArray& encoded)
 {
     QSslKey key(encoded, QSsl::Rsa);
@@ -84,9 +69,6 @@ void CoreIdentity::setSslCert(const QByteArray& encoded)
     setSslCert(QSslCertificate(encoded));
 }
 
-#endif
-
-#ifdef HAVE_SSL
 // ========================================
 //  CoreCertManager
 // ========================================
@@ -114,5 +96,3 @@ void CoreCertManager::setSslCert(const QByteArray& encoded)
     _identity->setSslCert(encoded);
     CertManager::setSslCert(encoded);
 }
-
-#endif  // HAVE_SSL

--- a/src/core/coreidentity.h
+++ b/src/core/coreidentity.h
@@ -24,17 +24,14 @@
 
 #include "identity.h"
 
-#ifdef HAVE_SSL
-#    include <QSslCertificate>
-#    include <QSslKey>
-#endif  // HAVE_SSL
+#include <QSslCertificate>
+#include <QSslKey>
 
 class SignalProxy;
 
 // ========================================
 //  CoreCertManager
 // ========================================
-#ifdef HAVE_SSL
 class CoreIdentity;
 class CORE_EXPORT CoreCertManager : public CertManager
 {
@@ -43,22 +40,18 @@ class CORE_EXPORT CoreCertManager : public CertManager
 public:
     CoreCertManager(CoreIdentity* identity);
 
-#    ifdef HAVE_SSL
     const QSslKey& sslKey() const override;
     const QSslCertificate& sslCert() const override;
 
 public slots:
     void setSslKey(const QByteArray& encoded) override;
     void setSslCert(const QByteArray& encoded) override;
-#    endif
 
     void setId(IdentityId id);
 
 private:
     CoreIdentity* _identity{nullptr};
 };
-
-#endif  // HAVE_SSL
 
 // =========================================
 //  CoreIdentity
@@ -74,25 +67,20 @@ public:
 
     void synchronize(SignalProxy* proxy);
 
-#ifdef HAVE_SSL
     inline const QSslKey& sslKey() const { return _sslKey; }
     inline void setSslKey(const QSslKey& key) { _sslKey = key; }
     void setSslKey(const QByteArray& encoded);
     inline const QSslCertificate& sslCert() const { return _sslCert; }
     inline void setSslCert(const QSslCertificate& cert) { _sslCert = cert; }
     void setSslCert(const QByteArray& encoded);
-#endif /* HAVE_SSL */
 
 private:
-#ifdef HAVE_SSL
     QSslKey _sslKey;
     QSslCertificate _sslCert;
 
     CoreCertManager _certManager;
-#endif
 };
 
-#ifdef HAVE_SSL
 inline const QSslKey& CoreCertManager::sslKey() const
 {
     return _identity->sslKey();
@@ -102,5 +90,3 @@ inline const QSslCertificate& CoreCertManager::sslCert() const
 {
     return _identity->sslCert();
 }
-
-#endif

--- a/src/core/corenetwork.h
+++ b/src/core/corenetwork.h
@@ -22,14 +22,9 @@
 
 #include <functional>
 
+#include <QSslError>
+#include <QSslSocket>
 #include <QTimer>
-
-#ifdef HAVE_SSL
-#    include <QSslError>
-#    include <QSslSocket>
-#else
-#    include <QTcpSocket>
-#endif
 
 #ifdef HAVE_QCA2
 #    include "cipher.h"
@@ -476,9 +471,7 @@ private slots:
     void sendAutoWho();
     void startAutoWhoCycle();
 
-#ifdef HAVE_SSL
     void onSslErrors(const QList<QSslError>& errors);
-#endif
 
     /**
      * Check the message token bucket
@@ -513,11 +506,7 @@ private:
     bool _debugLogRawIrc;      ///< If true, include raw IRC socket messages in the debug log
     qint32 _debugLogRawNetId;  ///< Network ID for logging raw IRC socket messages, or -1 for all
 
-#ifdef HAVE_SSL
     QSslSocket socket;
-#else
-    QTcpSocket socket;
-#endif
     qint64 _socketId{0};
 
     CoreUserInputHandler* _userInputHandler;

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -529,17 +529,11 @@ Protocol::SessionState CoreSession::sessionState() const
 /*** Identity Handling ***/
 void CoreSession::createIdentity(const Identity& identity, const QVariantMap& additional)
 {
-#ifndef HAVE_SSL
-    Q_UNUSED(additional)
-#endif
-
     CoreIdentity coreIdentity(identity);
-#ifdef HAVE_SSL
     if (additional.contains("KeyPem"))
         coreIdentity.setSslKey(additional["KeyPem"].toByteArray());
     if (additional.contains("CertPem"))
         coreIdentity.setSslCert(additional["CertPem"].toByteArray());
-#endif
     qDebug() << Q_FUNC_INFO;
     IdentityId id = Core::createIdentity(user(), coreIdentity);
     if (!id.isValid())

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -134,9 +134,7 @@ void CoreSessionEventProcessor::processIrcEventAuthenticate(IrcEvent* e)
 
     CoreNetwork* net = coreNetwork(e);
 
-#ifdef HAVE_SSL
     if (net->identityPtr()->sslCert().isNull()) {
-#endif
         QString construct = net->saslAccount();
         construct.append(QChar(QChar::Null));
         construct.append(net->saslAccount());
@@ -145,12 +143,10 @@ void CoreSessionEventProcessor::processIrcEventAuthenticate(IrcEvent* e)
         QByteArray saslData = QByteArray(construct.toLatin1().toBase64());
         saslData.prepend("AUTHENTICATE ");
         net->putRawLine(saslData);
-#ifdef HAVE_SSL
     }
     else {
         net->putRawLine("AUTHENTICATE +");
     }
-#endif
 }
 
 void CoreSessionEventProcessor::processIrcEventCap(IrcEvent* e)

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -527,13 +527,8 @@ IdentityId PostgreSqlStorage::createIdentity(UserId user, CoreIdentity& identity
     query.bindValue(":kickreason", identity.kickReason());
     query.bindValue(":partreason", identity.partReason());
     query.bindValue(":quitreason", identity.quitReason());
-#ifdef HAVE_SSL
     query.bindValue(":sslcert", identity.sslCert().toPem());
     query.bindValue(":sslkey", identity.sslKey().toPem());
-#else
-    query.bindValue(":sslcert", QByteArray());
-    query.bindValue(":sslkey", QByteArray());
-#endif
     safeExec(query);
     if (!watchQuery(query)) {
         db.rollback();
@@ -610,13 +605,8 @@ bool PostgreSqlStorage::updateIdentity(UserId user, const CoreIdentity& identity
     query.bindValue(":kickreason", identity.kickReason());
     query.bindValue(":partreason", identity.partReason());
     query.bindValue(":quitreason", identity.quitReason());
-#ifdef HAVE_SSL
     query.bindValue(":sslcert", identity.sslCert().toPem());
     query.bindValue(":sslkey", identity.sslKey().toPem());
-#else
-    query.bindValue(":sslcert", QByteArray());
-    query.bindValue(":sslkey", QByteArray());
-#endif
     query.bindValue(":identityid", identity.id().toInt());
 
     safeExec(query);
@@ -717,10 +707,8 @@ std::vector<CoreIdentity> PostgreSqlStorage::identities(UserId user)
         identity.setKickReason(query.value(15).toString());
         identity.setPartReason(query.value(16).toString());
         identity.setQuitReason(query.value(17).toString());
-#ifdef HAVE_SSL
         identity.setSslCert(query.value(18).toByteArray());
         identity.setSslKey(query.value(19).toByteArray());
-#endif
 
         nickQuery.bindValue(":identityid", identity.id().toInt());
         QList<QString> nicks;

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -503,13 +503,8 @@ IdentityId SqliteStorage::createIdentity(UserId user, CoreIdentity& identity)
         query.bindValue(":kickreason", identity.kickReason());
         query.bindValue(":partreason", identity.partReason());
         query.bindValue(":quitreason", identity.quitReason());
-#ifdef HAVE_SSL
         query.bindValue(":sslcert", identity.sslCert().toPem());
         query.bindValue(":sslkey", identity.sslKey().toPem());
-#else
-        query.bindValue(":sslcert", QByteArray());
-        query.bindValue(":sslkey", QByteArray());
-#endif
 
         lockForWrite();
         safeExec(query);
@@ -581,13 +576,8 @@ bool SqliteStorage::updateIdentity(UserId user, const CoreIdentity& identity)
         query.bindValue(":kickreason", identity.kickReason());
         query.bindValue(":partreason", identity.partReason());
         query.bindValue(":quitreason", identity.quitReason());
-#ifdef HAVE_SSL
         query.bindValue(":sslcert", identity.sslCert().toPem());
         query.bindValue(":sslkey", identity.sslKey().toPem());
-#else
-        query.bindValue(":sslcert", QByteArray());
-        query.bindValue(":sslkey", QByteArray());
-#endif
         query.bindValue(":identityid", identity.id().toInt());
         safeExec(query);
         watchQuery(query);
@@ -687,10 +677,8 @@ std::vector<CoreIdentity> SqliteStorage::identities(UserId user)
             identity.setKickReason(query.value(15).toString());
             identity.setPartReason(query.value(16).toString());
             identity.setQuitReason(query.value(17).toString());
-#ifdef HAVE_SSL
             identity.setSslCert(query.value(18).toByteArray());
             identity.setSslKey(query.value(19).toByteArray());
-#endif
 
             nickQuery.bindValue(":identityid", identity.id().toInt());
             QList<QString> nicks;

--- a/src/core/sslserver.cpp
+++ b/src/core/sslserver.cpp
@@ -20,16 +20,11 @@
 
 #include "sslserver.h"
 
-#ifdef HAVE_SSL
-#    include <QSslSocket>
-#endif
-
 #include <QDateTime>
+#include <QSslSocket>
 
 #include "core.h"
 #include "quassel.h"
-
-#ifdef HAVE_SSL
 
 SslServer::SslServer(QObject* parent)
     : QTcpServer(parent)
@@ -235,5 +230,3 @@ void SslServer::setMetricsServer(MetricsServer* metricsServer) {
         _metricsServer->setCertificateExpires(_certificateExpires);
     }
 }
-
-#endif  // HAVE_SSL

--- a/src/core/sslserver.cpp
+++ b/src/core/sslserver.cpp
@@ -57,28 +57,19 @@ SslServer::SslServer(QObject* parent)
     }
 }
 
-QTcpSocket* SslServer::nextPendingConnection()
-{
-    if (_pendingConnections.isEmpty())
-        return nullptr;
-    else
-        return _pendingConnections.takeFirst();
-}
-
 void SslServer::incomingConnection(qintptr socketDescriptor)
 {
-    auto* serverSocket = new QSslSocket(this);
-    if (serverSocket->setSocketDescriptor(socketDescriptor)) {
+    auto* socket = new QSslSocket(this);
+    if (socket->setSocketDescriptor(socketDescriptor)) {
         if (isCertValid()) {
-            serverSocket->setLocalCertificate(_cert);
-            serverSocket->setPrivateKey(_key);
-            serverSocket->addCaCertificates(_ca);
+            socket->setLocalCertificate(_cert);
+            socket->setPrivateKey(_key);
+            socket->addCaCertificates(_ca);
         }
-        _pendingConnections << serverSocket;
-        emit newConnection();
+        addPendingConnection(socket);
     }
     else {
-        delete serverSocket;
+        delete socket;
     }
 }
 

--- a/src/core/sslserver.h
+++ b/src/core/sslserver.h
@@ -20,15 +20,13 @@
 
 #pragma once
 
-#ifdef HAVE_SSL
+#include <QFile>
+#include <QLinkedList>
+#include <QSslCertificate>
+#include <QSslKey>
+#include <QTcpServer>
 
-#    include <QFile>
-#    include <QLinkedList>
-#    include <QSslCertificate>
-#    include <QSslKey>
-#    include <QTcpServer>
-
-#    include "metricsserver.h"
+#include "metricsserver.h"
 
 class SslServer : public QTcpServer
 {
@@ -87,5 +85,3 @@ private:
 
     QDateTime _certificateExpires;
 };
-
-#endif  // HAVE_SSL

--- a/src/core/sslserver.h
+++ b/src/core/sslserver.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include <QFile>
-#include <QLinkedList>
 #include <QSslCertificate>
 #include <QSslKey>
 #include <QTcpServer>
@@ -34,9 +33,6 @@ class SslServer : public QTcpServer
 
 public:
     SslServer(QObject* parent = nullptr);
-
-    bool hasPendingConnections() const override { return !_pendingConnections.isEmpty(); }
-    QTcpSocket* nextPendingConnection() override;
 
     const QSslCertificate& certificate() const { return _cert; }
     const QSslKey& key() const { return _key; }
@@ -73,7 +69,6 @@ private:
 
     MetricsServer* _metricsServer{nullptr};
 
-    QLinkedList<QTcpSocket*> _pendingConnections;
     QSslCertificate _cert;
     QSslKey _key;
     QList<QSslCertificate> _ca;

--- a/src/qtui/CMakeLists.txt
+++ b/src/qtui/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(${TARGET} PRIVATE
     settingsdlg.cpp
     settingspagedlg.cpp
     simplenetworkeditor.cpp
+    sslinfodlg.cpp
     systemtray.cpp
     systrayanimationnotificationbackend.cpp
     systraynotificationbackend.cpp
@@ -80,6 +81,7 @@ target_sources(${TARGET} PRIVATE
     settingsdlg.ui
     settingspagedlg.ui
     simplenetworkeditor.ui
+    sslinfodlg.ui
     systrayanimationconfigwidget.ui
     topicwidget.ui
 )
@@ -170,13 +172,6 @@ if (HAVE_WEBENGINE)
     target_link_libraries(${TARGET} PRIVATE
         Qt5::WebEngine
         Qt5::WebEngineWidgets)
-endif()
-
-if (HAVE_SSL)
-    target_sources(${TARGET} PRIVATE
-        sslinfodlg.cpp
-        sslinfodlg.ui
-    )
 endif()
 
 if (LibsnoreQt5_FOUND)

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -91,6 +91,7 @@
 #include "resourcetreedlg.h"
 #include "settingsdlg.h"
 #include "settingspagedlg.h"
+#include "sslinfodlg.h"
 #include "statusnotifieritem.h"
 #include "toolbaractionprovider.h"
 #include "topicwidget.h"
@@ -112,10 +113,6 @@
 #    include "snorenotificationbackend.h"
 #endif
 
-#ifdef HAVE_SSL
-#    include "sslinfodlg.h"
-#endif
-
 #ifdef HAVE_NOTIFICATION_CENTER
 #    include "osxnotificationbackend.h"
 #endif
@@ -123,8 +120,6 @@
 #ifdef HAVE_DBUS
 #    include "dockmanagernotificationbackend.h"
 #endif
-
-#include <settingspages/corehighlightsettingspage.h>
 
 #include "settingspages/aliasessettingspage.h"
 #include "settingspages/appearancesettingspage.h"
@@ -136,6 +131,7 @@
 #include "settingspages/connectionsettingspage.h"
 #include "settingspages/coreaccountsettingspage.h"
 #include "settingspages/coreconnectionsettingspage.h"
+#include "settingspages/corehighlightsettingspage.h"
 #include "settingspages/dccsettingspage.h"
 #include "settingspages/highlightsettingspage.h"
 #include "settingspages/identitiessettingspage.h"
@@ -202,9 +198,7 @@ void MainWin::init()
     connect(Client::coreConnection(), &CoreConnection::userAuthenticationRequired, this, &MainWin::userAuthenticationRequired);
     connect(Client::coreConnection(), &CoreConnection::handleNoSslInClient, this, &MainWin::handleNoSslInClient);
     connect(Client::coreConnection(), &CoreConnection::handleNoSslInCore, this, &MainWin::handleNoSslInCore);
-#ifdef HAVE_SSL
     connect(Client::coreConnection(), &CoreConnection::handleSslErrors, this, &MainWin::handleSslErrors);
-#endif
 
     // Setup Dock Areas
     setDockNestingEnabled(true);
@@ -1380,8 +1374,6 @@ void MainWin::handleNoSslInCore(bool* accepted)
     *accepted = (box.exec() == QMessageBox::Ignore);
 }
 
-#ifdef HAVE_SSL
-
 void MainWin::handleSslErrors(const QSslSocket* socket, bool* accepted, bool* permanently)
 {
     QString errorString = "<ul>";
@@ -1419,8 +1411,6 @@ void MainWin::handleSslErrors(const QSslSocket* socket, bool* accepted, bool* pe
         *permanently = (box2.buttonRole(box2.clickedButton()) == QMessageBox::YesRole);
     }
 }
-
-#endif /* HAVE_SSL */
 
 void MainWin::handleCoreConnectionError(const QString& error)
 {

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -148,9 +148,7 @@ private slots:
     void userAuthenticationRequired(CoreAccount*, bool* valid, const QString& errorMessage);
     void handleNoSslInClient(bool* accepted);
     void handleNoSslInCore(bool* accepted);
-#ifdef HAVE_SSL
     void handleSslErrors(const QSslSocket* socket, bool* accepted, bool* permanently);
-#endif
 
     void onConfigureNetworksTriggered();
     void onConfigureViewsTriggered();

--- a/src/qtui/settingspages/identitiessettingspage.h
+++ b/src/qtui/settingspages/identitiessettingspage.h
@@ -57,9 +57,7 @@ private slots:
     void on_deleteIdentity_clicked();
     void on_renameIdentity_clicked();
 
-#ifdef HAVE_SSL
     void continueUnsecured();
-#endif
     void widgetHasChanged();
     void setWidgetStates();
 
@@ -78,12 +76,10 @@ private:
     void removeIdentity(Identity* identity);
     void renameIdentity(IdentityId id, const QString& newName);
 
-#ifdef HAVE_SSL
     QSslKey keyByFilename(const QString& filename);
     void showKeyState(const QSslKey& key);
     QSslCertificate certByFilename(const QString& filename);
     void showCertState(const QSslCertificate& cert);
-#endif
 
     bool testHasChanged();
 };

--- a/src/qtui/settingspages/identityeditwidget.cpp
+++ b/src/qtui/settingspages/identityeditwidget.cpp
@@ -75,12 +75,10 @@ IdentityEditWidget::IdentityEditWidget(QWidget* parent)
 
     ui.detachAwayEnabled->setVisible(!Client::internalCore());
 
-#ifdef HAVE_SSL
     ui.sslKeyGroupBox->setAcceptDrops(true);
     ui.sslKeyGroupBox->installEventFilter(this);
     ui.sslCertGroupBox->setAcceptDrops(true);
     ui.sslCertGroupBox->installEventFilter(this);
-#endif
 
     if (Client::isCoreFeatureEnabled(Quassel::Feature::AwayFormatTimestamp)) {
         // Core allows formatting %%timestamp%% messages in away strings.  Update tooltips.
@@ -172,10 +170,8 @@ void IdentityEditWidget::displayIdentity(CertIdentity* id, CertIdentity* saveId)
     ui.kickReason->setText(id->kickReason());
     ui.partReason->setText(id->partReason());
     ui.quitReason->setText(id->quitReason());
-#ifdef HAVE_SSL
     showKeyState(id->sslKey());
     showCertState(id->sslCert());
-#endif
 }
 
 void IdentityEditWidget::saveToIdentity(CertIdentity* id)
@@ -202,11 +198,9 @@ void IdentityEditWidget::saveToIdentity(CertIdentity* id)
     id->setKickReason(ui.kickReason->text().remove(linebreaks));
     id->setPartReason(ui.partReason->text().remove(linebreaks));
     id->setQuitReason(ui.quitReason->text().remove(linebreaks));
-#ifdef HAVE_SSL
     id->setSslKey(
         QSslKey(ui.keyTypeLabel->property("sslKey").toByteArray(), (QSsl::KeyAlgorithm)(ui.keyTypeLabel->property("sslKeyType").toInt())));
     id->setSslCert(QSslCertificate(ui.certOrgLabel->property("sslCert").toByteArray()));
-#endif
 }
 
 void IdentityEditWidget::on_addNick_clicked()
@@ -304,7 +298,6 @@ void IdentityEditWidget::setSslState(SslState state)
     }
 }
 
-#ifdef HAVE_SSL
 bool IdentityEditWidget::eventFilter(QObject* watched, QEvent* event)
 {
     bool isCert = (watched == ui.sslCertGroupBox);
@@ -464,5 +457,3 @@ void IdentityEditWidget::showCertState(const QSslCertificate& cert)
     }
     ui.certOrgLabel->setProperty("sslCert", cert.toPem());
 }
-
-#endif  // HAVE_SSL

--- a/src/qtui/settingspages/identityeditwidget.h
+++ b/src/qtui/settingspages/identityeditwidget.h
@@ -18,18 +18,15 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef IDENTITYEDITWIDGET_H
-#define IDENTITYEDITWIDGET_H
+#pragma once
+
+#include <QSslCertificate>
+#include <QSslKey>
+
+#include "clientidentity.h"
 
 #include "ui_identityeditwidget.h"
 #include "ui_nickeditdlg.h"
-
-#ifdef HAVE_SSL
-#    include <QSslCertificate>
-#    include <QSslKey>
-#endif
-
-#include "clientidentity.h"
 
 class IdentityEditWidget : public QWidget
 {
@@ -53,9 +50,7 @@ public slots:
     void showAdvanced(bool advanced);
 
 protected:
-#ifdef HAVE_SSL
     bool eventFilter(QObject* watched, QEvent* event) override;
-#endif
 
 signals:
     void requestEditSsl();
@@ -68,27 +63,21 @@ private slots:
     void on_nickUp_clicked();
     void on_nickDown_clicked();
 
-#ifdef HAVE_SSL
     void on_clearOrLoadKeyButton_clicked();
     void on_clearOrLoadCertButton_clicked();
-#endif
     void setWidgetStates();
 
-#ifdef HAVE_SSL
     void sslDragEnterEvent(QDragEnterEvent* event);
     void sslDropEvent(QDropEvent* event, bool isCert);
-#endif
 
 private:
     Ui::IdentityEditWidget ui;
     bool _editSsl;
 
-#ifdef HAVE_SSL
     QSslKey keyByFilename(const QString& filename);
     void showKeyState(const QSslKey& key);
     QSslCertificate certByFilename(const QString& filename);
     void showCertState(const QSslCertificate& cert);
-#endif
 
     bool testHasChanged();
 };
@@ -111,5 +100,3 @@ private:
     QString oldNick;
     QStringList existing;
 };
-
-#endif  // IDENTITYEDITWIDGET_H

--- a/src/qtui/settingspages/networkssettingspage.cpp
+++ b/src/qtui/settingspages/networkssettingspage.cpp
@@ -50,9 +50,6 @@ NetworksSettingsPage::NetworksSettingsPage(QWidget* parent)
         ui.sasl->hide();
     if (!Client::isCoreFeatureEnabled(Quassel::Feature::SaslExternal))
         ui.saslExtInfo->hide();
-#ifndef HAVE_SSL
-    ui.saslExtInfo->hide();
-#endif
 
     // set up icons
     ui.renameNetwork->setIcon(icon::get("edit-rename"));
@@ -180,11 +177,9 @@ void NetworksSettingsPage::load()
                                                         "modify message rate limits.")));
     }
 
-#ifdef HAVE_SSL
     // Hide the SASL EXTERNAL notice until a network's shown.  Stops it from showing while loading
     // backlog from the core.
     sslUpdated();
-#endif
 
     // Reset network capability status in case no valid networks get selected (a rare situation)
     resetNetworkCapStates();
@@ -575,7 +570,6 @@ void NetworksSettingsPage::displayNetwork(NetworkId id)
     if (id != 0) {
         NetworkInfo info = networkInfos[id];
 
-#ifdef HAVE_SSL
         // this is only needed when the core supports SASL EXTERNAL
         if (Client::isCoreFeatureEnabled(Quassel::Feature::SaslExternal)) {
             if (_cid) {
@@ -586,7 +580,6 @@ void NetworksSettingsPage::displayNetwork(NetworkId id)
             _cid->enableEditSsl(true);
             connect(_cid, &CertIdentity::sslSettingsUpdated, this, &NetworksSettingsPage::sslUpdated);
         }
-#endif
 
         ui.identityList->setCurrentIndex(ui.identityList->findData(info.identity.toInt()));
         ui.serverList->clear();
@@ -635,12 +628,10 @@ void NetworksSettingsPage::displayNetwork(NetworkId id)
     }
     else {
         // just clear widgets
-#ifdef HAVE_SSL
         if (_cid) {
             disconnect(_cid, &CertIdentity::sslSettingsUpdated, this, &NetworksSettingsPage::sslUpdated);
             delete _cid;
         }
-#endif
         ui.identityList->setCurrentIndex(-1);
         ui.serverList->clear();
         ui.performEdit->clear();
@@ -737,7 +728,6 @@ void NetworksSettingsPage::setSASLStatus(const CapSupportStatus saslStatus)
     }
 }
 
-#ifdef HAVE_SSL
 void NetworksSettingsPage::sslUpdated()
 {
     if (_cid && !_cid->sslKey().isNull()) {
@@ -760,7 +750,6 @@ void NetworksSettingsPage::sslUpdated()
         ui.saslExtInfo->setHidden(true);
     }
 }
-#endif
 
 /*** Network list ***/
 

--- a/src/qtui/settingspages/networkssettingspage.h
+++ b/src/qtui/settingspages/networkssettingspage.h
@@ -92,9 +92,7 @@ private slots:
      */
     void clientNetworkCapsUpdated();
 
-#ifdef HAVE_SSL
     void sslUpdated();
-#endif
 
     void on_networkList_itemSelectionChanged();
     void on_addNetwork_clicked();
@@ -134,9 +132,7 @@ private:
     NetworkId currentId;
     QHash<NetworkId, NetworkInfo> networkInfos;
     bool _ignoreWidgetChanges{false};
-#ifdef HAVE_SSL
     CertIdentity* _cid{nullptr};
-#endif
 
     QIcon connectedIcon, connectingIcon, disconnectedIcon;
 


### PR DESCRIPTION
There is no sane reason for not using SSL in the year 2020, plus every distro should be shipping the Qt libraries with SSL support enabled. Thus, make it mandatory for Quassel, too.

This allows us to remove lots of fallback code paths that make the code much more complex in many places, and that have not been tested (or even been built) in a long time.

Thanks to @justjanne for doing the heavy lifting of removing `HAVE_SSL`-protected fallback code throughout the whole code base!