### PR TITLE
common: Make regular expressions Unicode-aware

### DIFF
--- a/src/common/expressionmatch.cpp
+++ b/src/common/expressionmatch.cpp
@@ -384,10 +384,14 @@ void ExpressionMatch::cacheRegEx()
 
 QRegularExpression ExpressionMatch::regExFactory(const QString& regExString, bool caseSensitive)
 {
-    // Construct the regular expression object, setting case sensitivity as appropriate
-    QRegularExpression newRegEx = QRegularExpression(regExString,
-                                                     caseSensitive ? QRegularExpression::PatternOption::NoPatternOption
-                                                                   : QRegularExpression::PatternOption::CaseInsensitiveOption);
+    // This is required, else extra-ASCII codepoints get treated as word boundaries
+    QRegularExpression::PatternOptions options = QRegularExpression::UseUnicodePropertiesOption;
+
+    if (!caseSensitive) {
+        options |= QRegularExpression::CaseInsensitiveOption;
+    }
+
+    QRegularExpression newRegEx = QRegularExpression(regExString, options);
 
     // Check if rule is valid
     if (!newRegEx.isValid()) {


### PR DESCRIPTION
## In short

* Enable [Unicode-aware QRegularExpression](https://doc.qt.io/qt-5/qregularexpression.html#unicode-properties-support )
  * Avoids spam highlights like `V` in `XYZ M°VəD to TOTALLY.REAL.CHAT`
  * Expands character classes (`\w`, `\d`, etc) to handle Unicode
  * Affects existing highlight rules

*Thanks to @deviant for writing the commit!  I merely added the unit tests.  Thanks to `oprypin` for finding the Qt documentation and such, too.*

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Makes it easier to manage Unicode-based spam
Risk | ★☆☆ *1/3* | Impacts nickname highlights, regex rules in Unicode situations
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Rationale

With the recent waves of spam like `/︕\ THІЅ ᏟHΑΝΝᎬL ዘAS МOVED TO ABC.XYZ #ⲎAM /﹗＼`, proper Unicode support in Quassel can help avoid errant highlights and make ignoring spam easier.

This may be worthwhile backporting to `0.13.x` if a maintenance release is being made anyways.

Note that the word `МOVED` in the above message is not what it looks like:
```
0          0  00039F   CE 9F          Ο      GREEK CAPITAL LETTER OMICRON
1          2  000056   56             V      LATIN CAPITAL LETTER V
2          3  000395   CE 95          Ε      GREEK CAPITAL LETTER EPSILON
```

### Breaking changes

The nickname `V` would previously be highlighted with the words `Västra` and `TÜV`.

Now, `V` will require actual word boundaries (punctuation, spaces, emoji, etc) to trigger a highlight.

*Note:* This impacts both the client and the core.  Mismatching client/core versions will result in different behavior for ignoring messages with formatting codes inside the ignore rule itself.  The core must be upgraded for core-side (non-legacy) highlights to make use of this fix.

## Examples
### Setup

**Sample message:**
```
A testing message with the word TÜV in it
```

**Before continuing**, create a core-side/remote/non-legacy highlight rule for the Latin/ASCII letter `V`.

### Before
![Screenshot of Quassel showing a message from "digitalcircuit" in the perspective of "V" with highlight](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-regex-handle-unicode/Unicode%20-%20before.png#v2 )
> `<V> I am V`
> `<digitalcircuit> A testing message with the word TÜV in it` (in highlighted message orange)

A highlight is incorrectly generated.

### After
![Screenshot of Quassel showing a message from "digitalcircuit" in the perspective of "V" not being highlighted](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/ft-regex-handle-unicode/Unicode%20-%20after.png#v2 )
> `<V> I am V, updated`
> `<digitalcircuit> A testing message with the word TÜV in it` (in normal message color)

No highlight is generated, as expected.