### PR TITLE
client: Deemphasize local highlights, fix ignores

### DIFF
--- a/src/client/clientsettings.cpp
+++ b/src/client/clientsettings.cpp
@@ -296,7 +296,7 @@ void NotificationSettings::setHighlightNick(NotificationSettings::HighlightNickT
 
 NotificationSettings::HighlightNickType NotificationSettings::highlightNick() const
 {
-    return (NotificationSettings::HighlightNickType)localValue("Highlights/HighlightNick", CurrentNick).toInt();
+    return (NotificationSettings::HighlightNickType)localValue("Highlights/HighlightNick", NoNick).toInt();
 }
 
 void NotificationSettings::setNicksCaseSensitive(bool cs)

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -1520,8 +1520,15 @@ void MainWin::showSettingsDlg()
 #ifdef HAVE_SONNET
     dlg->registerSettingsPage(new SonnetSettingsPage(dlg));
 #endif
-    dlg->registerSettingsPage(new HighlightSettingsPage(dlg));
-    dlg->registerSettingsPage(new CoreHighlightSettingsPage(dlg));
+    auto coreHighlightsPage = new CoreHighlightSettingsPage(dlg);
+    auto localHighlightsPage = new HighlightSettingsPage(dlg);
+    // Let CoreHighlightSettingsPage reload HighlightSettingsPage after doing an import with
+    // cleaning up.  Otherwise, HighlightSettingsPage won't show that the local rules were deleted.
+    connect(coreHighlightsPage, &CoreHighlightSettingsPage::localHighlightsChanged,
+            localHighlightsPage, &HighlightSettingsPage::load);
+    // Put core-side highlights before local/legacy highlights
+    dlg->registerSettingsPage(coreHighlightsPage);
+    dlg->registerSettingsPage(localHighlightsPage);
     dlg->registerSettingsPage(new NotificationsSettingsPage(dlg));
     dlg->registerSettingsPage(new BacklogSettingsPage(dlg));
 

--- a/src/qtui/settingspages/corehighlightsettingspage.h
+++ b/src/qtui/settingspages/corehighlightsettingspage.h
@@ -46,6 +46,15 @@ public slots:
     void revert();
     void clientConnected();
 
+signals:
+    /**
+     * Signals the local highlight settings have been changed as part of cleaning up after
+     * importing the rules locally.
+     *
+     * @see CoreHighlightSettingsPage::importRules()
+     */
+    void localHighlightsChanged();
+
 private slots:
     void coreConnectionStateChanged(bool state);
     void widgetHasChanged();

--- a/src/qtui/settingspages/highlightsettingspage.cpp
+++ b/src/qtui/settingspages/highlightsettingspage.cpp
@@ -117,7 +117,7 @@ bool HighlightSettingsPage::hasDefaults() const
 
 void HighlightSettingsPage::defaults()
 {
-    ui.highlightCurrentNick->setChecked(true);
+    ui.highlightNoNick->setChecked(true);
     ui.nicksCaseSensitive->setChecked(false);
     emptyTable();
 

--- a/src/qtui/settingspages/highlightsettingspage.cpp
+++ b/src/qtui/settingspages/highlightsettingspage.cpp
@@ -31,9 +31,7 @@
 #include "uisettings.h"
 
 HighlightSettingsPage::HighlightSettingsPage(QWidget* parent)
-    : SettingsPage(tr("Interface"),
-                   // In Monolithic mode, local highlights are replaced by remote highlights
-                   Quassel::runMode() == Quassel::Monolithic ? tr("Legacy Highlights") : tr("Local Highlights"),
+    : SettingsPage(tr("Interface"), tr("Legacy Highlights"),
                    parent)
 {
     ui.setupUi(this);
@@ -84,17 +82,6 @@ HighlightSettingsPage::HighlightSettingsPage(QWidget* parent)
 
     // Information icon
     ui.localHighlightsIcon->setPixmap(icon::get("dialog-information").pixmap(16));
-
-    // Set up client/monolithic local highlights information
-    if (Quassel::runMode() == Quassel::Monolithic) {
-        // We're running in Monolithic mode, core/client version in total sync.  Discourage the use
-        // of local (legacy) highlights as it's identical to setting remote highlights.
-        ui.localHighlightsLabel->setText(tr("Legacy Highlights are replaced by Highlights"));
-    }
-    else {
-        // We're running in client/split mode, allow for splitting the details.
-        ui.localHighlightsLabel->setText(tr("Local Highlights apply to this device only"));
-    }
 
     connect(ui.add, &QAbstractButton::clicked, this, [this]() { addNewRow(); });
     connect(ui.remove, &QAbstractButton::clicked, this, &HighlightSettingsPage::removeSelectedRows);
@@ -265,34 +252,16 @@ void HighlightSettingsPage::tableChanged(QTableWidgetItem* item)
 
 void HighlightSettingsPage::on_localHighlightsDetails_clicked()
 {
-    // Show information specific to client/monolithic differences
-    if (Quassel::runMode() == Quassel::Monolithic) {
-        // We're running in Monolithic mode, core/client version in total sync.  Discourage the use
-        // of local (legacy) highlights as it's identical to setting remote highlights.
-        QMessageBox::information(this,
-                                 tr("Legacy Highlights vs. Highlights"),
-                                 QString("<p><b>%1</b></p></br><p>%2</p></br><p>%3</p>")
-                                     .arg(tr("Legacy Highlights are replaced by Highlights"),
-                                          tr("These highlights will keep working for now, but you should move to "
-                                             "the improved highlight rules when you can."),
-                                          tr("Configure the new style of highlights in "
-                                             "<i>%1</i>.")
-                                              .arg(tr("Highlights"))));
-    }
-    else {
-        // We're running in client/split mode, allow for splitting the details.
-        QMessageBox::information(this,
-                                 tr("Local Highlights vs. Remote Highlights"),
-                                 QString("<p><b>%1</b></p></br><p>%2</p></br><p>%3</p>")
-                                     .arg(tr("Local Highlights apply to this device only"),
-                                          tr("Highlights configured on this page only apply to your current "
-                                             "device."),
-                                          tr("Configure highlights for all of your devices in "
-                                             "<i>%1</i>.")
-                                              .arg(tr("Remote Highlights").replace(" ", "&nbsp;"))));
-        // Re-use translations of "Remote Highlights" as this is a word-for-word reference, forcing
-        // all spaces to be non-breaking
-    }
+    // Discourage the use of local (legacy) highlights.  When not running in Monolithic mode, they
+    // need to be kept around for pre-0.13 cores.
+    QMessageBox::information(this,
+                             tr("Legacy Highlights vs. Highlights"),
+                             QString("<p><b>%1</b></p></br><p>%2</p></br><p>%3</p>")
+                             .arg(tr("Legacy Highlights are replaced by Highlights"),
+                                  tr("These highlights will keep working for now, but you should move to "
+                                     "the improved highlight rules when you can."),
+                                  tr("Configure the new style of highlights in <i>%1</i>.")
+                                  .arg(tr("Highlights"))));
 }
 
 void HighlightSettingsPage::load()

--- a/src/qtui/settingspages/highlightsettingspage.ui
+++ b/src/qtui/settingspages/highlightsettingspage.ui
@@ -15,6 +15,37 @@
   </property>
   <layout class="QVBoxLayout">
    <item>
+    <layout class="QHBoxLayout">
+     <item>
+      <widget class="QLabel" name="localHighlightsIcon">
+       <property name="text">
+        <string notr="true">[icon]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="localHighlightsLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Legacy Highlights are replaced by Highlights</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="localHighlightsDetails">
+       <property name="text">
+        <string>Details...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Custom Highlights</string>
@@ -134,37 +165,6 @@
       </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout">
-     <item>
-      <widget class="QLabel" name="localHighlightsIcon">
-       <property name="text">
-        <string notr="true">[icon]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="localHighlightsLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Local Highlights apply to this device only</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="localHighlightsDetails">
-       <property name="text">
-        <string>Details...</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
## In short

* Disable local nickname highlights by default
  * Works around core-side highlight ignores being overridden by local highlights
  * Quassel 0.13 with core-side highlights came out 1.5 years ago
* Deemphasize local highlights
  * Rename `Local Highlights` → `Legacy Highlights` for core + client setups
  * Rename `Remote Highlights` → `Highlights` and place it first in settings
  * Make `Import Legacy` import nickname highlight settings, offer to remove old rules
  * After 0.14/stable, Quassel should disable client highlights when core highlights exist

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing clarity, reduces highlight annoyances
Risk | ★★☆ *2/3* | Changes highlight rule matching behavior, possible confusion
Intrusiveness | ★★☆ *2/3* | UI, string changes, may interfere with other PRs

## Rationale
There's been several complaints of highlight ignore rules not working, when it turns out client-side nickname highlights were overriding the core-side highlight ignore rules.

Now that 0.13 has been out for over a year, it should be safe to disable client-side nickname highlights by default.  For those using older cores, they may need to re-enable client-side nickname highlights.

In a future stable release, Quassel should disable client-side highlights whenever core-side highlights are supported, avoiding all of this mess, as @justJanne originally designed.  By renaming `Local Highlights` to `Legacy Highlights`, this provides an opportunity for those relying on client-side highlights alongside core-side highlights to offer feedback.

### Breaking changes
* Quassel will no longer highlight nicknames by default for cores older than 0.13
  * This can be re-enabled by visiting `Legacy Highlights` and enabling nickname highlights there

### Alternatives
If the community agrees that it's time for Quassel to move on to a single highlight system right now (client-side highlights for < 0.13, core-side highlights for >=0.13), I can file a new pull request that does this.

This will avoid the breaking change above, but will remove the ability to have per-client choice in highlight rules.

Personally, I would prefer this alternative (less confusion, less support hassle), but I'm not sure if others are willing to accept the loss of functionality, and it involves some complex questions.  (E.g. what happens to unsaved changes when connecting to a core?  When should the client-side settings show - all the time when disconnected, or only when connected to an older core?)

*I'll try to come back to this.  This can be done after the upcoming stable release, too.*

## Examples
### Settings order
*In Settings, showing order of `Highlights` and `Legacy Highlights`*
![Settings page showing order of settings entries](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-local-highlight-deprecate/Settings%20page%20order.png#v1)
> `Spell Checking`
> `Highlights`
> `Legacy Highlights`
> `Notifications`

### Legacy Highlights (Client and Monolithic)
*In Settings → Interface → Legacy Highlights, information bar at top and "Details…" dialog*
![Settings - Legacy Highlights - Details dialog, showing Legacy Highlight vs. Highlights](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-local-highlight-deprecate/Settings%20-%20Legacy%20Highlights%20infobar%2C%20dialog.png#v1)
> *:information_source: Local Highlights are replaced by Remote Highlights*
> 
> Dialog:
> **Local Highlights are replaced by Remote Highlights**
> These highlights will keep working for now, but you should move to the improved highlight rules when you can.
> Configure the new style of highlights in *Remote Highlights*.

### Core-side Highlights unsupported
**This hasn't changed and is included just for reference.**

*In Settings → Interface → Highlights, warning bar at top and "Details…" dialog*
![Settings - Highlights - Details dialog, showing when core-side Highlights aren't supported](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-local-highlight-deprecate/Settings%20-%20core-side%20Highlights%20unsupported.png#v1 )
> *:warning: Your Quassel core is too old to support remote highlights*
> 
> Dialog:
> **Your Quassel core is too old to support remote highlights**
> You need a Quassel core v0.13.0 or newer to configure remote highlights.
> You can still configure highlights for this device only in *Legacy Highlights*.

### Core-side Highlights importing Legacy
*In Settings → Interface → Highlights, clicking the Import Legacy button*
![Settings - Highlights - Import Legacy dialogs, showing the stages of an import](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-local-highlight-deprecate/Settings%20-%20core-side%20Highlights%20import%20dialogs.png#v1 )

*Asking to import*
> Import all highlight rules from *Legacy Highlights*?
> Yes | No

*Import done, asking to clean up old rules*
> `number` highlight rules successfully imported.
>
> Clean up old, duplicate highlight rules?
> Yes | No

*Nothing to import*
> No highlight rules in *Legacy Highlights*.

![Settings - Highlights window showing imported highlight rules, after the Import Legacy run shown previously](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-local-highlight-deprecate/Settings%20-%20core-side%20Highlights%20import%20finished.png#v1 )

*`Highlight Nicks` and `Custom Highlights` are properly copied from the `Legacy Highlights` shown in a previous screenshot.*
