### PR TITLE
client: Swap order of "Configure" and "Connect/Disconnect" in context menu

### DIFF
--- a/src/uisupport/contextmenuactionprovider.cpp
+++ b/src/uisupport/contextmenuactionprovider.cpp
@@ -277,10 +277,11 @@ void ContextMenuActionProvider::addNetworkItemActions(QMenu* menu, const QModelI
     if (!network)
         return;
 
-    addAction(ShowNetworkConfig, menu, index);
-    menu->addSeparator();
+
     addAction(NetworkConnect, menu, network->connectionState() == Network::Disconnected);
     addAction(NetworkDisconnect, menu, network->connectionState() != Network::Disconnected);
+    menu->addSeparator();
+    addAction(ShowNetworkConfig, menu, index);
     menu->addSeparator();
     addAction(ShowChannelList, menu, index, ActiveState);
     addAction(JoinChannel, menu, index, ActiveState);


### PR DESCRIPTION
This commit changes the order of the "Configure" and "Connect/Disconnect" items in the context menu, found when right-clicking on a network.

My rationale behind this is that when right-clicking on a network, it is extraordinarily more likely that the user's intent is to either connect to or disconnect from the network, and not to edit that network's settings.

I am not the only person to have this complaint, see [this bug](https://bugs.quassel-irc.org/issues/1494) filed in September 2018.