### PR TITLE
Change default IRC network to Libera Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ documentation.
 
 IRC is the preferred means of getting in touch with the developers.
 
-The Quassel IRC Team can be contacted on **`Freenode/#quassel`**
-(or **`#quassel.de`**).  If you have trouble getting Quassel to connect,
-you can use [Freenode's webchat][help-freenode].
+The Quassel IRC Team can be contacted on **`Libera Chat/#quassel`**
+(or **`#quassel.de`**). 
 
 We always welcome new users in our channels!
 
@@ -65,7 +64,6 @@ Thanks for reading,
 
 [web-home]: https://quassel-irc.org
 [dev-email]: mailto:devel@quassel-irc.org
-[help-freenode]: https://webchat.freenode.net?channels=%23quassel
 [repo-changelog]: ChangeLog
 [ci-badge]: https://github.com/quassel/quassel/workflows/Quassel%20CI/badge.svg?branch=master
 [ci-status-page]: https://github.com/quassel/quassel/actions?query=branch%3Amaster

--- a/data/networks.ini
+++ b/data/networks.ini
@@ -19,8 +19,6 @@ Servers=irc.efnet.info:6667,irc.efnet.org:6667,irc.inter.net.il:6667,irc.igs.ca:
 Servers=irc.enterthegame.com:6667
 
 [Freenode]
-Default=Yes
-DefaultChannels=#quassel
 Servers=chat.freenode.net:+6697,chat.freenode.net:6667
 
 [GalaxyNet]
@@ -34,6 +32,11 @@ Servers=irc.gamesnet.net:6667
 
 [IRCnet]
 Servers=irc.ircnet.com:6667,open.ircnet.net:6666,irc.us.ircnet.net:6665,ircnet.netvision.net.il:6666,irc.tokyo.wide.ad.jp:6666,irc.freebsd.org.tw:6666,linz.irc.at:6666,vienna.irc.at:6666,ircnet.realroot.be:6666,irc.datacomm.ch:6664,irc.felk.cvut.cz:6667,random.ircd.de:6666,irc.dotsrc.org:6666,irc.ircnet.ee:6666,irc.cs.hut.fi:6667,ircnet.club-internet.fr:6666,atw.irc.hu:6667,irc.simnet.is:6660,irc.eutelia.it:6664,irc.eutelia.it:7000,irc.tin.it:6665,irc.apollo.lv:6666,irc.apollo.lv:7000,irc.uunet.nl:6660,irc.xs4all.nl:6660,irc.snt.utwente.nl:6660,irc.ifi.uio.no:6667,irc.pvv.ntnu.no:6667,lublin.irc.pl:6666,warszawa.irc.pl:6666,irc.ludd.luth.se:6661,irc.swipnet.se:6660,irc.swipnet.se:8000,irc.arnes.si:6666,irc.link.si:6666,irc.nextra.sk:6666,ircnet.demon.co.uk:6665,ircnet.eversible.com:6665,ircnet.choopa.net:6665
+
+[Libera Chat]
+Default=Yes
+DefaultChannels=#quassel
+Servers=irc.libera.chat:+6697,irc.libera.chat:6667
 
 [OFTC]
 Servers=irc.oftc.net:+6697,irc.oftc.net:6667

--- a/src/qtui/aboutdlg.cpp
+++ b/src/qtui/aboutdlg.cpp
@@ -65,7 +65,7 @@ QString AboutDlg::about() const
     QString res{tr("<b>A modern, distributed IRC Client</b><br><br>"
                    "&copy;%1 by the Quassel Project<br>"
                    "<a href=\"https://quassel-irc.org\">https://quassel-irc.org</a><br>"
-                   "<a href=\"irc://irc.freenode.net/quassel\">#quassel</a> on <a href=\"https://www.freenode.net\">Freenode</a><br><br>"
+                   "<a href=\"irc://irc.libera.chat/quassel\">#quassel</a> on <a href=\"https://libera.chat\">Libera Chat</a><br><br>"
                    "Quassel IRC is dual-licensed under <a href=\"https://www.gnu.org/licenses/gpl-2.0.txt\">GPLv2</a> and "
                    "<a href=\"https://www.gnu.org/licenses/gpl-3.0.txt\">GPLv3</a>.<br>"
                    "<a href=\"https://api.kde.org/frameworks/breeze-icons/html\">Breeze icon theme</a> &copy; Uri Herrera and others, "


### PR DESCRIPTION
### Heads up! I suspect this will be a topic that gets discussed a LOT before a decision is made.

As some folks may be aware, there have been some recent issues that have come to light regarding the ownership and management of Freenode. As a result of this, the entire volunteer staff of Freenode has resigned.

Many projects are packing up and moving to Libera, which is a new IRC network founded by the previous staff of Freenode.

This PR makes the following changes:

* Removes Freenode as the "Default" network. This means that new installations of Quassel will no longer automatically connect to Freenode, unless the user specifically adds Freenode as a network.
* Removes #quassel from "DefaultChannels" under Freenode. This means that new installations of Quassel will no longer join the #quassel channel on Freenode.
* Adds Libera Chat as a new IRC network, and specifies it as the "Default" network, and adds #quassel under "DefaultChannels". This means that new installations of Quassel will now automatically connect to `irc.libera.chat:+6697` and automatically join #quassel.
* Changes the link in Help>About Quassel to `irc://irc.libera.chat/quassel` and links to Libera Chat's website instead of Freenode's. (Note that `ircs://` was specifically not chosen because `irc://` is a more widely recognized URI scheme.)
* Updates the README document with the new network name and address. The webchat link is temporarily removed, as the new network does not yet have one up and running. I will add it with another PR when the webchat is online.

For more information about this situation, please read this: https://gist.github.com/joepie91/df80d8d36cd9d1bde46ba018af497409