### PR TITLE
common: Make SyncableObject non-copyable

### DIFF
--- a/src/common/aliasmanager.cpp
+++ b/src/common/aliasmanager.cpp
@@ -25,16 +25,6 @@
 
 #include "network.h"
 
-AliasManager& AliasManager::operator=(const AliasManager& other)
-{
-    if (this == &other)
-        return *this;
-
-    SyncableObject::operator=(other);
-    _aliases = other._aliases;
-    return *this;
-}
-
 int AliasManager::indexOf(const QString& name) const
 {
     for (int i = 0; i < _aliases.count(); i++) {

--- a/src/common/aliasmanager.h
+++ b/src/common/aliasmanager.h
@@ -42,7 +42,6 @@ public:
     {
         setAllowClientUpdates(true);
     }
-    AliasManager& operator=(const AliasManager& other);
 
     struct Alias
     {

--- a/src/common/highlightrulemanager.cpp
+++ b/src/common/highlightrulemanager.cpp
@@ -25,18 +25,6 @@
 #include "expressionmatch.h"
 #include "util.h"
 
-HighlightRuleManager& HighlightRuleManager::operator=(const HighlightRuleManager& other)
-{
-    if (this == &other)
-        return *this;
-
-    SyncableObject::operator=(other);
-    _highlightRuleList = other._highlightRuleList;
-    _nicksCaseSensitive = other._nicksCaseSensitive;
-    _highlightNick = other._highlightNick;
-    return *this;
-}
-
 int HighlightRuleManager::indexOf(int id) const
 {
     for (int i = 0; i < _highlightRuleList.count(); i++) {

--- a/src/common/highlightrulemanager.h
+++ b/src/common/highlightrulemanager.h
@@ -55,7 +55,6 @@ public:
     {
         setAllowClientUpdates(true);
     }
-    HighlightRuleManager& operator=(const HighlightRuleManager& other);
 
     /**
      * Individual highlight rule

--- a/src/common/ignorelistmanager.cpp
+++ b/src/common/ignorelistmanager.cpp
@@ -23,16 +23,6 @@
 #include <QDebug>
 #include <QStringList>
 
-IgnoreListManager& IgnoreListManager::operator=(const IgnoreListManager& other)
-{
-    if (this == &other)
-        return *this;
-
-    SyncableObject::operator=(other);
-    _ignoreList = other._ignoreList;
-    return *this;
-}
-
 int IgnoreListManager::indexOf(const QString& ignore) const
 {
     for (int i = 0; i < _ignoreList.count(); i++) {

--- a/src/common/ignorelistmanager.h
+++ b/src/common/ignorelistmanager.h
@@ -43,7 +43,6 @@ public:
     {
         setAllowClientUpdates(true);
     }
-    IgnoreListManager& operator=(const IgnoreListManager& other);
 
     enum IgnoreType
     {

--- a/src/common/syncableobject.cpp
+++ b/src/common/syncableobject.cpp
@@ -44,13 +44,6 @@ SyncableObject::SyncableObject(const QString& objectName, QObject* parent)
     });
 }
 
-SyncableObject::SyncableObject(const SyncableObject& other, QObject* parent)
-    : SyncableObject(QString{}, parent)
-{
-    _initialized = other._initialized;
-    _allowClientUpdates = other._allowClientUpdates;
-}
-
 SyncableObject::~SyncableObject()
 {
     QList<SignalProxy*>::iterator proxyIter = _signalProxies.begin();
@@ -59,16 +52,6 @@ SyncableObject::~SyncableObject()
         proxyIter = _signalProxies.erase(proxyIter);
         proxy->stopSynchronize(this);
     }
-}
-
-SyncableObject& SyncableObject::operator=(const SyncableObject& other)
-{
-    if (this == &other)
-        return *this;
-
-    _initialized = other._initialized;
-    _allowClientUpdates = other._allowClientUpdates;
-    return *this;
 }
 
 bool SyncableObject::isInitialized() const

--- a/src/common/syncableobject.h
+++ b/src/common/syncableobject.h
@@ -58,7 +58,6 @@ class COMMON_EXPORT SyncableObject : public QObject
 public:
     SyncableObject(QObject* parent = nullptr);
     SyncableObject(const QString& objectName, QObject* parent = nullptr);
-    SyncableObject(const SyncableObject& other, QObject* parent = nullptr);
     ~SyncableObject() override;
 
     //! Stores the object's state into a QVariantMap.
@@ -93,8 +92,6 @@ public slots:
 
 protected:
     void sync_call__(SignalProxy::ProxyMode modeType, const char* funcname, ...) const;
-
-    SyncableObject& operator=(const SyncableObject& other);
 
 signals:
     void initDone();

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -34,7 +34,6 @@ public:
 
     std::unique_ptr<AbstractSqlMigrationWriter> createMigrationWriter() override;
 
-public slots:
     /* General */
     bool isAvailable() const override;
     QString backendId() const override;

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -38,7 +38,6 @@ public:
 
     std::unique_ptr<AbstractSqlMigrationReader> createMigrationReader() override;
 
-public slots:
     /* General */
 
     bool isAvailable() const override;

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -56,7 +56,6 @@ public:
 
     };
 
-public slots:
     /* General */
 
     //! Check if the storage type is available.

--- a/src/qtui/settingspages/aliasesmodel.h
+++ b/src/qtui/settingspages/aliasesmodel.h
@@ -18,11 +18,11 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef ALIASESMODEL_H
-#define ALIASESMODEL_H
+#pragma once
+
+#include <memory>
 
 #include <QAbstractItemModel>
-#include <QPointer>
 
 #include "clientaliasmanager.h"
 
@@ -47,7 +47,7 @@ public:
     inline int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     inline int columnCount(const QModelIndex& parent = QModelIndex()) const override;
 
-    inline bool hasConfigChanged() const { return _configChanged; }
+    inline bool hasConfigChanged() const { return static_cast<bool>(_clonedAliasManager); }
     inline bool isReady() const { return _modelReady; }
 
 public slots:
@@ -62,8 +62,7 @@ signals:
     void modelReady(bool);
 
 private:
-    ClientAliasManager _clonedAliasManager;
-    bool _configChanged{false};
+    std::unique_ptr<ClientAliasManager> _clonedAliasManager;
     bool _modelReady{false};
 
     const AliasManager& aliasManager() const;
@@ -88,5 +87,3 @@ int AliasesModel::columnCount(const QModelIndex& parent) const
     Q_UNUSED(parent);
     return isReady() ? 2 : 0;
 }
-
-#endif  // ALIASESMODEL_H

--- a/src/qtui/settingspages/corehighlightsettingspage.cpp
+++ b/src/qtui/settingspages/corehighlightsettingspage.cpp
@@ -620,7 +620,7 @@ void CoreHighlightSettingsPage::save()
     if (ruleManager == nullptr)
         return;
 
-    auto clonedManager = HighlightRuleManager();
+    HighlightRuleManager clonedManager;
     clonedManager.fromVariantMap(ruleManager->toVariantMap());
     clonedManager.clear();
 
@@ -734,7 +734,7 @@ void CoreHighlightSettingsPage::importRules()
         save();
     }
 
-    auto clonedManager = HighlightRuleManager();
+    HighlightRuleManager clonedManager;
     clonedManager.fromVariantMap(Client::highlightRuleManager()->toVariantMap());
 
     for (const auto& variant : notificationSettings.highlightList()) {

--- a/src/qtui/settingspages/dccsettingspage.cpp
+++ b/src/qtui/settingspages/dccsettingspage.cpp
@@ -81,14 +81,14 @@ bool DccSettingsPage::hasDefaults() const
 
 void DccSettingsPage::defaults()
 {
-    _localConfig = DccConfig();
+    _localConfig.fromVariantMap(DccConfig{}.toVariantMap());
     SettingsPage::load();
     widgetHasChanged();
 }
 
 void DccSettingsPage::load()
 {
-    _localConfig = isClientConfigValid() ? *_clientConfig : DccConfig{};
+    _localConfig.fromVariantMap(isClientConfigValid() ? _clientConfig->toVariantMap() : DccConfig{}.toVariantMap());
     SettingsPage::load();
     widgetHasChanged();
 }

--- a/src/qtui/settingspages/ignorelistmodel.h
+++ b/src/qtui/settingspages/ignorelistmodel.h
@@ -18,11 +18,11 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef IGNORELISTMODEL_H
-#define IGNORELISTMODEL_H
+#pragma once
+
+#include <memory>
 
 #include <QAbstractItemModel>
-#include <QPointer>
 
 #include "clientignorelistmanager.h"
 
@@ -47,7 +47,7 @@ public:
     inline int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     inline int columnCount(const QModelIndex& parent = QModelIndex()) const override;
 
-    inline bool hasConfigChanged() const { return _configChanged; }
+    inline bool hasConfigChanged() const { return static_cast<bool>(_clonedIgnoreListManager); }
     inline bool isReady() const { return _modelReady; }
 
     const IgnoreListManager::IgnoreListItem& ignoreListItemAt(int row) const;
@@ -66,8 +66,7 @@ signals:
     void modelReady(bool);
 
 private:
-    ClientIgnoreListManager _clonedIgnoreListManager;
-    bool _configChanged{false};
+    std::unique_ptr<ClientIgnoreListManager> _clonedIgnoreListManager;
     bool _modelReady{false};
 
     const IgnoreListManager& ignoreListManager() const;
@@ -92,5 +91,3 @@ int IgnoreListModel::columnCount(const QModelIndex& parent) const
     Q_UNUSED(parent);
     return isReady() ? 3 : 0;
 }
-
-#endif  // IGNORELISTMODEL_H


### PR DESCRIPTION
QObjects are non-copyable for good reasons. SyncableObject, although
deriving from QObject, was made sort-of copyable by adding custom copy
ctor and copy assignment operator that did not make a full copy of the
underlying QObject, but just copied (most) properties. Several classes
deriving from SyncableObject then implemented their own versions of
those special member functions on top of that. This was not only
rather unexpected and intransparent behavior due to the incomplete
copy functionality, but also a most fragile hack since one had to
remember to update those functions when adding or modifying
properties.

In addition, newer compilers apply a somewhat stricter interpretation
of the C++ standard, basically enforcing the Rule of Three by omitting
implicit generation of copy ctor and/or copy assignment operating
in case certain user-defined special member functions exist. In
particular, Clang 10 started to emit several warnings (and we already
worked around a similar warning from GCC 9+ in cc21148).

Instead of adding more workarounds further obfuscating matters, remove
the relevant special member functions altogether and thus make
SyncableObject and its derivatives non-copyable as they should be.
Modify affected code to cope with this cleanly, and without abusing
unexpected behavior.