### PR TITLE
client: Fix Networks settings crash on missing network identity

### DIFF
--- a/src/qtui/settingspages/networkssettingspage.cpp
+++ b/src/qtui/settingspages/networkssettingspage.cpp
@@ -573,12 +573,21 @@ void NetworksSettingsPage::displayNetwork(NetworkId id)
         // this is only needed when the core supports SASL EXTERNAL
         if (Client::isCoreFeatureEnabled(Quassel::Feature::SaslExternal)) {
             if (_cid) {
+                // Clean up existing CertIdentity
                 disconnect(_cid, &CertIdentity::sslSettingsUpdated, this, &NetworksSettingsPage::sslUpdated);
                 delete _cid;
+                _cid = nullptr;
             }
-            _cid = new CertIdentity(*Client::identity(info.identity), this);
-            _cid->enableEditSsl(true);
-            connect(_cid, &CertIdentity::sslSettingsUpdated, this, &NetworksSettingsPage::sslUpdated);
+            auto *identity = Client::identity(info.identity);
+            if (identity) {
+                // Connect new CertIdentity
+                _cid = new CertIdentity(*identity, this);
+                _cid->enableEditSsl(true);
+                connect(_cid, &CertIdentity::sslSettingsUpdated, this, &NetworksSettingsPage::sslUpdated);
+            }
+            else {
+                qWarning() << "NetworksSettingsPage::displayNetwork can't find Identity for IdentityId:" << info.identity;
+            }
         }
 
         ui.identityList->setCurrentIndex(ui.identityList->findData(info.identity.toInt()));


### PR DESCRIPTION
## In short
* Check for non-existent identity in `Networks` settings
  * Fixes crash when identity is deleted or non-existent
  * Ported from [patch provided by `kater` in issue #1409](https://bugs.quassel-irc.org/issues/1409 )

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes confusing crash after canceling setup wizard
Risk | ★☆☆ *1/3* | Invalid identity could expose crashes/bugs elsewhere
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

*I'm not sure how to properly provide credit to `kater`; if they notice this and request different attribution, I'll happily fix it!*

## Testing
### Steps

1.  Clear the configuration for Quassel monolithic
2.  Start Quassel monolithic
3.  Cancel the setup wizard (before creating any identity)
4.  Go to `Settings` → `Configure Quassel...` (<kbd>F7</kbd>)
5.  Navigate to `IRC` → `Identities`, confirm that no identity exists
6.  Navigate to `IRC` → `Networks`
7.  Add a new network (details don't matter)
8.  Observe results
9.  Try to connect to the new network with invalid identity (if not crashed)

### Before

Quassel crashes after adding the network.

### After

Quassel `Networks` page does not show any identity for the `Identity:` selection combo-box.  It is still possible to add an identity with the "configure" button next to the selection combo-box, or on the `IRC` → `Identities` page.

Quassel debug log (`Help` → `Debug` → `Debug Log`):
```
2020-09-23 00:49:11 [Warn ] NetworksSettingsPage::displayNetwork can't find Identity for IdentityId:  0
```

Quassel debug log after connection attempt:
```
2020-09-23 00:50:00 [Warn ] InputWidget::updateNickSelector(): can't find Identity for Network  1 IdentityId:  0
2020-09-23 00:50:01 [Warn ] Invalid identity configures, ignoring connect request!
```

Quassel connects successfully after adding a new identity.