### PR TITLE
common: Default to SSL/TLS for new IRC networks

### DIFF
--- a/src/common/network.h
+++ b/src/common/network.h
@@ -110,22 +110,22 @@ public:
         D_CHANMODE = 0x08
     };
 
-    // Default port assignments according to what many IRC networks have settled on.
-    // Technically not a standard, but it's fairly widespread.
-    // See https://freenode.net/news/port-6697-irc-via-tlsssl
+    /// Default port assignments according to what many IRC networks have settled on.
+    /// Technically not a standard, but it's fairly widespread.
+    /// See https://freenode.net/news/port-6697-irc-via-tlsssl
     enum PortDefaults
     {
-        PORT_PLAINTEXT = 6667,  /// Default port for unencrypted connections
-        PORT_SSL = 6697         /// Default port for encrypted connections
+        PORT_PLAINTEXT = 6667,  ///< Default port for unencrypted connections
+        PORT_SSL = 6697         ///< Default port for encrypted connections
     };
 
     struct Server
     {
         QString host;
-        uint port{6667};
+        uint port{PortDefaults::PORT_SSL};
         QString password;
-        bool useSsl{false};
-        bool sslVerify{true};  /// If true, validate SSL certificates
+        bool useSsl{true};     ///< If true, connect via SSL/TLS
+        bool sslVerify{true};  ///< If true, validate SSL certificates
         int sslVersion{0};
 
         bool useProxy{false};

--- a/src/qtui/settingspages/networkadddlg.ui
+++ b/src/qtui/settingspages/networkadddlg.ui
@@ -105,7 +105,7 @@
            <number>65535</number>
           </property>
           <property name="value">
-           <number>6667</number>
+           <number>6697</number>
           </property>
          </widget>
         </item>
@@ -132,6 +132,9 @@
         </property>
         <property name="text">
          <string>Use encrypted connection</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/src/qtui/settingspages/servereditdlg.ui
+++ b/src/qtui/settingspages/servereditdlg.ui
@@ -58,7 +58,7 @@
             <number>65535</number>
            </property>
            <property name="value">
-            <number>6667</number>
+            <number>6697</number>
            </property>
           </widget>
          </item>
@@ -99,6 +99,9 @@
          <property name="icon">
           <iconset>
            <normaloff>:/16x16/actions/oxygen/16x16/actions/document-encrypt.png</normaloff>:/16x16/actions/oxygen/16x16/actions/document-encrypt.png</iconset>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
## In short
* Enable SSL/TLS by default for new IRC networks
  * Existing networks will stay as they are
  * SSL/TLS can be disabled by editing the network
  * Default port will revert to `6667` when unchecking `Use encrypted connection`
  * Client-side change; core has no impact
* Fix up Doxygen comments for `Server::useSSL` and `PortDefaults`

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing better security by default
Risk | ★★★ *3/3* | May frustrate, confuse those who don't know to try disabling SSL/TLS
Intrusiveness | ★☆☆ *1/3* | UI/defaults changes, shouldn't interfere with other pull requests

## Rationale
It's the year 2020, and several networks offer SSL/TLS with valid certificates.  Quassel could default to enabling SSL/TLS for newly added networks.

However, a few large networks still do not support SSL/TLS on port 6697, alongside locally-hosted bridges, such as Bitlbee.  This will require unchecking `Use encrypted connection` to connect those networks without SSL/TLS.

All preset networks will work as before, according to the preset (most have SSL/TLS ports added already).

**Subjective choice.  This may result in increased support requests in `#quassel`.**

When SSL/TLS is not available on the configured port, Quassel will fail to connect to the IRC network with an error message (i.e. `Connection refused`).  This can be remedied by editing the network and unchecking `Use encrypted connection`, but that's an extra step that might put off new users.

**There are other, more complex options**, [such as auto-detecting if an SSL/TLS port is available](https://github.com/ircdocs/best-practices/blob/master/client/tls-guidelines.md), or [supporting the IRCv3 `sts` capability](https://ircv3.net/specs/extensions/sts ).

Opinions in `freenode`/`#ircv3` are mixed - some clients are doing this already without reported issues, others are in favor of the more complex methods.

## Examples
### Before
**Add Network dialog**
*On the Settings - IRC - Networks page under the `Networks` heading, `Add..` button clicked to add a new network to an existing network.*

![Add Network dialog, showing a "Port" of "6667" and "Use encrypted connection" unchecked by default](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-irc-ssl-default/before%20-%20Add%20Network%20dialog.png#v2 )

**Server Edit dialog**
*On the Settings - IRC - Networks page under the `Servers` heading, `Add..` button clicked to add a new server to an existing network.*

![Edit Server dialog, showing a "Port" of "6667" and "Use encrypted connection" unchecked by default](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-irc-ssl-default/before%20-%20Edit%20Server%20dialog.png#v2 )

### After
**Add Network dialog**
*On the Settings - IRC - Networks page under the `Networks` heading, `Add..` button clicked to add a new network to an existing network.*

![Add Network dialog, showing a "Port" of "6697" and "Use encrypted connection" checked by default](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-irc-ssl-default/after%20-%20Add%20network%20dialog.png#v2 )

**Server Edit dialog**
*On the Settings - IRC - Networks page under the `Servers` heading, `Add..` button clicked to add a new server to an existing network.*

![Edit Server dialog, showing a "Port" of "6697" and "Use encrypted connection" checked by default](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-irc-ssl-default/after%20-%20Edit%20Server%20dialog.png#v2 )
