### PR TITLE
client: Only fetch backlog when needed, fixup zero backlog

### DIFF
--- a/src/client/backlogrequester.h
+++ b/src/client/backlogrequester.h
@@ -39,6 +39,7 @@ public:
         InvalidRequester = 0,
         PerBufferFixed,
         PerBufferUnread,
+        AsNeeded,              ///< Only request backlog on cores without Feature::BufferActivitySync
         GlobalUnread
     };
 
@@ -113,4 +114,21 @@ public:
 private:
     int _limit;
     int _additional;
+};
+
+// ========================================
+//  AS NEEDED BACKLOG REQUESTER
+// ========================================
+/**
+ * Backlog requester that only fetches initial backlog when the core doesn't support buffer activity
+ * tracking
+ */
+class AsNeededBacklogRequester : public BacklogRequester
+{
+public:
+    AsNeededBacklogRequester(ClientBacklogManager* backlogManager);
+    void requestBacklog(const BufferIdList& bufferIds) override;
+
+private:
+    int _legacyBacklogCount;
 };

--- a/src/client/backlogsettings.cpp
+++ b/src/client/backlogsettings.cpp
@@ -26,10 +26,10 @@ BacklogSettings::BacklogSettings()
 
 int BacklogSettings::requesterType() const
 {
-    int _requesterType = localValue("RequesterType", BacklogRequester::PerBufferUnread).toInt();
+    int _requesterType = localValue("RequesterType", BacklogRequester::AsNeeded).toInt();
     if (_requesterType == BacklogRequester::GlobalUnread) {
         // GlobalUnread is currently disabled; don't allow it to be used.  Reset to default instead.
-        _requesterType = BacklogRequester::PerBufferUnread;
+        _requesterType = BacklogRequester::AsNeeded;
     }
     return _requesterType;
 }

--- a/src/client/backlogsettings.cpp
+++ b/src/client/backlogsettings.cpp
@@ -44,6 +44,17 @@ void BacklogSettings::setDynamicBacklogAmount(int amount)
     return setLocalValue("DynamicBacklogAmount", amount);
 }
 
+bool BacklogSettings::ensureBacklogOnBufferShow() const
+{
+    // This settings key is also used within BufferWidget::BufferWidget()
+    return localValue("EnsureBacklogOnBufferShow", true).toBool();
+}
+
+void BacklogSettings::setEnsureBacklogOnBufferShow(bool enabled)
+{
+    return setLocalValue("EnsureBacklogOnBufferShow", enabled);
+}
+
 int BacklogSettings::fixedBacklogAmount() const
 {
     return localValue("FixedBacklogAmount", 500).toInt();

--- a/src/client/backlogsettings.cpp
+++ b/src/client/backlogsettings.cpp
@@ -26,11 +26,17 @@ BacklogSettings::BacklogSettings()
 
 int BacklogSettings::requesterType() const
 {
-    return localValue("RequesterType", BacklogRequester::PerBufferUnread).toInt();
+    int _requesterType = localValue("RequesterType", BacklogRequester::PerBufferUnread).toInt();
+    if (_requesterType == BacklogRequester::GlobalUnread) {
+        // GlobalUnread is currently disabled; don't allow it to be used.  Reset to default instead.
+        _requesterType = BacklogRequester::PerBufferUnread;
+    }
+    return _requesterType;
 }
 
 void BacklogSettings::setRequesterType(int requesterType)
 {
+    // This settings key is also used within ChatMonitorSettingsPage::ChatMonitorSettingsPage()
     setLocalValue("RequesterType", requesterType);
 }
 
@@ -103,4 +109,16 @@ int BacklogSettings::perBufferUnreadBacklogAdditional() const
 void BacklogSettings::setPerBufferUnreadBacklogAdditional(int additional)
 {
     return setLocalValue("PerBufferUnreadBacklogAdditional", additional);
+}
+
+int BacklogSettings::asNeededLegacyBacklogAmount() const
+{
+    // Mimic FixedBacklogAmount defaults.  This is only used on cores lacking
+    // Feature::BufferActivitySync.
+    return localValue("AsNeededLegacyBacklogAmount", 500).toInt();
+}
+
+void BacklogSettings::setAsNeededLegacyBacklogAmount(int amount)
+{
+    return setLocalValue("AsNeededLegacyBacklogAmount", amount);
 }

--- a/src/client/backlogsettings.h
+++ b/src/client/backlogsettings.h
@@ -62,4 +62,21 @@ public:
     void setPerBufferUnreadBacklogLimit(int limit);
     int perBufferUnreadBacklogAdditional() const;
     void setPerBufferUnreadBacklogAdditional(int additional);
+
+    /**
+     * Get the initial amount of backlog fetched across all buffers for legacy cores that do not
+     * support Quassel::Feature::BufferActivitySync
+     *
+     * @seealso Quassel::Feature::BufferActivitySync
+     * @return The amount of backlog to fetch per buffer
+     */
+    int asNeededLegacyBacklogAmount() const;
+    /**
+     * Set the initial amount of backlog fetched across all buffers for legacy cores that do not
+     * support Quassel::Feature::BufferActivitySync
+     *
+     * @seealso BacklogSettings::asNeededLegacyBacklogAmount()
+     * @param amount The amount of backlog to fetch per buffer
+     */
+    void setAsNeededLegacyBacklogAmount(int amount);
 };

