### PR TITLE
Start a CocoaHelper class for macOS 10.12 and add a few improvements to the client

### DIFF
--- a/src/common/message.cpp
+++ b/src/common/message.cpp
@@ -132,9 +132,20 @@ QDataStream& operator>>(QDataStream& in, Message& msg)
     in >> sender;
     msg._sender = QString::fromUtf8(sender);
 
-    QByteArray senderPrefixes;
+    QByteArray receivedPrefixes;
     if (SignalProxy::current()->sourcePeer()->hasFeature(Quassel::Feature::SenderPrefixes))
-        in >> senderPrefixes;
+        in >> receivedPrefixes;
+
+    QByteArray prefixes = "!~@%+";
+    QByteArray senderPrefixes;
+    for (char c : prefixes) {
+       if (receivedPrefixes.indexOf(c) != -1) {
+           senderPrefixes[0] = c;
+           senderPrefixes[1] = '\0';
+           break;
+       }
+    }
+
     msg._senderPrefixes = QString::fromUtf8(senderPrefixes);
 
     QByteArray realName;

--- a/src/qtui/CMakeLists.txt
+++ b/src/qtui/CMakeLists.txt
@@ -188,6 +188,12 @@ if (LibsnoreQt5_FOUND)
     target_link_libraries(${TARGET} PRIVATE Snore::Libsnore Snore::LibsnoreSettings)
 endif()
 
+if (APPLE)
+    list(APPEND SOURCES cocoahelper.mm)
+    list(APPEND LIBS "/System/Library/Frameworks/Cocoa.framework"
+                     "/System/Library/Frameworks/Foundation.framework")
+endif()
+
 if (WITH_NOTIFICATION_CENTER)
     target_compile_definitions(${TARGET} PRIVATE -DHAVE_NOTIFICATION_CENTER)
     target_sources(${TARGET} PRIVATE osxnotificationbackend.mm)

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -637,7 +637,13 @@ qreal ContentsChatItem::setGeometryByWidth(qreal w)
     WrapColumnFinder finder(this);
     while (finder.nextWrapColumn(w) > 0)
         lines++;
-    qreal spacing = qMax(fontMetrics()->lineSpacing(), fontMetrics()->height());  // cope with negative leading()
+
+#ifdef Q_OS_MAC
+    qreal spacing = qMax(fontMetrics()->lineSpacing(), fontMetrics()->height()) * 1.1; // cope with negative leading()
+#else
+    qreal spacing = qMax(fontMetrics()->lineSpacing(), fontMetrics()->height()) * 1.1; // cope with negative leading()
+#endif
+
     qreal h = lines * spacing;
     delete _data;
     _data = nullptr;
@@ -661,7 +667,7 @@ void ContentsChatItem::doLayout(QTextLayout* layout) const
         return;  // empty chatitem
 
     qreal h = 0;
-    qreal spacing = qMax(fontMetrics()->lineSpacing(), fontMetrics()->height());  // cope with negative leading()
+    qreal spacing = qMax(fontMetrics()->lineSpacing(), fontMetrics()->height()) * 1.1; // cope with negative leading()
     WrapColumnFinder finder(this);
     layout->beginLayout();
     forever

