### PR TITLE
build: Set macOS minimum version to what Qt supports, fix slow CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,18 @@ jobs:
       run: git fetch -f origin $GITHUB_REF:$GITHUB_REF
 
     - name: Install dependencies
-      run: brew update && brew install boost ccache ninja qca qt5
+      # Skip "brew update" as it can trigger 50+ minutes of updating.
+      # GitHub Actions intentionally disables the default auto-update on their
+      # macOS CI images (and macOS CI images usually update once a week).
+      #
+      # See https://github.com/actions/virtual-environments/issues/2173
+      # > We've set no auto-update intentionally here [...]
+      # And https://github.com/microsoft/appcenter/issues/293
+      #
+      # If Homebrew begins failing in the future due to out-of-date versions,
+      # it can be re-enabled here as follows...
+      # run: brew update && [below command]
+      run: brew install boost ccache ninja qca qt5
 
     - name: Get timestamp
       id: get-timestamp

--- a/scripts/build/Info.plist
+++ b/scripts/build/Info.plist
@@ -34,5 +34,7 @@
 	<string>© 2005-2020, Quassel IRC Team</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<key>LSMinimumSystemVersion</key>
+	<string>%(QT_MACOSX_DEPLOYMENT_TARGET)s</string>
 </dict>
 </plist>

--- a/scripts/build/macosx_DeployApp.py
+++ b/scripts/build/macosx_DeployApp.py
@@ -19,6 +19,9 @@ import os.path
 
 from subprocess import Popen, PIPE
 
+# Handling Qt properties
+import macosx_qt
+
 # ==============================
 #  Constants
 # ==============================
@@ -55,40 +58,11 @@ class InstallQt(object):
         if not skipInstallQtConf:
             self.installQtConf()
 
-    def qtProperty(self, qtProperty):
-        """
-        Query persistent property of Qt via qmake
-        """
-        VALID_PROPERTIES = ['QT_INSTALL_PREFIX',
-                            'QT_INSTALL_DATA',
-                            'QT_INSTALL_DOCS',
-                            'QT_INSTALL_HEADERS',
-                            'QT_INSTALL_LIBS',
-                            'QT_INSTALL_BINS',
-                            'QT_INSTALL_PLUGINS',
-                            'QT_INSTALL_IMPORTS',
-                            'QT_INSTALL_TRANSLATIONS',
-                            'QT_INSTALL_CONFIGURATION',
-                            'QT_INSTALL_EXAMPLES',
-                            'QT_INSTALL_DEMOS',
-                            'QMAKE_MKSPECS',
-                            'QMAKE_VERSION',
-                            'QT_VERSION'
-                            ]
-        if qtProperty not in VALID_PROPERTIES:
-            return None
-
-        qmakeProcess = Popen('qmake -query %s' % qtProperty, shell=True, stdout=PIPE, stderr=PIPE)
-        result = qmakeProcess.stdout.read().strip()
-        qmakeProcess.stdout.close()
-        qmakeProcess.wait()
-        return result
-
     def findFrameworkPath(self):
-        self.sourceFrameworkPath = self.qtProperty('QT_INSTALL_LIBS')
+        self.sourceFrameworkPath = macosx_qt.qtProperty('QT_INSTALL_LIBS')
 
     def findPluginsPath(self):
-        self.sourcePluginsPath = self.qtProperty('QT_INSTALL_PLUGINS')
+        self.sourcePluginsPath = macosx_qt.qtProperty('QT_INSTALL_PLUGINS')
 
     def findPlugin(self, pluginname):
         qmakeProcess = Popen('find %s -name %s' % (self.sourcePluginsPath, pluginname), shell=True, stdout=PIPE, stderr=PIPE)

--- a/scripts/build/macosx_makePackage.sh
+++ b/scripts/build/macosx_makePackage.sh
@@ -87,6 +87,14 @@ esac
 
 echo "Creating macOS disk image with hdiutil: 'Quassel ${BUILDTYPE} - ${QUASSEL_VERSION}'"
 
