### PR TITLE
docs: Add back webchat link after Libera migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ documentation.
 IRC is the preferred means of getting in touch with the developers.
 
 The Quassel IRC Team can be contacted on **`Libera Chat/#quassel`**
-(or **`#quassel.de`**). 
+(or **`#quassel.de`**).  If you have trouble getting Quassel to connect,
+you can use [Libera Chat's web client](https://web.libera.chat/?channels=#quassel).
 
 We always welcome new users in our channels!
 


### PR DESCRIPTION
## In brief
* Add back the `README.md` webchat link now that Libera Chat has an option
  * Follow up to [changing the official IRC channel](https://github.com/quassel/quassel/commit/322bec12418ab267d7b770ec90465a1a1034b17d)
  * Makes it easier for folks having trouble connecting

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | More convenient way to get help with Quassel
Risk | ★☆☆ *1/3* | Links to third-party service, easily reverted
Intrusiveness | ★☆☆ *1/3* | Only changes `README.md`, shouldn't interfere with other pull requests

*Note: Looking at [the branch directly](https://github.com/digitalcircuit/quassel/blob/fix-docs-webchat-again/README.md ) may be easier than using GitHub's pull request difference view.*

## Details

Quassel's moved official presence to Libera Chat, but for folks having difficulty connecting to Libera within Quassel, having a link to the webchat with `#quassel` pre-filled may help.

This only impacts folks looking at the `README.md` document.

*I overlooked this when reviewing the original commit, my bad.*