--- a/src/qtui/chatlinemodelitem.cpp
+++ b/src/qtui/chatlinemodelitem.cpp
@@ -168,8 +168,14 @@ UiStyle::MessageLabel ChatLineModelItem::messageLabel() const
 
 QVariant ChatLineModelItem::backgroundBrush(UiStyle::FormatType subelement, bool selected) const
 {
-    QTextCharFormat fmt = QtUi::style()->format({UiStyle::formatType(_styledMsg.type()) | subelement, {}, {}},
-                                                messageLabel() | (selected ? UiStyle::MessageLabel::Selected : UiStyle::MessageLabel::None));
+    QTextCharFormat fmt = QtUi::style()->format(
+        {UiStyle::formatType(_styledMsg.type()) | subelement, {}, {}},
+        messageLabel() |
+        (selected ?
+            UiStyle::MessageLabel::Selected :
+            UiStyle::MessageLabel::None)
+    );
+
     if (fmt.hasProperty(QTextFormat::BackgroundBrush))
         return QVariant::fromValue(fmt.background());
     return QVariant();

--- a/src/qtui/cocoahelper.h
+++ b/src/qtui/cocoahelper.h
@@ -1,0 +1,37 @@
+/* 
+ * Copyright (c) 2018 xi <xi@nuxi.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <QVector>
+#include <QMenu>
+#include <QMenuBar>
+
+class CocoaHelper {
+	public:
+		static void configure(long winId = -1);
+		static QMenu *makeEditMenu(QMenuBar *, QObject *);
+		static void setDarkTitlebar(bool);
+		static bool getDarkTitlebar(void);
+};

--- a/src/qtui/cocoahelper.h
+++ b/src/qtui/cocoahelper.h
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2018 xi <xi@nuxi.ca>
+ * Copyright (c) 2018-2020 Laurent Cimon <laurent@nilio.ca>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/qtui/cocoahelper.mm
+++ b/src/qtui/cocoahelper.mm
@@ -1,15 +1,15 @@
 /* 
- * Copyright (c) 2018 xi <xi@nuxi.ca>
+ * Copyright (c) 2018-2020 Laurent Cimon <laurent@nilio.ca>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, object
+ * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    object list of conditions and the following disclaimer in the documentation
+ *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -23,6 +23,18 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include <QVector>
+#include <QMenu>
+#include <QMenuBar>
+
+class CocoaHelper {
+	public:
+		static void configure(long winId = -1);
+		static QMenu *makeEditMenu(QMenuBar *, QObject *);
+		static void setDarkTitlebar(bool);
+		static bool getDarkTitlebar(void);
+};
 
 #include <Cocoa/Cocoa.h>
 #include <QGuiApplication>

--- a/src/qtui/cocoahelper.mm
+++ b/src/qtui/cocoahelper.mm
@@ -1,0 +1,141 @@
+/* 
+ * Copyright (c) 2018 xi <xi@nuxi.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, object
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    object list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Cocoa/Cocoa.h>
+#include <QGuiApplication>
+#include <QWindow>
+
+#include "cocoahelper.h"
+
+static bool darkTitlebarSetting = 1;
+static void initNativeConfig(NSWindow *nw);
+static void setTitlebarColour(NSWindow *nw);
+static QVector<long> getWinIds();
+
+void
+CocoaHelper::configure(long winId)
+{
+	QVector<long> winIds;
+
+	if(winId == -1) {
+		winIds = getWinIds();
+	} else {
+		winIds.append(winId);
+	}
+
+	for (long id : winIds) {
+		NSView *nativeView = reinterpret_cast<NSView *>(id);
+		NSWindow *nativeWindow = [nativeView window];
+		initNativeConfig(nativeWindow);
+	}
+
+	return;
+}
+
+QMenu *
+CocoaHelper::makeEditMenu(QMenuBar *menubar, QObject *parent)
+{
+	QMenu *menu = menubar->addMenu(QObject::tr("&Edit"));
+
+	QAction *undoAct = new QAction(QObject::tr("&Undo"), parent);
+	undoAct->setShortcuts(QKeySequence::Undo);
+
+	QAction *redoAct = new QAction(QObject::tr("&Redo"), parent);
+	redoAct->setShortcuts(QKeySequence::Redo);
+
+	QAction *cutAct = new QAction(QObject::tr("Cu&t"), parent);
+	cutAct->setShortcuts(QKeySequence::Cut);
+	cutAct->setStatusTip(QObject::tr("Cut the current selection's"
+	    " contents to the clipboard"));
+
+	QAction *copyAct = new QAction(QObject::tr("&Copy"), parent);
+	copyAct->setShortcuts(QKeySequence::Copy);
+	copyAct->setStatusTip(QObject::tr("Copy the current selection's"
+	    " contents to the clipboard"));
+
+	QAction *pasteAct = new QAction(QObject::tr("&Paste"), parent);
+	pasteAct->setShortcuts(QKeySequence::Paste);
+	pasteAct->setStatusTip(QObject::tr("Paste the clipboard's"
+	    " contents into the current selection"));
+
+	menu->addAction(undoAct);
+	menu->addAction(redoAct);
+	menu->addSeparator();
+	menu->addAction(cutAct);
+	menu->addAction(copyAct);
+	menu->addAction(pasteAct);
+	return menu;
+}
+
+void
+CocoaHelper::setDarkTitlebar(bool setting)
+{
+	darkTitlebarSetting = setting;
+	return;
+}
+
+bool
+CocoaHelper::getDarkTitlebar()
+{
+	return darkTitlebarSetting;
+}
+
+static void
+setTitlebarColour(NSWindow *nw)
+{
+	if (darkTitlebarSetting) {
+		[nw setAppearance:
+		    [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark]];
+	} else {
+		[nw setAppearance:
+		    [NSAppearance appearanceNamed:NSAppearanceNameAqua]];
+		[nw setBackgroundColor: [NSColor blackColor]];
+	}
+
+	return;
+}
+
+static void
+initNativeConfig(NSWindow *nw)
+{
+	setTitlebarColour(nw);
+	return;
+}
+
+static QVector<long>
+getWinIds()
+{
+	QVector<long> winIds;
+	QWindowList windows = QGuiApplication::allWindows();
+	if (windows.empty())
+		/* There is no window, abort */
+		return winIds;
+
+	for (QWindow *qwin : windows)
+		winIds.append(qwin->winId());
+
+	return winIds;
+}

