### PR TITLE
common: strip format codes for Message ignores

### DIFF
--- a/src/common/ignorelistmanager.cpp
+++ b/src/common/ignorelistmanager.cpp
@@ -23,6 +23,8 @@
 #include <QDebug>
 #include <QStringList>
 
+#include "util.h"
+
 int IgnoreListManager::indexOf(const QString& ignore) const
 {
     for (int i = 0; i < _ignoreList.count(); i++) {
@@ -131,10 +133,12 @@ IgnoreListManager::StrictnessType IgnoreListManager::_match(
         if (item.scope() == GlobalScope || (item.scope() == NetworkScope && item.scopeRuleMatcher().match(network))
             || (item.scope() == ChannelScope && item.scopeRuleMatcher().match(bufferName))) {
             QString str;
-            if (item.type() == MessageIgnore)
-                str = msgContents;
-            else
+            if (item.type() == MessageIgnore) {
+                // TODO: Make this configurable?  Pre-0.14, format codes were not removed
+                str = stripFormatCodes(msgContents);
+            } else {
                 str = msgSender;
+            }
 
             //      qDebug() << "IgnoreListManager::match: ";
             //      qDebug() << "string: " << str;


### PR DESCRIPTION
## In short

* Strip IRC format codes from message for ignores that match message contents
  * Simplifies ignoring rainbow-messages, consistent with highlight rules
  * Not possible to match specific format patterns, may break complex existing ignores

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Makes it easier to set ignore rules for rainbow spam
Risk | ★★☆ *2/3* | Removes the ability to set format-specific ignore rules
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Rationale

* Pros
  * Easier to set ignore rules for rainbow-messages or other format spam
  * Consistent with highlight rules/highlight ignore rules
* Cons
  * Not possible to ignore messages matching a specific format pattern
  * Breaks existing ignores written to handle mid-message format codes

Alternatively, we could wait until after 0.14 to make this a setting, with new protocol feature flag, new strings, etc.  (I intend to add a `Network` field to highlight rules to mimic ignore rule functionality so you can disable specific highlights across a network, so that'll be a network change anyways, but no timeline/ETA guaranteed.)

### Breaking changes

Ignore rules that matched specific IRC formatting characters will need adjusted to work.  See examples below.

*Note:* This impacts both the client and the core.  Mismatching client/core versions will result in different behavior for ignoring messages with formatting codes inside the ignore rule itself.

## Examples
### Sample message
Message sent with green and orange color formatting [as per the example on ircdocs](https://modern.ircdocs.horse/formatting.html#examples ).

![Screenshot of the Quassel channel history UI showing the color-formatted message](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-ignore-strip-format/Example%20message.png#v1 )

> \<digitalcircuit\> I love *IRC!*  It is the **best protocol ever!**

*Note: Markdown lacks support for color formatting, so I've substituted italics and bold*

### Before
*In `Configure Quassel…` → `IRC` → `Ignore List` → `New`/`Edit`*

![Screenshot of Quassel's "Configure Ignore Rule" dialog showing a Strictness of "Dynamic", a Rule Type of "Message", and an Ignore Rule of "I love ...IRC" with the "Regular expression" box checked](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-ignore-strip-format/Ignore%20rule%20-%20before.png#v1 )
> Strictness: Dynamic
> Rule Type: Message
> **Ignore Rule: `I love ...IRC`**
> Regular expression: enabled

### After
*In `Configure Quassel…` → `IRC` → `Ignore List` → `New`/`Edit`*

![Screenshot of Quassel's "Configure Ignore Rule" dialog showing a Strictness of "Dynamic", a Rule Type of "Message", and an Ignore Rule of "I love IRC" with the "Regular expression" box checked](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-ignore-strip-format/Ignore%20rule%20-%20after.png#v1 )
> Strictness: Dynamic
> Rule Type: Message
> **Ignore Rule: `I love IRC`**
> Regular expression: enabled

*The `...` from the previous ignore rule needed to be removed.*