### PR TITLE
client: Fix crash on switching buffers with no buffer selected

### DIFF
--- a/src/client/treemodel.cpp
+++ b/src/client/treemodel.cpp
@@ -569,6 +569,12 @@ void TreeModel::debug_rowsAboutToBeRemoved(const QModelIndex& parent, int start,
         parentItem = rootItem;
     qDebug() << "debug_rowsAboutToBeRemoved" << parent << parentItem << parent.data().toString() << rowCount(parent) << start << end;
 
+    // Make sure model is valid first
+    if (!parent.model()) {
+        qDebug() << "Parent model is not valid!" << end;
+        return;
+    }
+
     QModelIndex child;
     for (int i = end; i >= start; i--) {
         child = parent.model()->index(i, 0, parent);
@@ -584,6 +590,12 @@ void TreeModel::debug_rowsInserted(const QModelIndex& parent, int start, int end
     if (!parentItem)
         parentItem = rootItem;
     qDebug() << "debug_rowsInserted:" << parent << parentItem << parent.data().toString() << rowCount(parent) << start << end;
+
+    // Make sure model is valid first
+    if (!parent.model()) {
+        qDebug() << "Parent model is not valid!" << end;
+        return;
+    }
 
     QModelIndex child;
     for (int i = start; i <= end; i++) {

--- a/src/qtui/nicklistwidget.cpp
+++ b/src/qtui/nicklistwidget.cpp
@@ -176,6 +176,10 @@ void NickListWidget::rowsAboutToBeRemoved(const QModelIndex& parent, int start, 
     }
     else {
         // check if there are explicitly buffers removed
+        // Make sure model is valid first
+        if (!parent.model()) {
+            return;
+        }
         for (int i = start; i <= end; i++) {
             QVariant variant = parent.model()->index(i, 0, parent).data(NetworkModel::BufferIdRole);
             if (!variant.isValid())

--- a/src/uisupport/abstractbuffercontainer.cpp
+++ b/src/uisupport/abstractbuffercontainer.cpp
@@ -46,6 +46,10 @@ void AbstractBufferContainer::rowsAboutToBeRemoved(const QModelIndex& parent, in
     }
     else {
         // check if there are explicitly buffers removed
+        // Make sure model is valid first
+        if (!parent.model()) {
+            return;
+        }
         for (int i = start; i <= end; i++) {
             QVariant variant = parent.model()->index(i, 0, parent).data(NetworkModel::BufferIdRole);
             if (!variant.isValid())

--- a/src/uisupport/bufferview.cpp
+++ b/src/uisupport/bufferview.cpp
@@ -493,14 +493,18 @@ void BufferView::changeBuffer(Direction direction)
             QModelIndex newParent = currentIndex.sibling(currentIndex.row() - 1, 0);
             if (currentIndex.row() == 0)
                 newParent = lastNetIndex;
-            if (model()->hasChildren(newParent))
-                resultingIndex = newParent.model()->index(model()->rowCount(newParent) - 1, 0, newParent);
+            if (model()->hasChildren(newParent)) {
+                // Treat an invalid QAbstractItemModel as an invalid QModelIndex
+                resultingIndex = (newParent.model() ? newParent.model()->index(model()->rowCount(newParent) - 1, 0, newParent) : QModelIndex());
+            }
             else
                 resultingIndex = newParent;
         }
         else {
-            if (model()->hasChildren(currentIndex))
-                resultingIndex = currentIndex.model()->index(0, 0, currentIndex);
+            if (model()->hasChildren(currentIndex)) {
+                // Treat an invalid QAbstractItemModel as an invalid QModelIndex
+                resultingIndex = (currentIndex.model() ? currentIndex.model()->index(0, 0, currentIndex) : QModelIndex());
+            }
             else
                 resultingIndex = currentIndex.sibling(currentIndex.row() + 1, 0);
         }
@@ -509,8 +513,10 @@ void BufferView::changeBuffer(Direction direction)
     if (!resultingIndex.isValid()) {
         if (direction == Forward)
             resultingIndex = model()->index(0, 0, QModelIndex());
-        else
+        else {
+            // Assume model is valid
             resultingIndex = lastNetIndex.model()->index(model()->rowCount(lastNetIndex) - 1, 0, lastNetIndex);
+        }
     }
 
     selectionModel()->setCurrentIndex(resultingIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);

--- a/src/uisupport/nickviewfilter.cpp
+++ b/src/uisupport/nickviewfilter.cpp
@@ -41,7 +41,7 @@ NickViewFilter::NickViewFilter(const BufferId& bufferId, NetworkModel* parent)
 bool NickViewFilter::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const
 {
     // root node, networkindexes, the bufferindex of the buffer this filter is active for and it's children are accepted
-    if (!source_parent.isValid())
+    if (!(source_parent.isValid() && source_parent.model()))
         return true;
 
     QModelIndex source_child = source_parent.model()->index(source_row, 0, source_parent);


### PR DESCRIPTION
## In short
* Handle invalid `QAbstractItemModel` when switching buffers and elsewhere
  * Fixes [issue #1583, "Regression in "Mouse wheel changes selected chat" causing crash"](https://bugs.quassel-irc.org/issues/1583 )
  * Regression caused by [commit "Replace deprecated QModelIndex::child with QAbstractItemModel::index"](https://github.com/quassel/quassel/commit/a453c963cf1872e14c83adf1d40a31821c166805 )
  * Qt's documentation [only indirectly warned of this](https://doc.qt.io/qt-5/qmodelindex-obsolete.html ), issue is easy to overlook

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | User-facing crash fix when using hotkeys/shortcuts to switch buffers
Risk | ★☆☆ *1/3* | Return to original code path; possible unexpected behavior or incomplete fix
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

*Special thanks to `oprypin` [for reporting this with a detailed, reproducible test case](https://bugs.quassel-irc.org/issues/1583 )!*

## Implementation

*See the commit message!*

## Testing
### Steps

*Adapted from [the original issue](https://bugs.quassel-irc.org/issues/1583 ).*

1.  Start Quassel monolithic with a blank configuration
2.  Connect to an IRC network
3.  Join a channel
    * E.g. set `Join Channels Automatically` to `#quassel-test`
4.  Right-click any buffer, permanently hide
5.  **Do not select any other buffers by mouse**, ensure the buffer list shows nothing selected
5.  Use <kbd>Alt</kbd>+<kbd>Up arrow</kbd> and <kbd>Alt</kbd>+<kbd>Down arrow</kbd> to switch between buffers
6.  Observe results

### Example test case layout

*Nothing is selected when performing buffer switch*

* `freenode` (network, not selected)
  * `#quassel-test` (channel, **permanently hidden**)

### Before

Crash (null reference) in `BufferView::changeBuffer()` within file `src/uisupport/bufferview.cpp`.

### After

Quassel changes buffers as expected, skipping the permanently hidden buffer.