--- a/src/qtui/inputwidget.cpp
+++ b/src/qtui/inputwidget.cpp
@@ -498,7 +498,11 @@ void InputWidget::changeNick(const QString& newNick) const
 
 void InputWidget::onTextEntered(const QString& text)
 {
-    Client::userInput(currentBufferInfo(), text);
+    QString output = UiStyle::makeIrcReadable(text);
+    Client::userInput(currentBufferInfo(), output);
+    ui.boldButton->setChecked(false);
+    ui.underlineButton->setChecked(false);
+    ui.italicButton->setChecked(false);
 
     // Remove formatting from entered text
     // TODO: Offer a way to convert pasted text to mIRC formatting codes

--- a/src/qtui/inputwidget.cpp
+++ b/src/qtui/inputwidget.cpp
@@ -498,8 +498,7 @@ void InputWidget::changeNick(const QString& newNick) const
 
 void InputWidget::onTextEntered(const QString& text)
 {
-    QString output = UiStyle::makeIrcReadable(text);
-    Client::userInput(currentBufferInfo(), output);
+    Client::userInput(currentBufferInfo(), text);
     ui.boldButton->setChecked(false);
     ui.underlineButton->setChecked(false);
     ui.italicButton->setChecked(false);

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -97,6 +97,10 @@
 #include "transfermodel.h"
 #include "verticaldock.h"
 
+#ifdef Q_OS_MAC
+#include "cocoahelper.h"
+#endif
+
 #ifndef HAVE_KDE
 #    ifdef HAVE_QTMULTIMEDIA
 #        include "qtmultimedianotificationbackend.h"
@@ -593,6 +597,10 @@ void MainWin::setupMenus()
         flagRemoteCoreOnly(coreAction);
     }
     flagRemoteCoreOnly(_fileMenu->addSeparator());
+
+#ifdef Q_OS_MAC
+    _editMenu = CocoaHelper::makeEditMenu(menuBar(), this);
+#endif
 
     _networksMenu = _fileMenu->addMenu(tr("&Networks"));
     _networksMenu->addAction(coll->action("ConfigureNetworks"));

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -269,6 +269,10 @@ private:
 
     QAction* _fullScreenAction{nullptr};
     QMenu *_fileMenu, *_networksMenu, *_viewMenu, *_bufferViewsMenu, *_settingsMenu, *_helpMenu, *_helpDebugMenu;
+#ifdef Q_OS_MAC
+    QMenu *_editMenu;
+#endif
+
     QMenu* _toolbarMenu;
     QToolBar *_mainToolBar, *_chatViewToolBar, *_nickToolBar;
 

--- a/src/qtui/qtuiapplication.cpp
+++ b/src/qtui/qtuiapplication.cpp
@@ -30,7 +30,11 @@
 #include "qtuisettings.h"
 #include "types.h"
 
-QtUiApplication::QtUiApplication(int& argc, char** argv)
+#ifdef Q_OS_MAC
+#include "cocoahelper.h"
+#endif
+
+QtUiApplication::QtUiApplication(int &argc, char **argv)
     : QApplication(argc, argv)
 {
 #if QT_VERSION >= 0x050600
@@ -58,6 +62,10 @@ void QtUiApplication::init()
 
         // Needs to happen after UI init, so the MainWin quit handler is registered first
         Quassel::registerQuitHandler(quitHandler());
+
+#ifdef Q_OS_MAC
+        CocoaHelper::configure();
+#endif
 
         resumeSessionIfPossible();
     });