--- a/src/client/backlogsettings.h
+++ b/src/client/backlogsettings.h
@@ -37,6 +37,19 @@ public:
     int dynamicBacklogAmount() const;
     void setDynamicBacklogAmount(int amount);
 
+    /**
+     * Gets if a buffer should fetch backlog upon show to provide a scrollable amount of backlog
+     *
+     * @return True if showing a buffer without scrollbar visible fetches backlog, otherwise false
+     */
+    bool ensureBacklogOnBufferShow() const;
+    /**
+     * Sets if a buffer should fetch backlog upon show to provide a scrollable amount of backlog
+     *
+     * @param enabled True if showing a buffer without scrollbar fetches backlog, otherwise false
+     */
+    void setEnsureBacklogOnBufferShow(bool enabled);
+
     int fixedBacklogAmount() const;
     void setFixedBacklogAmount(int amount);
 

--- a/src/client/clientbacklogmanager.cpp
+++ b/src/client/clientbacklogmanager.cpp
@@ -97,6 +97,9 @@ void ClientBacklogManager::requestInitialBacklog()
 
     BacklogSettings settings;
     switch (settings.requesterType()) {
+    case BacklogRequester::AsNeeded:
+        _requester = new AsNeededBacklogRequester(this);
+        break;
     case BacklogRequester::GlobalUnread:
         _requester = new GlobalUnreadBacklogRequester(this);
         break;
@@ -144,6 +147,7 @@ void ClientBacklogManager::checkForBacklog(const QList<BufferId>& bufferIds)
         break;
     case BacklogRequester::PerBufferUnread:
     case BacklogRequester::PerBufferFixed:
+    case BacklogRequester::AsNeeded:
     default: {
         BufferIdList buffers = filterNewBufferIds(bufferIds);
         if (!buffers.isEmpty())

--- a/src/client/messagemodel.cpp
+++ b/src/client/messagemodel.cpp
@@ -393,16 +393,34 @@ void MessageModel::requestBacklog(BufferId bufferId)
     BacklogSettings backlogSettings;
     int requestCount = backlogSettings.dynamicBacklogAmount();
 
+    // Assume there's no available messages
+    MsgId oldestAvailableMsgId{-1};
+
+    // Try to find the oldest (lowest ID) message belonging to this buffer
     for (int i = 0; i < messageCount(); i++) {
         if (messageItemAt(i)->bufferId() == bufferId) {
-            _messagesWaiting[bufferId] = requestCount;
-            Client::backlogManager()->emitMessagesRequested(tr("Requesting %1 messages from backlog for buffer %2:%3")
-                                                                .arg(requestCount)
-                                                                .arg(Client::networkModel()->networkName(bufferId))
-                                                                .arg(Client::networkModel()->bufferName(bufferId)));
-            Client::backlogManager()->requestBacklog(bufferId, -1, messageItemAt(i)->msgId(), requestCount);
-            return;
+            // Match found, use this message ID for requesting more backlog
+            oldestAvailableMsgId = messageItemAt(i)->msgId();
+            break;
         }
+    }
+
+    // Prepare to fetch messages
+    _messagesWaiting[bufferId] = requestCount;
+    Client::backlogManager()->emitMessagesRequested(tr("Requesting %1 messages from backlog for buffer %2:%3")
+                                                        .arg(requestCount)
+                                                        .arg(Client::networkModel()->networkName(bufferId))
+                                                        .arg(Client::networkModel()->bufferName(bufferId)));
+
+    if (oldestAvailableMsgId.isValid()) {
+        // Request messages from backlog starting from this message ID, going into the past
+        Client::backlogManager()->requestBacklog(bufferId, -1, oldestAvailableMsgId, requestCount);
+    }
+    else {
+        // No existing messages could be found.  Try to fetch the newest available messages instead.
+        // This may happen when initial backlog fetching is set to zero, or if no messages exist in
+        // a buffer.
+        Client::backlogManager()->requestBacklog(bufferId, -1, -1, requestCount);
     }
 }
 

--- a/src/qtui/bufferwidget.cpp
+++ b/src/qtui/bufferwidget.cpp
@@ -86,7 +86,7 @@ BufferWidget::BufferWidget(QWidget* parent)
     s.initAndNotify("AutoMarkerLineOnLostFocus", this, &BufferWidget::setAutoMarkerLineOnLostFocus, true);
 
     BacklogSettings backlogSettings;
-    backlogSettings.initAndNotify("EnsureBacklogOnBufferShow", this, &BufferWidget::setEnsureBacklogOnBufferShow);
+    backlogSettings.initAndNotify("EnsureBacklogOnBufferShow", this, &BufferWidget::setEnsureBacklogOnBufferShow, true);
 }
 
 BufferWidget::~BufferWidget()

