### PR TITLE
remove Boost dependency in favor of C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,20 +356,6 @@ endif()
 # Non-Qt-based packages
 #####################################################################
 
-find_package(Boost 1.54 REQUIRED)
-set_package_properties(Boost PROPERTIES TYPE REQUIRED
-    URL "https://www.boost.org/"
-    DESCRIPTION "Boost libraries for C++"
-)
-# Older versions don't define the imported target
-if (NOT TARGET Boost::boost)
-    add_library(Boost::boost INTERFACE IMPORTED GLOBAL)
-    if (Boost_INCLUDE_DIRS)
-        set_target_properties(Boost::boost PROPERTIES
-            INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
-    endif()
-endif()
-
 find_package(ZLIB REQUIRED)
 set_package_properties(ZLIB PROPERTIES TYPE REQUIRED
     URL "http://www.zlib.net"

--- a/cmake/QuasselCompileSettings.cmake
+++ b/cmake/QuasselCompileSettings.cmake
@@ -20,7 +20,7 @@ function(check_and_set_linker_flag flag name outvar)
 endfunction()
 
 # General compile settings
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED OFF)    # Rely on compile features if standard is not supported
 set(CMAKE_CXX_EXTENSIONS OFF)           # We like to be standard conform
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -67,7 +67,6 @@ target_include_directories(${TARGET} PRIVATE ${CMAKE_BINARY_DIR})
 
 target_link_libraries(${TARGET} PUBLIC
     ${CMAKE_DL_LIBS}
-    Boost::boost
     Qt5::Core
     Qt5::Network
     ZLIB::ZLIB

--- a/src/test/util/CMakeLists.txt
+++ b/src/test/util/CMakeLists.txt
@@ -7,7 +7,6 @@ target_sources(${TARGET} PRIVATE
 
 target_link_libraries(${TARGET}
     PUBLIC
-        Boost::boost
         Quassel::Common
         Quassel::Test::Global
 )

--- a/src/test/util/invocationspy.h
+++ b/src/test/util/invocationspy.h
@@ -94,12 +94,12 @@ public:
      * Provides the value the spy was last notified with.
      *
      * @note The value is only valid if wait() returned with true.
-     * @returns The value given to notify(), or boost::none if the spy wasn't notified
+     * @returns The value given to notify(), or std::nullopt if the spy wasn't notified
      */
     T value() const { return *_value; }
 
 private:
-    boost::optional<T> _value;
+    std::optional<T> _value;
 };
 
 // -----------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This removes the needless Boost library requirement for Quassel by using std::optional from C++17 instead of Boost::optional.