+# Modern macOS versions support APFS, however default to HFS+ for now in order
+# to ensure old macOS versions can parse the package and display the warning
+# about being out of date.  This mirrors the approach taken by Qt's macdeployqt
+# tool.  In the future if this isn't needed, just remove "-fs HFS+" to revert
+# to default.
+#
+# See https://doc.qt.io/qt-5/macos-deployment.html
+
 # hdiutil seems to have a bit of a reputation for failing to create disk images
 # for various reasons.
 #
@@ -105,7 +113,7 @@ echo "Creating macOS disk image with hdiutil: 'Quassel ${BUILDTYPE} - ${QUASSEL_
 #
 # Option 1:
 
-hdiutil create -srcfolder ${PACKAGETMPDIR} -format UDBZ -volname "Quassel ${BUILDTYPE} - ${QUASSEL_VERSION}" "${WORKINGDIR}${QUASSEL_DMG}" >/dev/null
+hdiutil create -srcfolder ${PACKAGETMPDIR} -format UDBZ -fs HFS+ -volname "Quassel ${BUILDTYPE} - ${QUASSEL_VERSION}" "${WORKINGDIR}${QUASSEL_DMG}" >/dev/null
 
 # If hdiutil changes over time and fails often, you can try the other option.
 #
@@ -114,7 +122,7 @@ hdiutil create -srcfolder ${PACKAGETMPDIR} -format UDBZ -volname "Quassel ${BUIL
 #PACKAGESIZE_MARGIN="1.1"
 #PACKAGESIZE=$(echo "$(du -ms ${PACKAGETMPDIR} | cut -f1) * $PACKAGESIZE_MARGIN" | bc)
 #echo "PACKAGESIZE: $PACKAGESIZE MB"
-#hdiutil create -srcfolder ${PACKAGETMPDIR} -format UDBZ -size ${PACKAGESIZE}M -volname "Quassel ${BUILDTYPE} - ${QUASSEL_VERSION}" "${WORKINGDIR}${QUASSEL_DMG}" >/dev/null
+#hdiutil create -srcfolder ${PACKAGETMPDIR} -format UDBZ -fs HFS+ -size ${PACKAGESIZE}M -volname "Quassel ${BUILDTYPE} - ${QUASSEL_VERSION}" "${WORKINGDIR}${QUASSEL_DMG}" >/dev/null
 
 
 # Regardless of choice, clean up the packaging temporary directory

--- a/scripts/build/macosx_makebundle.py
+++ b/scripts/build/macosx_makebundle.py
@@ -18,6 +18,9 @@ import os.path
 import sys
 import commands
 
+# Handling Qt properties
+import macosx_qt
+
 # ==============================
 #  Constants
 # ==============================
@@ -60,10 +63,20 @@ def createPlist(bundleName, bundleVersion):
     template = templateFile.read()
     templateFile.close()
 
+    # Get the minimum macOS deployment version
+    QT_MACOSX_DEPLOYMENT_TARGET = macosx_qt.qtMakespec('QMAKE_MACOSX_DEPLOYMENT_TARGET')
+    # Keep in sync with QMAKE_MACOSX_DEPLOYMENT_TARGET
+    # See https://doc.qt.io/qt-5/macos.html
+    if QT_MACOSX_DEPLOYMENT_TARGET is None:
+        # Something went wrong
+        sys.exit("Could not determine 'QMAKE_MACOSX_DEPLOYMENT_TARGET', check build scripts")
+    print("Qt macOS deployment target (minimum version): %s" % QT_MACOSX_DEPLOYMENT_TARGET)
+
     plistFile = file(CONTENTS_DIR + "Info.plist", 'w')
     plistFile.write(template % {"BUNDLE_NAME": bundleName,
                                 "ICON_FILE": "quassel.icns",
-                                "BUNDLE_VERSION": bundleVersion})
+                                "BUNDLE_VERSION": bundleVersion,
+                                "QT_MACOSX_DEPLOYMENT_TARGET": QT_MACOSX_DEPLOYMENT_TARGET})
     plistFile.close()
 
 def convertIconset():

