### PR TITLE
pics: stop installing app icon in pixmaps location

### DIFF
--- a/icons/CMakeLists.txt
+++ b/icons/CMakeLists.txt
@@ -64,10 +64,5 @@ if (WANT_MONO OR WANT_QTCLIENT)
             # Install Quassel-specific ones from Oxygen into hicolor as fallback
             install(DIRECTORY oxygen/ DESTINATION ${CMAKE_INSTALL_ICONDIR}/hicolor)
         endif()
-
-        # For a system install, also copy to pixmaps
-        if (CMAKE_INSTALL_PREFIX STREQUAL "/usr")
-            install(FILES hicolor/48x48/apps/quassel.png DESTINATION /usr/share/pixmaps)
-        endif()
     endif()
 endif()


### PR DESCRIPTION
The `/usr/share/pixmaps` location is considered a legacy location for application icons; since the application icons are already installed in the global XDG hicolor theme, then simply stop installing the 48px one in the legacy pixmaps location.