--- a/src/qtui/bufferwidget.cpp
+++ b/src/qtui/bufferwidget.cpp
@@ -27,6 +27,7 @@
 
 #include "action.h"
 #include "actioncollection.h"
+#include "backlogsettings.h"
 #include "chatline.h"
 #include "chatview.h"
 #include "chatviewsearchbar.h"
@@ -83,6 +84,9 @@ BufferWidget::BufferWidget(QWidget* parent)
     ChatViewSettings s;
     s.initAndNotify("AutoMarkerLine", this, &BufferWidget::setAutoMarkerLine, true);
     s.initAndNotify("AutoMarkerLineOnLostFocus", this, &BufferWidget::setAutoMarkerLineOnLostFocus, true);
+
+    BacklogSettings backlogSettings;
+    backlogSettings.initAndNotify("EnsureBacklogOnBufferShow", this, &BufferWidget::setEnsureBacklogOnBufferShow);
 }
 
 BufferWidget::~BufferWidget()
@@ -99,6 +103,11 @@ void BufferWidget::setAutoMarkerLine(const QVariant& v)
 void BufferWidget::setAutoMarkerLineOnLostFocus(const QVariant& v)
 {
     _autoMarkerLineOnLostFocus = v.toBool();
+}
+
+void BufferWidget::setEnsureBacklogOnBufferShow(const QVariant& v)
+{
+    _ensureBacklogOnBufferShow = v.toBool();
 }
 
 AbstractChatView* BufferWidget::createChatView(BufferId id)