--- a/scripts/build/macosx_qt.py
+++ b/scripts/build/macosx_qt.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python
+# -*- coding: iso-8859-1 -*-
+
+################################################################################
+#                                                                              #
+# 2008 June 27th by Marcus 'EgS' Eggenberger <egs@quassel-irc.org>             #
+#                                                                              #
+# The author disclaims copyright to this source code.                          #
+# This Python Script is in the PUBLIC DOMAIN.                                  #
+#                                                                              #
+################################################################################
+
+# ==============================
+#  Imports
+# ==============================
+import os
+from subprocess import Popen, PIPE
+
+# ==============================
+#  Global Functions
+# ==============================
+def qtProperty(qtProperty):
+    """
+    Query persistent property of Qt via qmake
+    """
+    VALID_PROPERTIES = ['QT_INSTALL_PREFIX',
+                        'QT_INSTALL_DATA',
+                        'QT_INSTALL_DOCS',
+                        'QT_INSTALL_HEADERS',
+                        'QT_INSTALL_LIBS',
+                        'QT_INSTALL_BINS',
+                        'QT_INSTALL_PLUGINS',
+                        'QT_INSTALL_IMPORTS',
+                        'QT_INSTALL_TRANSLATIONS',
+                        'QT_INSTALL_CONFIGURATION',
+                        'QT_INSTALL_EXAMPLES',
+                        'QT_INSTALL_DEMOS',
+                        'QMAKE_MKSPECS',
+                        'QMAKE_VERSION',
+                        'QT_VERSION'
+                        ]
+    if qtProperty not in VALID_PROPERTIES:
+        return None
+
+    qmakeProcess = Popen('qmake -query %s' % qtProperty, shell=True, stdout=PIPE, stderr=PIPE)
+    result = qmakeProcess.stdout.read().strip()
+    qmakeProcess.stdout.close()
+    qmakeProcess.wait()
+    return result
+
+def qtMakespec(qtMakespec):
+    """
+    Query a Makespec value of Qt via qmake
+    """
+
+    VALID_PROPERTIES = ['QMAKE_MACOSX_DEPLOYMENT_TARGET',
+                        ]
+    if qtMakespec not in VALID_PROPERTIES:
+        return None
+
+    # QMAKE_MACOSX_DEPLOYMENT_TARGET sadly cannot be queried in the traditional way
+    #
+    # Inspired by https://code.qt.io/cgit/pyside/pyside-setup.git/tree/qtinfo.py?h=5.6
+    # Simplified, no caching, etc, as we're just looking for the macOS version.
+    # If a cleaner solution is desired, look into license compatibility in
+    # order to simply copy the above code.
+
+    current_dir = os.getcwd()
+    qmakeFakeProjectFile = os.path.join(current_dir, "qmake_empty_project.txt")
+    qmakeStashFile = os.path.join(current_dir, ".qmake.stash")
+    # Make an empty file
+    open(qmakeFakeProjectFile, 'a').close()
+
+    qmakeProcess = Popen('qmake -E %s' % qmakeFakeProjectFile, shell=True, stdout=PIPE, stderr=PIPE)
+    result = qmakeProcess.stdout.read().strip()
+    qmakeProcess.stdout.close()
+    qmakeProcess.wait()
+
+    # Clean up temporary files
+    try:
+        os.remove(qmakeFakeProjectFile)
+    except OSError:
+        pass
+    try:
+        os.remove(qmakeStashFile)
+    except OSError:
+        pass
+
+    # Result should be like this:
+    # PROPERTY = VALUE\n
+    result_list = result.splitlines()
+    # Clear result so if nothing matches, nothing is returned
+    result = None
+    # Search keys
+    for line in result_list:
+        if not '=' in line:
+            # Ignore lines without '='
+            continue
+
+        # Find property = value
+        parts = line.split('=', 1)
+        prop = parts[0].strip()
+        value = parts[1].strip()
+        if (prop == qtMakespec):
+            result = value
+            break
+
+    return result