--- a/src/qtui/topicwidget.cpp
+++ b/src/qtui/topicwidget.cpp
@@ -196,12 +196,10 @@ void TopicWidget::on_topicLineEdit_textEntered()
     QModelIndex currentIdx = currentIndex();
     if (currentIdx.isValid() && currentIdx.data(NetworkModel::BufferTypeRole) == BufferInfo::ChannelBuffer) {
         BufferInfo bufferInfo = currentIdx.data(NetworkModel::BufferInfoRole).value<BufferInfo>();
-        if (ui.topicLineEdit->text().isEmpty()) {
+        if (ui.topicLineEdit->text().isEmpty())
             Client::userInput(bufferInfo, QString("/quote TOPIC %1 :").arg(bufferInfo.bufferName()));
-        } else {
-            QString newTopic = UiStyle::makeIrcReadable(ui.topicLineEdit->text());
-            Client::userInput(bufferInfo, QString("/topic %1").arg(newTopic));
-	}
+        else
+            Client::userInput(bufferInfo, QString("/topic %1").arg(ui.topicLineEdit->text()));
     }
     switchPlain();
 }
@@ -213,18 +211,14 @@ void TopicWidget::on_topicEditButton_clicked()
 
 void TopicWidget::switchEditable()
 {
-    _topic = UiStyle::makeHumanReadable(_topic);
-    ui.topicLineEdit->setText(_topic);
     ui.stackedWidget->setCurrentIndex(1);
     ui.topicLineEdit->setFocus();
     ui.topicLineEdit->moveCursor(QTextCursor::End, QTextCursor::MoveAnchor);
-
     updateGeometry();
 }
 
 void TopicWidget::switchPlain()
 {
-    _topic = UiStyle::makeIrcReadable(_topic);
     ui.stackedWidget->setCurrentIndex(0);
     ui.topicLineEdit->setPlainText(_topic);
     updateGeometry();
@@ -265,7 +259,6 @@ QString TopicWidget::sanitizeTopic(const QString& topic)
     result.replace(QChar::CarriageReturn, " ");
     result.replace(QChar::ParagraphSeparator, " ");
     result.replace(QChar::LineSeparator, " ");
-    result = UiStyle::makeIrcReadable(result);
 
     return result;
 }

--- a/src/uisupport/uistyle.cpp
+++ b/src/uisupport/uistyle.cpp
@@ -343,47 +343,6 @@ QVariant UiStyle::bufferViewItemData(const QModelIndex& index, int role) const
     return itemData(role, fmt);
 }
 
