### PR TITLE
ci: Add sanity check for artifacts to post-build job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,10 +200,9 @@ jobs:
         path: ${{ github.workspace }}/packages/*
 
 # ------------------------------------------------------------------------------------------------------------------------------------------
-  create-release:
-    name: Create release
+  post-build:
+    name: Post-Build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     needs: [ build-linux, build-macos, build-windows ]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -213,14 +212,8 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Fetch tag information
+      if: startsWith(github.ref, 'refs/tags/')
       run: git fetch -f origin $GITHUB_REF:$GITHUB_REF
-
-    - name: Create release notes
-      run: |
-        # Use the tag's annotation as release notes
-        TAGNAME=$(git rev-parse --abbrev-ref $GITHUB_REF)
-        MESSAGE=$(git tag -l --format='%(contents)' $TAGNAME | perl -ne 'print if not /-----BEGIN PGP SIGNATURE-----/../-----END PGP SIGNATURE-----/')
-        echo -e "Quassel $TAGNAME\n\n$MESSAGE" > release_notes.txt
 
     - name: Download artifacts
       uses: actions/download-artifact@v2
@@ -230,13 +223,28 @@ jobs:
     - name: List artifacts
       run: ls -lhR artifacts
 
+    - name: Check artifacts
+      run: |
+        # Sanity check: We should have exactly 5 files matching the given patterns
+        [[ 5 -eq $(find artifacts/ \( -type f -name 'Quassel*.dmg' -o -name 'quassel*.exe' -o -name 'quassel*.7z' \) -printf '.' | wc -c) ]]
+
+    - name: Create release notes
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        # Use the tag's annotation as release notes
+        TAGNAME=$(git rev-parse --abbrev-ref $GITHUB_REF)
+        MESSAGE=$(git tag -l --format='%(contents)' $TAGNAME | perl -ne 'print if not /-----BEGIN PGP SIGNATURE-----/../-----END PGP SIGNATURE-----/')
+        echo -e "Quassel $TAGNAME\n\n$MESSAGE" > release_notes.txt
+
     - name: Prepare source archive
+      if: startsWith(github.ref, 'refs/tags/')
       run: |
         mkdir assets
         TAGNAME=$(git rev-parse --abbrev-ref $GITHUB_REF)
         git archive --format=tar --prefix=quassel-$TAGNAME/ $TAGNAME | xz > assets/quassel-$TAGNAME.tar.xz
 
     - name: Prepare packages for release
+      if: startsWith(github.ref, 'refs/tags/')
       run: |
         TAGNAME=$(git rev-parse --abbrev-ref $GITHUB_REF)
         for type in Client Core Mono; do
@@ -246,9 +254,11 @@ jobs:
         mv artifacts/Windows/quassel-*.7z assets/quassel-windows-$TAGNAME.7z
 
     - name: Create checksums for release assets
+      if: startsWith(github.ref, 'refs/tags/')
       run: find assets/ -type f -execdir sh -c 'sha256sum "$1" > "$1.sha256sum"' _ {} \;
 
     - name: Create draft release
+      if: startsWith(github.ref, 'refs/tags/')
       run: |
         # The stock upload-release-asset action can only handle single files
         # Instead, use the hub utility so we can upload all assets at once


### PR DESCRIPTION
Check if expected artifacts have been created for every workflow run,
not only for tagged commits. While this is just a rudimentary
sanity check, it would at least cause a CI failure if one of the
build jobs didn't produce artifacts for some reason.

A nice side effect is that unlike the former create-release job,
the new post-build job is not completely skipped for non-tagged
commits, and thus shows up as successful for every good CI run
(even though the individual steps required for creating a draft
release are skipped, of course).
This causes the GitHub UI to automatically collapse the (giant)
list of checks after they are all complete.