@@ -132,6 +141,10 @@ void BufferWidget::showChatView(BufferId id)
         Q_ASSERT(view);
         ui.stackedWidget->setCurrentWidget(view);
         _chatViewSearchController->setScene(view->scene());
+        if (_ensureBacklogOnBufferShow) {
+            // Try to ensure some messages are visible
+            view->requestBacklogForScroll();
+        }
     }
 }
 

--- a/src/qtui/bufferwidget.h
+++ b/src/qtui/bufferwidget.h
@@ -64,6 +64,13 @@ private slots:
 
     void setAutoMarkerLine(const QVariant&);
     void setAutoMarkerLineOnLostFocus(const QVariant&);
+    /**
+     * Sets the local cache of whether or not a buffer should fetch backlog upon show to provide a
+     * scrollable amount of backlog
+     *
+     * @seealso BacklogSettings::setEnsureBacklogOnBufferShow()
+     */
+    void setEnsureBacklogOnBufferShow(const QVariant&);
 
 private:
     Ui::BufferWidget ui;
@@ -73,4 +80,5 @@ private:
 
     bool _autoMarkerLine;
     bool _autoMarkerLineOnLostFocus;
+    bool _ensureBacklogOnBufferShow; ///< If a buffer fetches backlog upon show until scrollable
 };

--- a/src/qtui/chatview.cpp
+++ b/src/qtui/chatview.cpp
@@ -100,8 +100,7 @@ bool ChatView::event(QEvent* event)
         case Qt::Key_Down:
         case Qt::Key_PageUp:
         case Qt::Key_PageDown:
-            if (!verticalScrollBar()->isVisible()) {
-                scene()->requestBacklog();
+            if (requestBacklogForScroll()) {
                 return true;
             }
         default:
@@ -145,8 +144,7 @@ bool ChatView::event(QEvent* event)
     if (event->type() == QEvent::Wheel
         || (event->type() == QEvent::TouchBegin && ((QTouchEvent*)event)->device()->type() == QTouchDevice::TouchScreen)
         || event->type() == QEvent::TouchUpdate) {
-        if (!verticalScrollBar()->isVisible()) {
-            scene()->requestBacklog();
+        if (requestBacklogForScroll()) {
             return true;
         }
     }
@@ -407,6 +405,23 @@ void ChatView::setHasCache(ChatLine* line, bool hasCache)
         _linesWithCache.insert(line);
     else
         _linesWithCache.remove(line);
+}
+
+bool ChatView::requestBacklogForScroll()
+{
+    if (!verticalScrollBar()->isVisible()) {
+        // Not able to scroll, fetch backlog
+        //
+        // Future improvement: continue fetching backlog in chunks until the scrollbar is visible,
+        // or the beginning of the buffer has been reached.
+        scene()->requestBacklog();
+        // Backlog has been requested
+        return true;
+    }
+    else {
+        // Scrollbar already visible, no backlog requested
+        return false;
+    }
 }
 
 void ChatView::checkChatLineCaches()

--- a/src/qtui/chatview.h
+++ b/src/qtui/chatview.h
@@ -79,6 +79,17 @@ public:
      */
     void setHasCache(ChatLine* line, bool hasCache = true);
 
+    /**
+     * Requests backlog if the scrollbar is not currently visible
+     *
+     * Use this whenever trying to scroll the backlog to try to ensure some text is visible.  If the
+     * backlog does not have additional messages or those messages are filtered out, the scrollbar
+     * might remain invisible.
+     *
+     * @return True if the scrollbar isn't visible and a backlog request was made, otherwise false
+     */
+    bool requestBacklogForScroll();
+
 public slots:
     inline virtual void clear() {}
     void zoomIn();

--- a/src/qtui/chatview.h
+++ b/src/qtui/chatview.h
@@ -102,6 +102,7 @@ public slots:
 
 protected:
     bool event(QEvent* event) override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     void scrollContentsBy(int dx, int dy) override;
 
@@ -129,6 +130,8 @@ private:
     bool _invalidateFilter;
     QSet<ChatLine*> _linesWithCache;
     bool _firstTouchUpdateHappened = false;
+    /// Workaround: If true, backlog has been requested before the vertical scrollbar became visible
+    bool _backlogRequestedBeforeScrollable{false};
 };
 
 #endif

