### PR TITLE
common: Exclude ignored messages in buffer activity

### DIFF
--- a/src/common/message.cpp
+++ b/src/common/message.cpp
@@ -71,7 +71,6 @@ QDataStream& operator<<(QDataStream& out, const Message& msg)
     Q_ASSERT(SignalProxy::current());
     Q_ASSERT(SignalProxy::current()->targetPeer());
 
-    // We do not serialize the sender prefixes until we have a new protocol or client-features implemented
     out << msg.msgId();
 
     if (SignalProxy::current()->targetPeer()->hasFeature(Quassel::Feature::LongTime)) {

--- a/src/common/message.h
+++ b/src/common/message.h
@@ -66,6 +66,7 @@ public:
         Redirected = 0x04,
         ServerMsg  = 0x08,
         StatusMsg  = 0x10,
+        Ignored    = 0x20, ///< This message matched an active ignore rule when first received
         Backlog    = 0x80
     };
     Q_DECLARE_FLAGS(Flags, Flag)

--- a/src/core/SQL/PostgreSQL/select_buffer_bufferactivity.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_bufferactivity.sql
@@ -3,5 +3,6 @@ FROM
   (SELECT DISTINCT TYPE
    FROM backlog
    WHERE bufferid = :bufferid
+     AND flags & 32 = 0
      AND flags & 1 = 0
      AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
+++ b/src/core/SQL/PostgreSQL/select_buffer_highlightcount.sql
@@ -2,6 +2,7 @@ SELECT COALESCE(t.sum,0)
 FROM
   (SELECT COUNT(*) AS sum FROM backlog
    WHERE bufferid = :bufferid
+     AND flags & 32 = 0
      AND flags & 2 != 0
      AND flags & 1 = 0
      AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/SQLite/select_buffer_bufferactivity.sql
+++ b/src/core/SQL/SQLite/select_buffer_bufferactivity.sql
@@ -3,5 +3,6 @@ FROM
   (SELECT DISTINCT TYPE
    FROM backlog
    WHERE bufferid = :bufferid
+     AND flags & 32 = 0
      AND flags & 1 = 0
      AND messageid > :lastseenmsgid) t;

--- a/src/core/SQL/SQLite/select_buffer_highlightcount.sql
+++ b/src/core/SQL/SQLite/select_buffer_highlightcount.sql
@@ -2,6 +2,7 @@ SELECT COALESCE(t.sum,0)
 FROM
   (SELECT COUNT(*) AS sum FROM backlog
    WHERE bufferid = :bufferid
+     AND flags & 32 = 0
      AND flags & 2 != 0
      AND flags & 1 = 0
      AND messageid > :lastseenmsgid) t;

--- a/src/core/corebuffersyncer.h
+++ b/src/core/corebuffersyncer.h
@@ -40,6 +40,10 @@ public slots:
 
     void addBufferActivity(const Message& message)
     {
+        if (message.flags().testFlag(Message::Flag::Ignored)) {
+            // Don't update buffer activity with messages that are ignored
+            return;
+        }
         auto oldActivity = activity(message.bufferId());
         if (!oldActivity.testFlag(message.type())) {
             setBufferActivity(message.bufferId(), (int)(oldActivity | message.type()));
@@ -48,6 +52,10 @@ public slots:
 
     void addCoreHighlight(const Message& message)
     {
+        if (message.flags().testFlag(Message::Flag::Ignored)) {
+            // Don't increase highlight count for messages that are ignored
+            return;
+        }
         auto oldHighlightCount = highlightCount(message.bufferId());
         if (message.flags().testFlag(Message::Flag::Highlight) && !message.flags().testFlag(Message::Flag::Self)) {
             setHighlightCount(message.bufferId(), oldHighlightCount + 1);


### PR DESCRIPTION
## In short
* Mark messages as `Ignored` if matched by an ignore rule
  * Useful for dynamic ignores (`SoftStrictness`); permanent (`HardStrictness`) are dropped
  * Simple clients/bots can filter out ignored messages without implementing `ExpressionMatch`
  * Not used for full clients as they reveal hidden messages when disabling specific ignore rules
* Exclude messages that match an ignore rule when updating `bufferActivity` and `highlightCount`
  * Fixes [issue #1511, appearance of new activity/highlights from ignored messages](https://bugs.quassel-irc.org/issues/1511 )
  * No client changes needed
* Clean up an old comment

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing, avoids common complaint of misleading activity/highlights
Risk | ★★☆ *2/3* | Protocol-visible message flag change, modifies database storage
Intrusiveness | ★☆☆ *1/3* | Minimal code changes, shouldn't interfere with other pull requests

*Thanks to `justJanne` for the [work in figuring out how to fix this and an earlier approach using a new column in pull request #496.](https://github.com/quassel/quassel/pull/496 )*

## Testing
---

# Overview - 2020-6-21
## Summary
* SQLite and Postgres success
* Downgrading core with new flag in database doesn't break core
* Upgrades testing skipped, no upgrade schema change

## Steps for a successful test
1.  Initialize Quassel core (*completing first run wizard if needed*)
2.  Connect to a network, verify message sends
3.  Enable a **dynamic** ignore rule on a message that would normally trigger buffer activity
4.  Receive message, verify buffer activity reacts properly to new messages
    * Shows new message for old core, no new message for new core
5.  Disable ignore rule
6.  Verify past message shows up
7.  Receive message, verify buffer activity reacts properly to new messages
    * Shows new message
8.  Enable a **dynamic** ignore rule on a message that would normally trigger a highlight
9.  Receive message, verify buffer activity reacts properly to new messages
    * Shows new highlight for old core, no new highlight for new core
10. Disable ignore rule
11.  Verify past message shows up
12. Receive message, verify buffer activity reacts properly to new messages
    * Shows new highlight

## Notes
* This does not impact database upgrade, so those tests have been skipped
* To verify that downgrading isn't impacted, the old core was run with the new flag in the database

# Test results - ✅ pass
## Linux - ✅ pass
### Fresh configuration - ✅ pass
*Quassel core from this PR set up without any initial data*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite, new core, new client | ✅ *pass* |
SQLite, new core, old client | ✅ *pass* | *Core reused from previous test*
SQLite, old core, new client | ✅ *pass* | *Done after the previous test to verify database downgrading*
SQLite, new monolithic |  ✅ *pass* |
Postgres, new core, new client | ✅ *pass* |
Postgres, new core, old client | ❓ *skipped* | *Protocol compatibility verified in SQLite tests*
Postgres, old core, new client | ✅ *pass* | *Core reused from SQLite → PostgreSQL migration test*

### Migration - ✅ pass
*Quassel core from this PR set up without any initial data, then migrated*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite → Postgres, new core, new client | ✅ *pass* | *Core reused from SQLite test, `Ignored` flag migrated tested via `select * from backlog where flags & 32 != 0;`*

### Upgrading existing - ❓ skipped
*Quassel core 0.14-git-master, then upgraded to this PR*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite, old → new core | ❓ *skipped* |
SQLite, old monolithic → new monolithic | ❓ *skipped* |
Postgres, old → new core | ❓ *skipped* |

## Windows - ✅ pass
### Fresh configuration - ✅ pass
*Quassel core from this PR set up without any initial data*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite, new core, new client | ✅ *pass* |
SQLite, new core, old client | ✅ *pass* | *Core reused from previous test*
SQLite, old core, new client | ✅ *pass* | *Done after the previous test to verify database downgrading*
SQLite, new monolithic | ✅ *pass* |

### Migration - ❓ N/A
*Without Postgres on Windows, migration could not be tested*

### Upgrading existing - ❓ skipped
*Quassel core 0.14-git-master set up, then upgraded to this PR*

Test conditions  | Result  | Remarks
-----------------|---------|-------------
SQLite, old → new core | ❓ *skipped* |
SQLite, old monolithic → new monolithic | ❓ *skipped* |

## Failed cases
None found!
