### PR TITLE
[Followup PR-495] Fixes backwards compatibility issues

### DIFF
--- a/src/common/ircchannel.cpp
+++ b/src/common/ircchannel.cpp
@@ -231,7 +231,7 @@ void IrcChannel::part(IrcUser* ircuser)
             _userModes.clear();
             foreach (IrcUser* user, users) {
                 disconnect(user, nullptr, this, nullptr);
-                user->partChannel(this, true);
+                user->partChannelInternal(this, true);
             }
             emit parted();
             network()->removeIrcChannel(this);

--- a/src/common/ircuser.cpp
+++ b/src/common/ircuser.cpp
@@ -291,17 +291,9 @@ void IrcUser::joinChannel(const QString& channelname)
     joinChannel(network()->newIrcChannel(channelname));
 }
 
-void IrcUser::partChannel(IrcChannel* channel, bool skip_sync)
+void IrcUser::partChannel(IrcChannel* channel)
 {
-    if (_channels.contains(channel)) {
-        _channels.remove(channel);
-        disconnect(channel, nullptr, this, nullptr);
-        channel->part(this);
-        QString channelName = channel->name();
-        if (!skip_sync) SYNC_OTHER(partChannel, ARG(channelName))
-        if (_channels.isEmpty() && !network()->isMe(this))
-            quit(skip_sync);
-    }
+    partChannelInternal(channel, false);
 }
 
 void IrcUser::partChannel(const QString& channelname)
@@ -315,7 +307,25 @@ void IrcUser::partChannel(const QString& channelname)
     }
 }
 
-void IrcUser::quit(bool skip_sync)
+void IrcUser::partChannelInternal(IrcChannel* channel, bool skip_sync)
+{
+    if (_channels.contains(channel)) {
+        _channels.remove(channel);
+        disconnect(channel, nullptr, this, nullptr);
+        channel->part(this);
+        QString channelName = channel->name();
+        if (!skip_sync) SYNC_OTHER(partChannel, ARG(channelName))
+        if (_channels.isEmpty() && !network()->isMe(this))
+            quitInternal(skip_sync);
+    }
+}
+
+void IrcUser::quit()
+{
+    quitInternal(false);
+}
+
+void IrcUser::quitInternal(bool skip_sync)
 {
     QList<IrcChannel*> channels = _channels.values();
     _channels.clear();

--- a/src/common/ircuser.h
+++ b/src/common/ircuser.h
@@ -131,6 +131,9 @@ public:
         _awayChanged = false;
     }
 
+    void partChannelInternal(IrcChannel* channel, bool skip_sync = false);
+    void quitInternal(bool skip_sync = false);
+
 public slots:
     void setUser(const QString& user);
     void setHost(const QString& host);
@@ -166,9 +169,9 @@ public slots:
      */
     void joinChannel(IrcChannel* channel, bool skip_channel_join = false);
     void joinChannel(const QString& channelname);
-    void partChannel(IrcChannel* channel, bool skip_sync = false);
+    void partChannel(IrcChannel* channel);
     void partChannel(const QString& channelname);
-    void quit(bool skip_sync = false);
+    void quit();
 
     void addUserModes(const QString& modes);
     void removeUserModes(const QString& modes);


### PR DESCRIPTION
## In Short
* Moves functionality to an internal function
* Restores original sync slots

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★★★  _3/3_ | Fixes functionality with older clients |
| Risk | ☆☆☆  _0/3_ | Just fixes existing functionality |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to few rarely-touched classes, shouldn't interfere with other pull requests |

## Rationale

The previous PR-495 broke functionality on several older clients, which this restores.