--- a/src/qtui/settingspages/backlogsettingspage.cpp
+++ b/src/qtui/settingspages/backlogsettingspage.cpp
@@ -33,7 +33,8 @@ BacklogSettingsPage::BacklogSettingsPage(QWidget* parent)
     // not an auto widget, because we store index + 1
 
     // FIXME: global backlog requester disabled until issues ruled out
-    ui.requesterType->removeItem(2);
+    ui.requesterType->removeItem(3);
+    // If modifying ui.requesterType's item list, set to the index of "Globally unread messages"
 
     connectToWidgetChangedSignal(ui.requesterType, this, &BacklogSettingsPage::widgetHasChanged);
 }

--- a/src/qtui/settingspages/backlogsettingspage.cpp
+++ b/src/qtui/settingspages/backlogsettingspage.cpp
@@ -46,7 +46,7 @@ bool BacklogSettingsPage::hasDefaults() const
 
 void BacklogSettingsPage::defaults()
 {
-    ui.requesterType->setCurrentIndex(BacklogRequester::PerBufferUnread - 1);
+    ui.requesterType->setCurrentIndex(BacklogRequester::AsNeeded - 1);
 
     SettingsPage::defaults();
 }

--- a/src/qtui/settingspages/backlogsettingspage.ui
+++ b/src/qtui/settingspages/backlogsettingspage.ui
@@ -94,6 +94,9 @@
      </item>
      <item>
       <widget class="QComboBox" name="requesterType">
+       <property name="currentIndex">
+        <number>2</number>
+       </property>
        <item>
         <property name="text">
          <string>Fixed amount per chat</string>
@@ -134,7 +137,7 @@
    <item>
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="page">
       <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/qtui/settingspages/backlogsettingspage.ui
+++ b/src/qtui/settingspages/backlogsettingspage.ui
@@ -106,6 +106,11 @@
        </item>
        <item>
         <property name="text">
+         <string>Only fetch when needed</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
          <string>Globally unread messages</string>
         </property>
        </item>
@@ -326,6 +331,91 @@ You can also choose to fetch additional older chatlines to provide a better cont
           <size>
            <width>20</width>
            <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_3">
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <widget class="QLabel" name="label_16">
+         <property name="text">
+          <string>&lt;p&gt;On modern cores (v0.13.0 or newer), no backlog will be fetched.  The core keeps track of chat activity automatically.&lt;br/&gt;
+&lt;i&gt;Note: Chat Monitor won't show past messages.&lt;/i&gt;
+&lt;/p&gt;
+&lt;p&gt;On older cores, this requester fetches a fixed amount of lines for each chat window from the backlog.&lt;/p&gt;</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item>
+          <widget class="QLabel" name="label_4">
+           <property name="toolTip">
+            <string>Amount of messages per buffer that are requested after the core connection has been established.</string>
+           </property>
+           <property name="text">
+            <string>For legacy cores, initial backlog amount:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="asNeededLegacyBacklogAmount">
+           <property name="specialValueText">
+            <string/>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>99999</number>
+           </property>
+           <property name="singleStep">
+            <number>10</number>
+           </property>
+           <property name="value">
+            <number>500</number>
+           </property>
+           <property name="settingsKey" stdset="0">
+            <string notr="true">AsNeededLegacyBacklogAmount</string>
+           </property>
+           <property name="defaultValue" stdset="0">
+            <number>500</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_6">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>263</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>47</height>
           </size>
          </property>
         </spacer>

