### PR TITLE
ci: Workaround macOS hdiutil out of space errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,7 +224,6 @@ jobs:
       run: ls -lhR artifacts
 
     - name: Check artifacts
-      continue-on-error: true # macOS packaging is unreliable
       run: |
         # Sanity check: We should have exactly 5 files matching the given patterns
         [[ 5 -eq $(find artifacts/ \( -type f -name 'Quassel*.dmg' -o -name 'quassel*.exe' -o -name 'quassel*.7z' \) -printf '.' | wc -c) ]]


### PR DESCRIPTION
## In short
* Workaround macOS packaging out of space errors
  * Allow `hdiutil` to automatically determine size
  * After [171 tests](https://github.com/digitalcircuit/quassel/actions?query=branch%3Afix-macos-hdiutil-size ), only [3 failed runs](https://github.com/digitalcircuit/quassel/actions?query=branch%3Afix-macos-hdiutil-size+is%3Afailure ) = 98% success
* Make the macOS packaging properly error when commands fail
* Re-enable requirement for macOS build success

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Developer-facing polish, ensures macOS builds keep working
Risk | ★☆☆ *1/3* | Possible unrelated intermittent build failures
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests


## Testing
### Results

* [171 tests](https://github.com/digitalcircuit/quassel/actions?query=branch%3Afix-macos-hdiutil-size ), [3 failures](https://github.com/digitalcircuit/quassel/actions?query=branch%3Afix-macos-hdiutil-size+is%3Afailure ) = 98% success rate!
  * One [hang when installing dependencies](https://github.com/digitalcircuit/quassel/actions/runs/355533522 ) (before packaging step, unrelated)
  * Two failures to mount filesystems in `hdiutil` - rare, [first time](https://github.com/digitalcircuit/quassel/runs/1380255458?check_suite_focus=true ) and [second time](https://github.com/digitalcircuit/quassel/runs/1381794021?check_suite_focus=true ) (`hdiutil: create failed - no mountable file systems`)

### Steps

1.  Disable all builds other than macOS
2.  Change artifact check to look for 3 artifacts instead of 5
3.  Repeatedly run workflow

```sh
# See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
GH_USERNAME="digitalcircuit"
GH_PERSONAL_TOKEN="<redacted>" # Generate at https://github.com/settings/tokens
GH_BRANCH_NAME="fix-macos-hdiutil-size"
# NOTE: This requires the patch to main.yml shown below!
while true; do curl --user "$GH_USERNAME:$GH_PERSONAL_TOKEN" -X POST -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/$GH_USERNAME/quassel/actions/workflows/main.yml/dispatches -d '{"ref":"$GH_BRANCH_NAME"}'; sleep 10m; done
```

### Patch to enable manually testing macOS CI

<details><summary>Tap or click to show the patch to ".github/workflows/main.yml"</summary>

```diff
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,11 @@
 # and attaching Windows and macOS builds, as well as the source archive.
 name: Quassel CI
 
-on: [ push, pull_request ]
+# ---------------------------------------
+# Temporarily allow manually running the workflow while testing macOS CI
+on: [ push, pull_request, workflow_dispatch ]
+#on: [ push, pull_request ]
+# ---------------------------------------
 
 defaults:
   run:
@@ -13,6 +17,9 @@ jobs:
 
 # ------------------------------------------------------------------------------------------------------------------------------------------
   build-linux:
+    # ---------------------------------------
+    if: ${{ false }} # Temporarily disable Linux builds while testing macOS CI
+    # ---------------------------------------
     name: Linux
     runs-on: ubuntu-latest
     container: quassel/quassel-build-env:${{ matrix.dist }}
@@ -153,6 +160,9 @@ jobs:
 
 # ------------------------------------------------------------------------------------------------------------------------------------------
   build-windows:
+    # ---------------------------------------
+    if: ${{ false }} # Temporarily disable Windows builds while testing macOS CI
+    # ---------------------------------------
     name: Windows
     runs-on: windows-latest
     env:
@@ -203,7 +213,10 @@ jobs:
   post-build:
     name: Post-Build
     runs-on: ubuntu-latest
-    needs: [ build-linux, build-macos, build-windows ]
+    # ---------------------------------------
+    needs: [ build-macos ] # Temporarily only require macOS builds while testing macOS CI
+    #needs: [ build-linux, build-macos, build-windows ]
+    # ---------------------------------------
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -224,9 +237,15 @@ jobs:
       run: ls -lhR artifacts
 
     - name: Check artifacts
+      # ---------------------------------------
+      # Temporarily only require 3 CI artifacts (macOS builds) while testing macOS CI
       run: |
         # Sanity check: We should have exactly 5 files matching the given patterns
-        [[ 5 -eq $(find artifacts/ \( -type f -name 'Quassel*.dmg' -o -name 'quassel*.exe' -o -name 'quassel*.7z' \) -printf '.' | wc -c) ]]
+        [[ 3 -eq $(find artifacts/ \( -type f -name 'Quassel*.dmg' -o -name 'quassel*.exe' -o -name 'quassel*.7z' \) -printf '.' | wc -c) ]]
+      #run: |
+      #  # Sanity check: We should have exactly 5 files matching the given patterns
+      #  [[ 5 -eq $(find artifacts/ \( -type f -name 'Quassel*.dmg' -o -name 'quassel*.exe' -o -name 'quassel*.7z' \) -printf '.' | wc -c) ]]
+      # ---------------------------------------
 
     - name: Create release notes
       if: startsWith(github.ref, 'refs/tags/')
```

</details>