-QString
-UiStyle::makeHumanReadable(const QString &s)
-{
-    QString line(s);
-
-    line.replace(QLatin1Char('\x02'), QStringLiteral("%B"));       // replace bold char with %B
-    line.replace(QLatin1Char('\x03'), QStringLiteral("%C"));       // replace color char with %C
-    line.replace(QLatin1Char('\x07'), QStringLiteral("%G"));       // replace ASCII BEL 0x07 with %G
-    line.replace(QLatin1Char('\x1d'), QStringLiteral("%I"));       // replace italics char with %I
-    line.replace(QLatin1Char('\x0f'), QStringLiteral("%O"));       // replace reset to default char with %O
-    line.replace(QLatin1Char('\x13'), QStringLiteral("%S"));       // replace strikethru char with %S
-    line.replace(QLatin1Char('\x16'), QStringLiteral("%R"));       // replace reverse char with %R
-    // underline char send by kvirc
-    line.replace(QLatin1Char('\x1f'), QStringLiteral("%U"));       // replace underline char with %U
-    // underline char send by mirc
-    line.replace(QLatin1Char('\x15'), QStringLiteral("%U"));       // replace underline char with %U
-
-    return line;
-}
-
-
-QString
-UiStyle::makeIrcReadable(const QString &s)
-{
-    QString line(s);
-
-    line.replace(QStringLiteral("%%"),QStringLiteral("%\x01"));      // make sure to protect double %%
-    line.replace(QStringLiteral("%B"),QStringLiteral("\x02"));       // replace %B with bold char
-    line.replace(QStringLiteral("%C"),QStringLiteral("\x03"));       // replace %C with color char
-    line.replace(QStringLiteral("%G"),QStringLiteral("\x07"));       // replace %G with ASCII BEL 0x07
-    line.replace(QStringLiteral("%I"),QStringLiteral("\x1d"));       // replace %I with italics char
-    line.replace(QStringLiteral("%O"),QStringLiteral("\x0f"));       // replace %O with reset to default char
-    line.replace(QStringLiteral("%S"),QStringLiteral("\x13"));       // replace %S with strikethru char
-    line.replace(QStringLiteral("%R"),QStringLiteral("\x16"));       // replace %R with reverse char
-    line.replace(QStringLiteral("%U"),QStringLiteral("\x1f"));       // replace %U with underline char
-    line.replace(QStringLiteral("%\x01"),QStringLiteral("%"));       // restore double %% as single %
-
-    return line;
-}
-
-
 QVariant UiStyle::nickViewItemData(const QModelIndex& index, int role) const
 {
     NetworkModel::ItemType type = (NetworkModel::ItemType)index.data(NetworkModel::ItemTypeRole).toInt();

--- a/src/uisupport/uistyle.cpp
+++ b/src/uisupport/uistyle.cpp
@@ -343,6 +343,47 @@ QVariant UiStyle::bufferViewItemData(const QModelIndex& index, int role) const
     return itemData(role, fmt);
 }
 
+QString
+UiStyle::makeHumanReadable(const QString &s)
+{
+    QString line(s);
+
+    line.replace(QLatin1Char('\x02'), QStringLiteral("%B"));       // replace bold char with %B
+    line.replace(QLatin1Char('\x03'), QStringLiteral("%C"));       // replace color char with %C
+    line.replace(QLatin1Char('\x07'), QStringLiteral("%G"));       // replace ASCII BEL 0x07 with %G
+    line.replace(QLatin1Char('\x1d'), QStringLiteral("%I"));       // replace italics char with %I
+    line.replace(QLatin1Char('\x0f'), QStringLiteral("%O"));       // replace reset to default char with %O
+    line.replace(QLatin1Char('\x13'), QStringLiteral("%S"));       // replace strikethru char with %S
+    line.replace(QLatin1Char('\x16'), QStringLiteral("%R"));       // replace reverse char with %R
+    // underline char send by kvirc
+    line.replace(QLatin1Char('\x1f'), QStringLiteral("%U"));       // replace underline char with %U
+    // underline char send by mirc
+    line.replace(QLatin1Char('\x15'), QStringLiteral("%U"));       // replace underline char with %U
+
+    return line;
+}
+
+
+QString
+UiStyle::makeIrcReadable(const QString &s)
+{
+    QString line(s);
+
+    line.replace(QStringLiteral("%%"),QStringLiteral("%\x01"));      // make sure to protect double %%
+    line.replace(QStringLiteral("%B"),QStringLiteral("\x02"));       // replace %B with bold char
+    line.replace(QStringLiteral("%C"),QStringLiteral("\x03"));       // replace %C with color char
+    line.replace(QStringLiteral("%G"),QStringLiteral("\x07"));       // replace %G with ASCII BEL 0x07
+    line.replace(QStringLiteral("%I"),QStringLiteral("\x1d"));       // replace %I with italics char
+    line.replace(QStringLiteral("%O"),QStringLiteral("\x0f"));       // replace %O with reset to default char
+    line.replace(QStringLiteral("%S"),QStringLiteral("\x13"));       // replace %S with strikethru char
+    line.replace(QStringLiteral("%R"),QStringLiteral("\x16"));       // replace %R with reverse char
+    line.replace(QStringLiteral("%U"),QStringLiteral("\x1f"));       // replace %U with underline char
+    line.replace(QStringLiteral("%\x01"),QStringLiteral("%"));       // restore double %% as single %
+
+    return line;
+}
+
+
 QVariant UiStyle::nickViewItemData(const QModelIndex& index, int role) const
 {
     NetworkModel::ItemType type = (NetworkModel::ItemType)index.data(NetworkModel::ItemTypeRole).toInt();
@@ -489,7 +530,8 @@ void UiStyle::mergeFormat(QTextCharFormat& charFormat, const Format& format, Mes
     if ((format.type & 0xfff00) != FormatType::Base) {  // element format
         for (quint32 mask = 0x00100; mask <= 0x80000; mask <<= 1) {
             if ((format.type & mask) != FormatType::Base) {
-                mergeSubElementFormat(charFormat, format.type & (mask | 0xff), label);
+                mergeSubElementFormat(charFormat,
+                    format.type & (mask | 0xff), label);
             }
         }
     }
@@ -1126,8 +1168,12 @@ quint8 UiStyle::StyledMessage::senderHash() const
         if (chopCount < nick.size())
             nick.chop(chopCount);
     }
-    quint16 hash = qChecksum(nick.toLatin1().data(), nick.toLatin1().size());
-    return (_senderHash = (hash & 0xf) + 1);
+
+
+    // quint16 hash = qChecksum(nick.toLatin1().data(), nick.toLatin1().size());
+    QByteArray nb = nick.toLocal8Bit();
+    quint16 col = (qChecksum(nb, nb.size()) >> ((nb.length() + nb[0]) % 12)) & 0x0f;
+    return (_senderHash = col + 1);
 }
 
 /***********************************************************************************/

