### PR TITLE
[PR-559] Resolve Deprecation warnings in newer Qt versions

### DIFF
--- a/src/client/clientauthhandler.cpp
+++ b/src/client/clientauthhandler.cpp
@@ -410,7 +410,11 @@ void ClientAuthHandler::onSslSocketEncrypted()
     auto* socket = qobject_cast<QSslSocket*>(sender());
     Q_ASSERT(socket);
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     if (!socket->sslErrors().count()) {
+#else
+    if (!socket->sslHandshakeErrors().count()) {
+#endif
         // Cert is valid, so we don't want to store it as known
         // That way, a warning will appear in case it becomes invalid at some point
         CoreAccountSettings s;

--- a/src/client/treemodel.cpp
+++ b/src/client/treemodel.cpp
@@ -45,7 +45,6 @@ private:
 AbstractTreeItem::AbstractTreeItem(AbstractTreeItem* parent)
     : QObject(parent)
     , _flags(Qt::ItemIsSelectable | Qt::ItemIsEnabled)
-    , _treeItemFlags(nullptr)
 {}
 
 bool AbstractTreeItem::newChild(AbstractTreeItem* item)
@@ -102,7 +101,7 @@ void AbstractTreeItem::removeAllChilds()
     childIter = _childItems.begin();
     while (childIter != _childItems.end()) {
         child = *childIter;
-        child->setTreeItemFlags(nullptr);  // disable self deletion, as this would only fuck up consitency and the child gets deleted anyways
+        child->setTreeItemFlags({});  // disable self deletion, as this would only fuck up consitency and the child gets deleted anyways
         child->removeAllChilds();
         ++childIter;
     }

--- a/src/client/treemodel.h
+++ b/src/client/treemodel.h
@@ -87,8 +87,8 @@ protected:
 
 private:
     QList<AbstractTreeItem*> _childItems;
-    Qt::ItemFlags _flags;
-    TreeItemFlags _treeItemFlags;
+    Qt::ItemFlags _flags{};
+    TreeItemFlags _treeItemFlags{};
 
     void removeChildLater(AbstractTreeItem* child);
     inline void checkForDeletion()

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -1533,7 +1533,7 @@ Message::Types PostgreSqlStorage::bufferActivity(BufferId bufferId, MsgId lastSe
     query.bindValue(":lastseenmsgid", lastSeenMsgId.toQint64());
     safeExec(query);
     watchQuery(query);
-    Message::Types result = Message::Types(nullptr);
+    Message::Types result{};
     if (query.first())
         result = Message::Types(query.value(0).toInt());
     return result;

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -1652,7 +1652,7 @@ Message::Types SqliteStorage::bufferActivity(BufferId bufferId, MsgId lastSeenMs
     QSqlDatabase db = logDb();
     db.transaction();
 
-    Message::Types result = Message::Types(nullptr);
+    Message::Types result{};
     {
         QSqlQuery query(db);
         query.prepare(queryString("select_buffer_bufferactivity"));

--- a/src/qtui/ircconnectionwizard.h
+++ b/src/qtui/ircconnectionwizard.h
@@ -30,7 +30,7 @@ class IrcConnectionWizard : public QWizard
     Q_OBJECT
 
 public:
-    IrcConnectionWizard(QWidget* parent = nullptr, Qt::WindowFlags flags = nullptr);
+    IrcConnectionWizard(QWidget* parent = nullptr, Qt::WindowFlags flags = {});
 
     static QWizardPage* createIntroductionPage(QWidget* parent = nullptr);
 

--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -1384,8 +1384,14 @@ void MainWin::handleNoSslInCore(bool* accepted)
 void MainWin::handleSslErrors(const QSslSocket* socket, bool* accepted, bool* permanently)
 {
     QString errorString = "<ul>";
-    foreach (const QSslError error, socket->sslErrors())
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+    for (const auto& error : socket->sslErrors()) {
+#else
+    for (const auto& error : socket->sslHandshakeErrors()) {
+#endif
         errorString += QString("<li>%1</li>").arg(error.errorString());
+    }
     errorString += "</ul>";
 
     QMessageBox box(QMessageBox::Warning,

--- a/src/qtui/nicklistwidget.cpp
+++ b/src/qtui/nicklistwidget.cpp
@@ -238,7 +238,7 @@ NickListDock::NickListDock(const QString& title, QWidget* parent)
 void NickListDock::setLocked(bool locked)
 {
     if (locked) {
-        setFeatures(nullptr);
+        setFeatures({});
     }
     else {
         setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);

--- a/src/qtui/sslinfodlg.cpp
+++ b/src/qtui/sslinfodlg.cpp
@@ -67,12 +67,19 @@ void SslInfoDlg::setCurrentCert(int index)
     ui.issuerState->setText(issuerInfo(cert, QSslCertificate::StateOrProvinceName));
     ui.issuerCity->setText(issuerInfo(cert, QSslCertificate::LocalityName));
 
-    if (socket()->sslErrors().isEmpty())
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+    const auto& sslErrors = socket()->sslErrors();
+#else
+    const auto& sslErrors = socket()->sslHandshakeErrors();
+#endif
+    if (sslErrors.isEmpty()) {
         ui.trusted->setText(tr("Yes"));
+    }
     else {
         QString errorString = tr("No, for the following reasons:<ul>");
-        foreach (const QSslError& error, socket()->sslErrors())
+        for (const auto& error : sslErrors) {
             errorString += "<li>" + error.errorString() + "</li>";
+        }
         errorString += "</ul>";
         ui.trusted->setText(errorString);
     }

--- a/src/qtui/verticaldock.h
+++ b/src/qtui/verticaldock.h
@@ -59,8 +59,8 @@ class VerticalDock : public QDockWidget
     Q_OBJECT
 
 public:
-    VerticalDock(const QString& title, QWidget* parent = nullptr, Qt::WindowFlags flags = nullptr);
-    VerticalDock(QWidget* parent = nullptr, Qt::WindowFlags flags = nullptr);
+    VerticalDock(const QString& title, QWidget* parent = nullptr, Qt::WindowFlags flags = {});
+    VerticalDock(QWidget* parent = nullptr, Qt::WindowFlags flags = {});
 
     void showTitle(bool show);
     void setDefaultTitleWidget();

--- a/src/uisupport/bufferview.cpp
+++ b/src/uisupport/bufferview.cpp
@@ -728,7 +728,7 @@ BufferViewDock::BufferViewDock(BufferViewConfig* config, QWidget* parent)
 void BufferViewDock::setLocked(bool locked)
 {
     if (locked) {
-        setFeatures(nullptr);
+        setFeatures({});
     }
     else {
         setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);


### PR DESCRIPTION
## In Short

* Use QSslConfiguration instead of modifying QSslSocket directly
* Use default constructors instead of nullptr for empty QFlags

## Impact

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Will only have an effect after Qt6 |
| Risk | ★☆☆  _1/3_ | Does not touch any critical code |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to a few classes

## Rationale

Currently our builds cause [Qt warnings](https://git.kuschku.de/justJanne/quassel-docker/-/jobs/2075#L452) about deprecated functionality.

