### PR TITLE
common: Default to Away on Detach for new identities

### DIFF
--- a/src/common/identity.cpp
+++ b/src/common/identity.cpp
@@ -179,7 +179,7 @@ void Identity::setToDefaults()
     setAutoAwayTime(10);
     setAutoAwayReason(tr("Not here. No, really. not here!"));
     setAutoAwayReasonEnabled(false);
-    setDetachAwayEnabled(false);
+    setDetachAwayEnabled(true);
     setDetachAwayReason(tr("All Quassel clients vanished from the face of the earth..."));
     setDetachAwayReasonEnabled(false);
     setIdent("quassel");

--- a/src/qtui/settingspages/identityeditwidget.ui
+++ b/src/qtui/settingspages/identityeditwidget.ui
@@ -286,7 +286,7 @@
           <bool>true</bool>
          </property>
          <property name="checked">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">
           <item>


### PR DESCRIPTION
## In short
* Enable `Away on Detach` by default for new identities
  * Existing identities will stay as they are
  * Matches IRCCloud behavior (not sure about ZNC), other chat networks
  * Client-side change; core has no impact

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | User-facing, helps communicate whether someone may respond
Risk | ★★☆ *2/3* | Privacy change, default now reveals whether a client is connected
Intrusiveness | ★☆☆ *1/3* | UI/defaults changes, shouldn't interfere with other pull requests

## Rationale
Most modern chat networks automatically manage presence to some manner.  IRCCloud defaults to setting `Auto-away` on (*Set your away status when you leave the page*), Discord, Steam, and several Jabber/XMPP clients (Conversations, Gajim, Pidgin) set presence based on detected activity.  Traditional IRC clients don't maintain any online presence upon closing.

While Quassel does not have activity detection yet (`KIdleTime` is needed), Quassel can set an away message on detaching all clients.  This should be enabled by default to match expectations from other IRC clients and conversation platforms, and to communicate availability.

Privacy-conscious users might be unhappy with the new default as it reveals whether or not a client is connected.  However, `Detach on Away` can always be disabled while creating a new identity, and existing identities won't be changed.

**This is a subjective choice.**