--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -305,9 +305,6 @@ public:
     QVariant bufferViewItemData(const QModelIndex& networkModelIndex, int role) const;
     QVariant nickViewItemData(const QModelIndex& networkModelIndex, int role) const;
 
-    static QString makeHumanReadable(const QString &);
-    static QString makeIrcReadable(const QString &);
-
 public slots:
     void reload();
 

--- a/src/uisupport/uistyle.h
+++ b/src/uisupport/uistyle.h
@@ -305,6 +305,9 @@ public:
     QVariant bufferViewItemData(const QModelIndex& networkModelIndex, int role) const;
     QVariant nickViewItemData(const QModelIndex& networkModelIndex, int role) const;
 
+    static QString makeHumanReadable(const QString &);
+    static QString makeIrcReadable(const QString &);
+
 public slots:
     void reload();
 


### PR DESCRIPTION
Hi, this fork has been lying around for a while and it brings some pretty good improvements to macOS 10.12 and later, as well as the start of macOS-specific code via the CocoaHelper class. I wanted to clean up the code and the commits, but some things got in the way and I forgot about this repository for a while.

Sadly, I don't have a Mac anymore and I don't plan to buy one in the near future. But if I ever do or if I eventually setup a macOS virtual machine, I'll definitely revisit it. The CocoaHelper class could be given its own pull request, but it should work right now, and I don't have something to test it on if I play with the code.

This is from my original commit:

* Added the start of a CocoaHelper class to customize how windows look. things in there should be turned into settings and piled up in the future.
* Removed the "stop editing on unfocus" behaviour the topic widget had
* Only the highest mode prefix shows in front of a nick when it's enabled. Ideally the core should sort them and there should be an attempt to grab the first one. This is an improvement that will probably be made later.
* ~Added makeHumanReadable and makeIrcReadable from Konversation's replaceFormattingCodes and replaceIRCMarkups. It was integrated in the topic widget, so that style bytes are converted to and from human-readable format when the topic is being edited. It was also integrated in the input widget.~
* Added the Edit menu from PR #176 on quassel's repo as a function to cocoahelper
* Fix emojis on macOS by leaving a tiny bit of space between the lines

I've reverted "Added makeHumanReadable and makeIrcReadable from Konversation's "replaceFormattingCodes and replaceIRCMarkups.", I'm still working on this on a separate branch.