--- a/src/qtui/settingspages/backlogsettingspage.ui
+++ b/src/qtui/settingspages/backlogsettingspage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>446</width>
-    <height>325</height>
+    <height>329</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -59,6 +59,22 @@
       </spacer>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="ensureBacklogOnBufferShow">
+     <property name="toolTip">
+      <string>When switching to a chat, more backlog will be fetched if no messages are shown yet or the scrollbar isn't visible.  Useful when not fetching any initial backlog.</string>
+     </property>
+     <property name="text">
+      <string>Fetch backlog if needed when switching chats</string>
+     </property>
+     <property name="settingsKey" stdset="0">
+      <string notr="true">EnsureBacklogOnBufferShow</string>
+     </property>
+     <property name="defaultValue" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="Line" name="line">

--- a/src/qtui/settingspages/chatmonitorsettingspage.cpp
+++ b/src/qtui/settingspages/chatmonitorsettingspage.cpp
@@ -73,7 +73,7 @@ ChatMonitorSettingsPage::ChatMonitorSettingsPage(QWidget* parent)
 
     // AsNeededBacklogRequester conflicts with showing backlog in Chat Monitor
     BacklogSettings backlogSettings;
-    backlogSettings.initAndNotify("RequesterType", this, &ChatMonitorSettingsPage::setRequesterType, BacklogRequester::PerBufferUnread);
+    backlogSettings.initAndNotify("RequesterType", this, &ChatMonitorSettingsPage::setRequesterType, BacklogRequester::AsNeeded);
 }
 
 bool ChatMonitorSettingsPage::hasDefaults() const

--- a/src/qtui/settingspages/chatmonitorsettingspage.cpp
+++ b/src/qtui/settingspages/chatmonitorsettingspage.cpp
@@ -20,8 +20,11 @@
 
 #include "chatmonitorsettingspage.h"
 
+#include <QMessageBox>
 #include <QVariant>
 
+#include "backlogrequester.h"
+#include "backlogsettings.h"
 #include "buffermodel.h"
 #include "bufferview.h"
 #include "bufferviewconfig.h"
@@ -67,6 +70,10 @@ ChatMonitorSettingsPage::ChatMonitorSettingsPage(QWidget* parent)
     connect(ui.alwaysOwn, &QAbstractButton::toggled, this, &ChatMonitorSettingsPage::widgetHasChanged);
     connect(ui.showBacklog, &QAbstractButton::toggled, this, &ChatMonitorSettingsPage::widgetHasChanged);
     connect(ui.includeRead, &QAbstractButton::toggled, this, &ChatMonitorSettingsPage::widgetHasChanged);
+
+    // AsNeededBacklogRequester conflicts with showing backlog in Chat Monitor
+    BacklogSettings backlogSettings;
+    backlogSettings.initAndNotify("RequesterType", this, &ChatMonitorSettingsPage::setRequesterType, BacklogRequester::PerBufferUnread);
 }
 
 bool ChatMonitorSettingsPage::hasDefaults() const
@@ -278,4 +285,35 @@ void ChatMonitorSettingsPage::switchOperationMode(int idx)
         ui.labelActiveBuffers->setText(tr("Ignore:"));
     }
     widgetHasChanged();
+}
+
+void ChatMonitorSettingsPage::setRequesterType(const QVariant& v)
+{
+    bool usingAsNeededRequester = (v.toInt() == BacklogRequester::AsNeeded);
+    ui.showBacklogUnavailableDetails->setVisible(usingAsNeededRequester);
+    if (usingAsNeededRequester) {
+        ui.showBacklog->setText(tr("Show messages from backlog (not available)"));
+    }
+    else {
+        ui.showBacklog->setText(tr("Show messages from backlog"));
+    }
+}
+
+void ChatMonitorSettingsPage::on_showBacklogUnavailableDetails_clicked()
+{
+    // Explain that backlog fetching is disabled, so backlog messages won't show up
+    //
+    // Technically, backlog messages *will* show up once fetched, e.g. after clicking on a buffer.
+    // This might be too trivial of a detail to warrant explaining, though.
+    QMessageBox::information(this,
+                             tr("Messages from backlog are not fetched"),
+                             QString("<p>%1</p><p>%2</p>")
+                                     .arg(tr("No initial backlog will be fetched when using the backlog request method of <i>%1</i>.")
+                                             .arg(tr("Only fetch when needed").replace(" ", "&nbsp;")),
+                                          tr("Configure this in the <i>%1</i> settings page.")
+                                             .arg(tr("Backlog Fetching").replace(" ", "&nbsp;"))
+                                     )
+    );
+    // Re-use translations of "Only fetch when needed" and "Backlog Fetching" as this is a
+    // word-for-word reference, forcing all spaces to be non-breaking
 }

