### PR TITLE
Keep editing topic while someone talks

### DIFF
--- a/src/qtui/topicwidget.cpp
+++ b/src/qtui/topicwidget.cpp
@@ -152,13 +152,17 @@ void TopicWidget::setTopic(const QModelIndex& index)
         }
     }
 
-    _topic = sanitizeTopic(newtopic);
-    _readonly = readonly;
+    QString sanitizedNewTopic = sanitizeTopic(newtopic);
+    if (readonly != _readonly || sanitizedNewTopic != _topic)
+    {
+        _topic = sanitizedNewTopic;
+        _readonly = readonly;
 
-    ui.topicEditButton->setVisible(!_readonly);
-    ui.topicLabel->setText(_topic);
-    ui.topicLineEdit->setPlainText(_topic);
-    switchPlain();
+        ui.topicEditButton->setVisible(!_readonly);
+        ui.topicLabel->setText(_topic);
+        ui.topicLineEdit->setPlainText(_topic);
+        switchPlain();
+    }
 }
 
 void TopicWidget::setReadOnly(const bool& readonly)


### PR DESCRIPTION
Without this change, it's almost impossible to edit the topic with the
topic widget in busy channels because every message would trigger the
dataChanged signal which would reset the topic and switch the topic
widget out of editing mode.

Fixes #1485.