### PR DESCRIPTION
## In short
* Specify macOS `LSMinimumSystemVersion` inside `Info.plist`
  * Minimum version automatically set [by Qt requirements, `QMAKE_MACOSX_DEPLOYMENT_TARGET`](https://doc.qt.io/qt-5/macos.html#supported-versions )
  * Older macOS versions show a clear "OS too old" compatibility warning instead of a crash
* Switch to `HFS+` from `APFS` for the `.dmg` app bundle
  * Enables older (pre-10.13) macOS versions to read and check minimum OS version
  * Follows [what the Qt `macdeployqt` tool does](https://doc.qt.io/qt-5/macos-deployment.html#the-mac-deployment-tool )
  * After [252 tests](https://github.com/digitalcircuit/quassel/actions?query=branch%3Aft-macos-warn-oldver-tests ), only [6 failed tests with 2 being unrelated](https://github.com/digitalcircuit/quassel/actions?query=branch%3Aft-macos-warn-oldver-tests+is%3Afailure ) = 98% success
* Stop running `brew update` before `brew install`
  * Saves up to 50-60 minutes of time when Homebrew is slightly behind
  * [Follows GitHub's recommendation](https://github.com/actions/virtual-environments/issues/2173 )
  * GitHub Actions CI images are usually updated every 1-2 weeks, shouldn't fall far behind
  * If broken in the future, `brew update` can be re-added

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | User-facing guidance for those running old macOS versions
Risk | ★☆☆ *1/3* | Mildly increased build complexity, possible intermittent build failures
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests


## Examples

*Thanks to [`Deas` on `freenode`/`#quassel` for taking these screenshots](https://imgur.com/a/PPEhFaP )!*

**Note: these screenshots are from a personal build `Deas` made, not from this pull request.  Though the same changes have been incorporated, it's possible something was overlooked.**

### Before
![Screenshot of a macOS dialog saying Quassel Client cannot be opened because of a problem.](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-macos-warn-oldver/1%20-%20before%20-%20Advw6VO.png#v1 )

> **Quassel Client cannot be opened because of a problem.**
>
> Check with the developer to make sure Quassel Client works with this version of OS X.  You may need to reinstall the application.  Be sure to install any available updates for the application and OS X.
>
> Click Report to see more detailed information and send a report to Apple.
>
> \[button `Ignore`\] \[button `Report…`\]

### After
![Screenshot of a macOS dialog saying you can't use this version of the application with this version of OS X.](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-macos-warn-oldver/2%20-%20after%20-%20dRZb8Y4.png#v1 )

> **You can't use this version of the application "Quassel Client" with this version of OS X.**
>
> You have OS X 10.10.5.  The application requires OS X 10.13 or later.
>
> \[button `OK`\]

*In the background, the `Quassel Client` app bundle shows a prohibited sign atop the icon (🚫, circle with a line through it).*

## Testing
### Results

* [252 tests](https://github.com/digitalcircuit/quassel/actions?query=branch%3Aft-macos-warn-oldver-tests ), only [3 failed tests with 2 being unrelated](https://github.com/digitalcircuit/quassel/actions?query=branch%3Aft-macos-warn-oldver-tests+is%3Afailure ) = 98% success rate
  * Four [`hdiutil: create failed - Resource busy`](https://github.com/digitalcircuit/quassel/runs/1484053616?check_suite_focus=true#step:9:776 ), happening a [second](https://github.com/digitalcircuit/quassel/runs/1486406156?check_suite_focus=true#step:9:776 ), [third](https://github.com/digitalcircuit/quassel/runs/1488467107?check_suite_focus=true#step:9:547 ), and [fourth](https://github.com/digitalcircuit/quassel/runs/1490120764?check_suite_focus=true#step:9:776 ) time as well
  * Two unrelated connection timeouts while uploading artifacts (after packaging step): [example one](https://github.com/digitalcircuit/quassel/runs/1475838538?check_suite_focus=true#step:13:11 ) and [example two](https://github.com/digitalcircuit/quassel/runs/1484495637?check_suite_focus=true#step:13:11 )

### Steps

1.  Disable all builds other than macOS
2.  Change artifact check to look for 3 artifacts instead of 5
3.  Repeatedly run workflow

```sh
# See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
GH_USERNAME="digitalcircuit"
GH_PERSONAL_TOKEN="<redacted>" # Generate at https://github.com/settings/tokens
GH_BRANCH_NAME="ft-macos-warn-oldver-tests"
# NOTE: This requires the patch to main.yml shown below!
while true; do curl --user "$GH_USERNAME:$GH_PERSONAL_TOKEN" -X POST -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/$GH_USERNAME/quassel/actions/workflows/main.yml/dispatches -d "{\"ref\":\"$GH_BRANCH_NAME\"}"; sleep 10m; done
```

### Patch to enable manually testing macOS CI

<details><summary>Tap or click to show the patch to ".github/workflows/main.yml"</summary>

```diff
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,11 @@
 # and attaching Windows and macOS builds, as well as the source archive.
 name: Quassel CI
 
-on: [ push, pull_request ]
+# ---------------------------------------
+# Temporarily allow manually running the workflow while testing macOS CI
+on: [ push, pull_request, workflow_dispatch ]
+#on: [ push, pull_request ]
+# ---------------------------------------
 
 defaults:
   run:
@@ -13,6 +17,9 @@ jobs:
 
 # ------------------------------------------------------------------------------------------------------------------------------------------
   build-linux:
+    # ---------------------------------------
+    if: ${{ false }} # Temporarily disable Linux builds while testing macOS CI
+    # ---------------------------------------
     name: Linux
     runs-on: ubuntu-latest
     container: quassel/quassel-build-env:${{ matrix.dist }}
@@ -153,6 +160,9 @@ jobs:
 
 # ------------------------------------------------------------------------------------------------------------------------------------------
   build-windows:
+    # ---------------------------------------
+    if: ${{ false }} # Temporarily disable Windows builds while testing macOS CI
+    # ---------------------------------------
     name: Windows
     runs-on: windows-latest
     env:
@@ -203,7 +213,10 @@ jobs:
   post-build:
     name: Post-Build
     runs-on: ubuntu-latest
-    needs: [ build-linux, build-macos, build-windows ]
+    # ---------------------------------------
+    needs: [ build-macos ] # Temporarily only require macOS builds while testing macOS CI
+    #needs: [ build-linux, build-macos, build-windows ]
+    # ---------------------------------------
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -224,9 +237,15 @@ jobs:
       run: ls -lhR artifacts
 
     - name: Check artifacts
+      # ---------------------------------------
+      # Temporarily only require 3 CI artifacts (macOS builds) while testing macOS CI
       run: |
         # Sanity check: We should have exactly 5 files matching the given patterns
-        [[ 5 -eq $(find artifacts/ \( -type f -name 'Quassel*.dmg' -o -name 'quassel*.exe' -o -name 'quassel*.7z' \) -printf '.' | wc -c) ]]
+        [[ 3 -eq $(find artifacts/ \( -type f -name 'Quassel*.dmg' -o -name 'quassel*.exe' -o -name 'quassel*.7z' \) -printf '.' | wc -c) ]]
+      #run: |
+      #  # Sanity check: We should have exactly 5 files matching the given patterns
+      #  [[ 5 -eq $(find artifacts/ \( -type f -name 'Quassel*.dmg' -o -name 'quassel*.exe' -o -name 'quassel*.7z' \) -printf '.' | wc -c) ]]
+      # ---------------------------------------
 
     - name: Create release notes
       if: startsWith(github.ref, 'refs/tags/')
```

</details>
