### PR TITLE
client: Group SASL EXTERNAL under Use SASL Auth, test right cap

### DIFF
--- a/src/qtui/settingspages/networkssettingspage.h
+++ b/src/qtui/settingspages/networkssettingspage.h
@@ -150,7 +150,8 @@ private:
     // Status icons
     QIcon infoIcon, successIcon, unavailableIcon, questionIcon;
 
-    CapSupportStatus _saslStatusSelected;  /// Status of SASL support for currently-selected network
+    CapSupportStatus _capSaslStatusSelected;  ///< Status of SASL support for selected network
+    bool _capSaslStatusUsingExternal{false};  ///< Whether SASL support status is for SASL EXTERNAL
 
     void reset();
     bool testHasChanged();
@@ -161,11 +162,19 @@ private:
     IdentityId defaultIdentity() const;
 
     /**
+     * Get whether or not the displayed network's identity has SSL certs associated with it
+     *
+     * @return True if the currently displayed network has SSL certs set, otherwise false
+     */
+    bool displayedNetworkHasCertId() const;
+
+    /**
      * Update the SASL settings interface according to the given SASL state
      *
-     * @param[in] saslStatus Current status of SASL support.
+     * @param saslStatus         Current status of SASL support.
+     * @param usingSASLExternal  If true, SASL support status is for SASL EXTERNAL, else SASL PLAIN
      */
-    void setSASLStatus(const CapSupportStatus saslStatus);
+    void setCapSASLStatus(const CapSupportStatus saslStatus, bool usingSASLExternal = false);
 };
 
 class NetworkAddDlg : public QDialog

--- a/src/qtui/settingspages/networkssettingspage.ui
+++ b/src/qtui/settingspages/networkssettingspage.ui
@@ -682,7 +682,7 @@ Note that Quassel IRC automatically rejoins channels, so /join will rarely be ne
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_11">
              <item>
-              <widget class="QFrame" name="saslContents">
+              <widget class="QFrame" name="saslPlainContents">
                <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
                </property>
@@ -755,51 +755,51 @@ Note that Quassel IRC automatically rejoins channels, so /join will rarely be ne
                   </item>
                  </layout>
                 </item>
-                <item>
-                 <layout class="QHBoxLayout" name="horizontalLayout_7">
-                  <item>
-                   <widget class="QLabel" name="saslStatusIcon">
-                    <property name="text">
-                     <string notr="true">[icon]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QLabel" name="saslStatusLabel">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>Could not detect if supported by server</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QPushButton" name="saslStatusDetails">
-                    <property name="text">
-                     <string>Details...</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
                </layout>
               </widget>
              </item>
+             <item>
+              <widget class="QLabel" name="saslExtInfo">
+               <property name="text">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; because the identity has an ssl certificate set, SASL EXTERNAL will be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_7">
+               <item>
+                <widget class="QLabel" name="saslStatusIcon">
+                 <property name="text">
+                  <string notr="true">[icon]</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="saslStatusLabel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Could not detect if supported by server</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="saslStatusDetails">
+                 <property name="text">
+                  <string>Details...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
             </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="saslExtInfo">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; because the identity has an ssl certificate set, SASL EXTERNAL will be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
            </widget>
           </item>
           <item>


### PR DESCRIPTION
## In short

* Group the SASL EXTERNAL note within the `Use SASL Authentication` box
  * Clarifies that `Use SASL` must be checked for SASL EXTERNAL to be used
  * Ties the use of SASL EXTERNAL with the SASL availability line
* Check for `sasl=EXTERNAL` support when SASL EXTERNAL is used
  * Avoids misleading message that SASL is supported when only `sasl=PLAIN` is available
  * Update `Details...` dialog text
  * SASL v3.1 may still mislead, phrase details to account for this

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | User-facing clarity for uncommon feature, reduces SASL confusion
Risk | ★☆☆ *1/3* | May make SSL cert appear to not apply for NickServ cert login
Intrusiveness | ★★☆ *2/3* | UI, string changes, may interfere with other PRs

## Rationale
Quassel only negotiates `SASL EXTERNAL` if `Use SASL Authentication` is checked, [even in `0.12` series](https://github.com/quassel/quassel/blob/0.12.5/src/core/corenetwork.cpp#L529-L531 ).  Quassel should communicate this in the interface by grouping the `SASL EXTERNAL` note text within the `Use SASL Authentication` group checkbox.  This will make it more clear when SASL is or is not being used.

When an identity has a certificate set in order to use `SASL EXTERNAL`, Quassel should check for `sasl=EXTERNAL` support before showing that SASL is supported, as some servers support `sasl=PLAIN` without `EXTERNAL`.  This should reduce confusion about why SASL certificate logins might not be working.

## Examples
### Before
*In Settings → IRC → Networks, showing the `Auto Identify` tab on a network supporting `SASL EXTERNAL`*
![Settings - IRC - Networks settings page showing SASL EXTERNAL note outside of the "Use SASL Authentication" group checkbox](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-sasl-external-ui-prompts/SASL%20-%20before%20-%20EXTERNAL%20supported.png#v1)
> **Note:** because the identity has an ssl certificate set, SASL EXTERNAL will be used.

Quassel does not indicate that `Use SASL Authentication` must be checked.

### After, `SASL EXTERNAL` supported by network
*In Settings → IRC → Networks, showing the `Auto Identify` tab on a network supporting `SASL EXTERNAL`*
![Settings - IRC - Networks settings page showing SASL EXTERNAL note inside the "Use SASL Authentication" group checkbox, above the "May be supported by network" line.  Above this, a dialog for "SASL support for 'Freenode'" is shown](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-sasl-external-ui-prompts/SASL%20-%20after%20-%20EXTERNAL%20supported.png#v3)
> **Note:** because the identity has an ssl certificate set, SASL EXTERNAL will be used.
> *:information_source: May be supported by network*

> Dialog *SASL support for "Freenode"*:
> **SASL EXTERNAL may be supported by network**
> The network "Freenode" may support SASL EXTERNAL for SSL certificate authentication.  In most cases, you should use SASL instead of NickServ identification.
>
> *SASL is a standardized way to log in and identity yourself to IRC servers.*

### After, `SASL EXTERNAL` *not* supported by network
*In Settings → IRC → Networks, showing the `Auto Identify` tab on a network **not** supporting `SASL EXTERNAL`*
![Settings - IRC - Networks settings page showing SASL EXTERNAL note inside the "Use SASL Authentication" group checkbox, above the "Not currently supported by network" line.  Above this, a dialog for "SASL support for 'Local (Bitlbee)'" is shown](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-sasl-external-ui-prompts/SASL%20-%20after%20-%20EXTERNAL%20not%20supported.png#v3)
> **Note:** because the identity has an ssl certificate set, SASL EXTERNAL will be used.
> *:warning: Not currently supported by network*

> Dialog *SASL support for "Local (Bitlbee)"*:
> **SASL EXTERNAL not currently supported by network**
> The network "Local (Bitlbee)" does not currently support SASL EXTERNAL for SSL certificate authentication.  However, support might be added later on.
>
> *SASL is a standardized way to log in and identity yourself to IRC servers.*
