### PR TITLE
common: Fix IrcUser::quitInternal() not syncing quit()

### DIFF
--- a/src/common/ircuser.cpp
+++ b/src/common/ircuser.cpp
@@ -334,7 +334,7 @@ void IrcUser::quitInternal(bool skip_sync)
         channel->part(this);
     }
     network()->removeIrcUser(this);
-    if (!skip_sync) SYNC(NO_ARG)
+    if (!skip_sync) SYNC_OTHER(quit, NO_ARG)
     emit quited();
 }
 


### PR DESCRIPTION
## In short
* Fix `IrcUser::quitInternal()` so it calls `IrcUser::quit()` in protocol
  * Addresses nicknames remaining visible in `Nicks` list and buffers after `/quit`
  * Finishes the [fix in a previous commit](https://github.com/quassel/quassel/commit/7298446b3e86140c4bbbfe7aeeb959c16c53363c#diff-ddb895c77a2bfda29c64344f593102daR323-R339 ) - that commit unintentionally changed the protocol
  * Affects old and new clients, only core needs upgraded

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | User-facing, fixes nickname quits broken for old and new clients
Risk | ★★☆ *2/3* | Protocol change could break other things, but it's already broken
Intrusiveness | ★☆☆ *1/3* | Minimal code changes, shouldn't interfere with other pull requests

*Thanks to `ephemer0l_` on `freenode/#quassel` for bringing this issue up.*

## Testing

### Channel activity

*Joined `#qcore_dev_test` on `freenode` via Kiwi IRC (client doesn't matter).*

```
--> kiwipre-68 ([...]) has joined #qcore_dev_test
<-- kiwipre-68 ([...]) has quit (Client Quit)
```

### Before: new client, new core

```
2020-07-11 17:53:26 [Warn ] "no matching slot for sync call: IrcUser::quitInternal (objectName=\"2/kiwipre-68\"). Params are:" ()
```

### After

Test conditions  | Result  | Remarks
-----------------|---------|-------------
New core, new client | ✅ *pass* |
New core, old client | ✅ *pass* |
Old core, new client | ✅ *pass* |
New monolithic | ✅ *pass* |

*IrcUser is successfully marked as having quit, removed from nick list.*