### PR TITLE
ci: Adapt warning configuration to new release of MSVC 19

### DIFF
--- a/cmake/QuasselCompileSettings.cmake
+++ b/cmake/QuasselCompileSettings.cmake
@@ -83,17 +83,17 @@ elseif(MSVC)
     # CMake puts /W3 in CMAKE_CXX_FLAGS which will be appended later, so we need to replace
     string(REPLACE "/W3" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
-    # Silence annoying/useless warnings
-    #   C4127: conditional expression is constant
+    # Silence warnings that are hard or impossible to avoid
+    #   C4127: conditional expression is constant [in qvector.h as of Qt 5.15.2]
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4127")
-    #   C4244: 'identifier': conversion from 't1' to 't2', possible loss of data
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
-    #   C4456: declaration of 'identifier' hides previous local declaration
+    #   C4456: declaration of 'identifier' hides previous local declaration [caused by foreach macro, among others]
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4456")
-    #   C4458: declaration of 'identifier' hides class member
+    #   C4458: declaration of 'identifier' hides class member [caused by MOC for Peer::_id]
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4458")
-    #   C4996: deprecation warnings
+    #   C4996: deprecation warnings [unavoidable due to wide range of supported Qt versions]
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4996")
+    #   C5240: 'nodiscard': attribute is ignored in this syntactic position [in qcolor.h as of Qt 5.15.2]
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd5240")
 
     # Link against the correct version of the C runtime
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/NODEFAULTLIB:libcmt /DEFAULTLIB:msvcrt ${CMAKE_EXE_LINKER_FLAGS_RELEASE}")

--- a/src/client/messagefilter.cpp
+++ b/src/client/messagefilter.cpp
@@ -185,7 +185,7 @@ bool MessageFilter::filterAcceptsRow(int sourceRow, const QModelIndex& sourcePar
         if (redirectionTarget & BufferSettings::CurrentBuffer && !(flags & Message::Backlog)) {
             BufferId redirectedTo = sourceModel()->data(sourceIdx, MessageModel::RedirectedToRole).value<BufferId>();
             if (!redirectedTo.isValid()) {
-                BufferId redirectedTo = Client::bufferModel()->currentIndex().data(NetworkModel::BufferIdRole).value<BufferId>();
+                redirectedTo = Client::bufferModel()->currentIndex().data(NetworkModel::BufferIdRole).value<BufferId>();
                 if (redirectedTo.isValid())
                     sourceModel()->setData(sourceIdx, QVariant::fromValue(redirectedTo), MessageModel::RedirectedToRole);
             }


### PR DESCRIPTION
Recently, MSVC introduced a new warning C5240 that apparently refers
to standard-compliant ordering of attributes and decl-specifies.
Unfortunately, this warning is triggered by Qt headers, in particular:

C:\CraftMaster\windows-msvc2019_64-cl\include\qt5\QtGui/qcolor.h(233):
    warning C5240: 'nodiscard': attribute is ignored in this syntactic position

Since we cannot fix this ourselves, make the warning non-fatal for now.
This fixes our CI failing with the new MSVC version.

Reenable C4244, which is no longer triggered by Quassel code, and add
some reasoning for the remaining warnings.

Fix an issue in MessageFilter that was discovered by disabling warnings
for testing.