### PR TITLE
ci: Make artifact sanity checks non-fatal for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,6 +224,7 @@ jobs:
       run: ls -lhR artifacts
 
     - name: Check artifacts
+      continue-on-error: true # macOS packaging is unreliable
       run: |
         # Sanity check: We should have exactly 5 files matching the given patterns
         [[ 5 -eq $(find artifacts/ \( -type f -name 'Quassel*.dmg' -o -name 'quassel*.exe' -o -name 'quassel*.7z' \) -printf '.' | wc -c) ]]


### PR DESCRIPTION
Currently, OSX packaging is unreliable due to a race condition in the
scripts, sporadically leading to a missing QuasselCore package. A
proper fix would require a modernization of the packaging process.

Mark the artifact sanity check non-fatal for now, until a proper
solution can be implemented.