--- a/src/qtui/settingspages/chatmonitorsettingspage.h
+++ b/src/qtui/settingspages/chatmonitorsettingspage.h
@@ -49,6 +49,18 @@ private slots:
     void on_deactivateBuffer_clicked();
     void switchOperationMode(int idx);
 
+    /**
+     * Sets the local cache of the current backlog requester type, used to determine if showing
+     * backlog in the Chat Monitor will work
+     *
+     * @seealso BacklogSettings::setRequesterType()
+     */
+    void setRequesterType(const QVariant&);
+
+    /**
+     * Event handler for Show Backlog Unavailable Details button
+     */
+    void on_showBacklogUnavailableDetails_clicked();
 private:
     Ui::ChatMonitorSettingsPage ui;
     QHash<QString, QVariant> settings;

--- a/src/qtui/settingspages/chatmonitorsettingspage.ui
+++ b/src/qtui/settingspages/chatmonitorsettingspage.ui
@@ -189,14 +189,31 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QCheckBox" name="showBacklog">
-     <property name="toolTip">
-      <string>Display messages from backlog on reconnect</string>
-     </property>
-     <property name="text">
-      <string>Show messages from backlog</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QCheckBox" name="showBacklog">
+       <property name="toolTip">
+        <string>Display messages from backlog on reconnect</string>
+       </property>
+       <property name="text">
+        <string>Show messages from backlog</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="showBacklogUnavailableDetails">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Details...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -247,6 +264,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>showOwnMessages</tabstop>
   <tabstop>alwaysOwn</tabstop>
   <tabstop>showBacklog</tabstop>
+  <tabstop>showBacklogUnavailableDetails</tabstop>
   <tabstop>includeRead</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
## In short
* Fix dynamic backlog requests with 0 initial backlog fetched
  * Fallback to fetching newest messages when none exist in a buffer
* Try to ensure backlog is available when showing a buffer
  * Fetch as if scrolling, unless the scrollbar is visible
  * Default enabled, can be disabled
  * Fetched messages might be filtered out; Quassel had this issue before (just scroll more)
* Add `AsNeededBacklogRequester`: fixed backlog for legacy, no backlog for `0.13.0`+
  * Modern cores with `Feature::BufferActivitySync` know if activity happened without client fetching
  * Should speed up logging in
  * Clients connecting to legacy cores behave as `FixedBacklogRequester`
  * Breaks `Show messages from backlog` Chat Monitor feature, warnings added to UI
  * Default enabled, can be changed to other backlog requester types
* Cleanup
  * Further enforce disabled state of `GlobalUnreadBacklogRequester` (stops manual config edits to enable this)
  * Workaround scroll jump when fetching backlog makes vertical scrollbar visible

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing performance and network improvements
Risk | ★★☆ *2/3* | Changes Chat Monitor behavior to not show backlog
Intrusiveness | ★★☆ *2/3* | UI, string, settings changes, may interfere with other PRs

## Rationale
As of `0.13.0` and newer cores, Quassel clients already know when buffer activity has occurred without fetching messages.  However, due to a bug in dynamic backlog fetching being broken when set to zero, it wasn't feasible to make use of this.  Additionally, the annoyance of having to scroll when switching to each buffer wasn't great.

