### PR TITLE
core: Error out when --require-ssl is specified, but no cert can be loaded

### DIFF
--- a/src/core/sslserver.cpp
+++ b/src/core/sslserver.cpp
@@ -53,7 +53,8 @@ SslServer::SslServer(QObject* parent)
         // do not proceed, throw an exception and quit. This prevents the core from falling
         // back to a plaintext-only core when they should be expecting SSL/TLS only.
         if (Quassel::isOptionSet("require-ssl")) {
-            throw ExitException{EXIT_FAILURE, tr("--require-ssl is set, but no SSL certificate is available. Exiting.")};
+            throw ExitException{EXIT_FAILURE, tr("--require-ssl is set, but no SSL certificate is available. Exiting.\n"
+                                                 "Please see https://quassel-irc.org/faq/cert to learn how to enable SSL support.")};
         }
         if (!sslWarningShown) {
             qWarning() << "SslServer: Unable to set certificate file\n"

--- a/src/core/sslserver.cpp
+++ b/src/core/sslserver.cpp
@@ -49,6 +49,12 @@ SslServer::SslServer(QObject* parent)
 
     // Initialize the certificates for first-time usage
     if (!loadCerts()) {
+        // If the core is unable to load a certificate, and "--require-ssl" is specified,
+        // do not proceed, throw an exception and quit. This prevents the core from falling
+        // back to a plaintext-only core when they should be expecting SSL/TLS only.
+        if (Quassel::isOptionSet("require-ssl")) {
+            throw ExitException{EXIT_FAILURE, tr("--require-ssl is set, but no SSL certificate is available. Exiting.")};
+        }
         if (!sslWarningShown) {
             qWarning() << "SslServer: Unable to set certificate file\n"
                        << "          Quassel Core will still work, but cannot provide SSL for client connections.\n"


### PR DESCRIPTION
As mentioned in [#1728](https://bugs.quassel-irc.org/issues/1728), cores launched with the `--require-ssl` flag, but no SSL/TLS certificate available (because the file does not exist, permissions are set incorrectly, the file does not contain a certificate, etc) will effectively be put into a plaintext-only mode, with little more than a small warning on the console to the user. Clients connecting to the core will be given the standard "Unencrypted Connection" warning.

This patch fixes that issue, requiring that cores launched with `--require-ssl` will successfully load a certificate before starting. If the certificate fails to load for any reason during startup, an exception is thrown and the core quits.

Thanks to @relrod for the help on this one.