### PR TITLE
client: Allow opening commit links in Core Info, add keyboard access

### DIFF
--- a/src/qtui/aboutdlg.ui
+++ b/src/qtui/aboutdlg.ui
@@ -78,7 +78,7 @@ p, li { white-space: pre-wrap; }
              <bool>true</bool>
             </property>
             <property name="textInteractionFlags">
-             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+             <set>Qt::TextBrowserInteraction</set>
             </property>
            </widget>
           </item>

--- a/src/qtui/coreinfodlg.ui
+++ b/src/qtui/coreinfodlg.ui
@@ -28,6 +28,12 @@
        <property name="text">
         <string notr="true">&lt;core version&gt;</string>
        </property>
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextBrowserInteraction</set>
+       </property>
       </widget>
      </item>
      <item row="1" column="0">

--- a/src/qtui/coresessionwidget.ui
+++ b/src/qtui/coresessionwidget.ui
@@ -43,6 +43,12 @@
           <property name="text">
            <string notr="true">v0.13-pre (0.12.0+372 git-12df418)</string>
           </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextBrowserInteraction</set>
+          </property>
          </widget>
         </item>
         <item row="1" column="0">


### PR DESCRIPTION
## In short
* Allow opening version links in `Core Info...`
  * Follows precedent set by `About` dialog
  * Assumes already-authenticated clients/cores won't specify deceptive links
* Add keyboard access to version links
  * For `About` dialog, follows the behavior of other links
  * For `Core Info...` dialog, ensures keyboard access is feasible
  * Introduces more tab stops

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Minor user-facing ability to open links like expected
Risk | ★☆☆ *1/3* | Malicious authenticated Quassel cores/clients could set phishing links
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Testing
### Steps

1.  Start Quassel client
2.  Connect to a Quassel core 0.13.0 or newer
3.  Open `Help` → `About Quassel`
4.  Try using <kbd>Tab</kbd> to navigate and activate the client version link
5.  Close `About` dialog, open `File` → `Core Info…`
6.  Click the core `Version:` commit link
7.  Click the connected client `Client:` commit link
8.  Try using <kbd>Tab</kbd> to navigate and activate the version links

### Before

* Keyboard could not be used to open the client version commit link in the `About` dialog
* Clicking the version commit links in `Core Information` did nothing
* Keyboard could not be used to navigate the client version commit links in the `Core Information` dialog

### After

* Keyboard navigation focuses client version commit link in the `About` dialog
* Clicking the version commit links in `Core Information` open the commit information
* Keyboard navigation focuses client version commit links in the `Core Information` dialog
