### PR TITLE
docs: Add nightly.link CI download URLs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ as well as in this repository's [`ChangeLog`][repo-changelog].
 ## Downloading
 Official, stable downloads are provided on the [Quassel IRC download page](https://quassel-irc.org/downloads).
 
-Automated Windows and macOS builds are available via the [GitHub Actions tab][ci-status-page].  Pick a build, then download the appropriate artifact.
-
-*NOTE: As of this writing, you need to log into GitHub to download the automated builds.  This [issue is being tracked with GitHub](https://github.com/actions/upload-artifact/issues/51 ).*
+Untested, automated builds are available [for Windows](https://nightly.link/quassel/quassel/workflows/main/master/Windows.zip ) and [for macOS](https://nightly.link/quassel/quassel/workflows/main/master/macOS.zip ).  More details at [the nightly.link page](https://nightly.link/quassel/quassel/workflows/main/master ), by `oprypin`.  Or, if you are logged in to GitHub, pick any build from the [GitHub Actions tab][ci-status-page].
 
 Unofficial builds and testing versions are [contributed by several community members](https://bugs.quassel-irc.org/projects/quassel-irc/wiki#Unofficial-builds).
 


### PR DESCRIPTION
## In brief
* Add [nightly.link](https://nightly.link/ ) download URLs to `README.md`
  * Allows downloading Windows and macOS automated builds without signing into GitHub!
  * Works around [this issue with GitHub Actions](https://github.com/actions/upload-artifact/issues/51 )
  * No special setup required, but strongly recommended to [grant access to the GitHub app](https://github.com/apps/nightly-link ) to avoid API rate limits

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Developer-facing polish, makes CI downloads easier
Risk | ★☆☆ *1/3* | Links to third-party service, easily reverted
Intrusiveness | ★☆☆ *1/3* | Only changes `README.md`, shouldn't interfere with other pull requests

*Note: Looking at [the branch directly](https://github.com/digitalcircuit/quassel/blob/ft-docs-readme-nightly-link/README.md ) may be easier than using GitHub's pull request difference view.*

## Details

The [nightly.link](https://nightly.link/ ) GitHub App should be given read-only access to the public Quassel repository in order to fetch artifact downloads separate from the shared, global API token used by default.  This ensures that if nightly.link gets popular, downloads of automated CI Quassel builds won't be affected.

Forks of Quassel can make use of similar URLs, e.g. [`https://nightly.link/digitalcircuit/quassel/workflows/main/master`](https://nightly.link/digitalcircuit/quassel/workflows/main/master ), replacing the username and branch name as desired.  To avoid sharing the global API token rate limit, forks may want to also set up the nightly.link GitHub App.