By fixing backlog scrolling with zero initial backlog and behaving as if one scrolled up whenever switching buffers (until the scrollbar is visible), Quassel can reasonably be used with zero backlog fetched.

Quasseldroid already makes use of this functionality to great effect, speeding up login.

Legacy cores are handled as if using the fixed backlog requester, so no functionality is lost, alongside the user being able to pick the previous backlog requester modes.

### Breaking changes
* Chat Monitor won't show messages from backlog on newer cores
  * This can be re-enabled by switching to the fixed backlog requester
  * Appropriate warnings are shown in the UI

## Testing
### Modern core
* Connecting doesn't fetch any backlog
* Buffer activity and highlights still show up
* Selecting a buffer by clicking/keyboard shortcuts fetches the dynamic backlog fetch amount (unless scrollbar is visible)

### Legacy core
*Note: this was emulated by disabling `Feature::BufferActivitySync` and making use of legacy/local highlights.  Otherwise, this applies to Quassel core version `0.12.5` and older.*

*Testing helper patch to [`client.cpp`](https://github.com/quassel/quassel/blob/master/src/client/client.cpp ):*
```diff
 bool Client::isCoreFeatureEnabled(Quassel::Feature feature)
 {
+    // DEBUG: testing helper
+    if (feature == Quassel::Feature::BufferActivitySync) {
+        qDebug() << "DEBUG: Simulating BufferActivitySync being disabled.";
+        return false;
+    }
     return coreConnection()->peer() ? coreConnection()->peer()->hasFeature(feature) : false;
 }
```

* Connecting fetches backlog up to the specified legacy initial backlog fetch amount
* Highlights show up if within the initial backlog fetch amount
* Selecting a buffer shows the initially fetched backlog

*Note: it's possible to change the defaults and use the fixed backlog requester with initial backlog fetch amount set to zero even with legacy cores.  However, that won't show buffer activity/highlights.*

## Examples
### Backlog Fetching showing `Only fetch when needed`
*In Settings → Interface → Backlog Fetching, details on the `Only fetch when needed` backlog fetching mode*
![Backlog Fetching settings page showing the "Backlog request method" of "Only fetch when needed"](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-backlog-zero-request-hero/Settings%20-%20Backlog%20Fetching%20-%20AsNeededBacklogRequester%20details.png#v1)
> Dynamic backlog amount: `200`
>
> \[checked\] Fetch backlog if needed when switching chats
>
> Backlog request method: `Only fetch when needed`
>
> On modern cores (v0.13.0 or newer), no backlog will be fetched.  The core keeps track of chat activity automatically.
> *Note: Chat Monitor won't show past messages.*
>
> On older cores, this requester fetches a fixed amount of lines for each chat window from the backlog.
>
> For legacy cores, initial backlog amount: `500`

*Tooltip for the checkbox `Fetch backlog if needed when switching chats`:*
> When switching to a chat, more backlog will be fetched if no messages are shown yet or the scrollbar isn't visible.  Useful when not fetching any initial backlog.

### Chat Monitor with `Only fetch when needed`
*In Settings → Interface → Chat Monitor, settings page showing `Show messages from backlog` marked as `(not available)` and "Details…" dialog*
![Settings page showing Chat Monitor configuration](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-backlog-zero-request-hero/Settings%20-%20Chat%20Monitor%20-%20ShowBacklog%20disabled%20due%20to%20AsNeededBacklogRequester.png#v4)
> Show messages from backlog (not available)

*Dialog with title of `Messages from backlog are not fetched`:*
> No initial backlog will be fetched when using the backlog request method of *Only fetch when needed*.
>
> Configure this in the *Backlog Fetching* settings page.

*Note: changing to the other backlog fetch modes result in hiding the `Details…` button and removing `(not available)`, returning the checkbox to `Show messages from backlog`, as before.*