### PR TITLE
ci: Find Qt5 again on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
       # If Homebrew begins failing in the future due to out-of-date versions,
       # it can be re-enabled here as follows...
       # run: brew update && [below command]
-      run: brew install boost ccache ninja qca qt5
+      run: brew install boost ccache ninja qca qt@5
 
     - name: Get timestamp
       id: get-timestamp
@@ -145,7 +145,7 @@ jobs:
                           -DWANT_CORE=ON \
                           -DWANT_QTCLIENT=ON \
                           -DWANT_MONO=ON \
-                          -DCMAKE_PREFIX_PATH=/usr/local/opt/qt/lib/cmake \
+                          -DCMAKE_PREFIX_PATH=$(brew --prefix)/opt/qt@5 \
                           -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/bundles \
                           -DCMAKE_BUILD_TYPE=Release \
                           -DBUILD_TESTING=ON \


### PR DESCRIPTION
With the introduction of Qt6 to homebrew, the install location of Qt5
has changed from /usr/local/opt/qt to the version-specific .../opt/qt@5.

Adapt CMAKE_PREFIX_PATH accordingly. No longer hardcode the brew
prefix. Also use the recommended, versioned package name "qt@5" instead
of the "qt5" alias.