### PR TITLE
[PR-582] Move buffer deletion to a background task

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${TARGET} PRIVATE
     corealiasmanager.cpp
     coreapplication.cpp
     coreauthhandler.cpp
+    backgroundtaskhandler.cpp
     corebacklogmanager.cpp
     corebasichandler.cpp
     corebuffersyncer.cpp

--- a/src/core/backgroundtaskhandler.cpp
+++ b/src/core/backgroundtaskhandler.cpp
@@ -1,0 +1,24 @@
+#include "backgroundtaskhandler.h"
+
+#include "core.h"
+#include "coresession.h"
+
+BackgroundTaskHandler::BackgroundTaskHandler(CoreSession* coreSession)
+    : QObject(nullptr),
+    _coreSession(coreSession) {
+    _workerThread.start();
+    moveToThread(&_workerThread);
+}
+
+BackgroundTaskHandler::~BackgroundTaskHandler()
+{
+    _workerThread.quit();
+    _workerThread.wait();
+}
+
+void BackgroundTaskHandler::deleteBuffer(BufferId bufferId) {
+    QThread::sleep(10);
+    Core::removeBuffer(_coreSession->user(), bufferId);
+    QThread::sleep(10);
+    emit onBufferDeleted(bufferId);
+}

--- a/src/core/backgroundtaskhandler.h
+++ b/src/core/backgroundtaskhandler.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "syncableobject.h"
+#include "types.h"
+
+class CoreSession;
+class BackgroundTaskHandler : public QObject
+{
+    Q_OBJECT
+public:
+    explicit BackgroundTaskHandler(CoreSession* coreSession);
+    ~BackgroundTaskHandler() override;
+public slots:
+    void deleteBuffer(BufferId bufferId);
+signals:
+    void onBufferDeleted(BufferId);
+private:
+    CoreSession* _coreSession;
+    QThread _workerThread;
+};

--- a/src/core/corebuffersyncer.h
+++ b/src/core/corebuffersyncer.h
@@ -84,6 +84,12 @@ public slots:
 
     void storeDirtyIds();
 
+signals:
+    void doRemoveBuffer(BufferId);
+
+private slots:
+    void onBufferRemoved(BufferId buffer);
+
 protected:
     void customEvent(QEvent* event) override;
 

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -59,6 +59,7 @@ public:
 
 CoreSession::CoreSession(UserId uid, bool restoreState, bool strictIdentEnabled, QObject* parent)
     : QObject(parent)
+    , _backgroundTaskHandler(new BackgroundTaskHandler(this))
     , _user(uid)
     , _strictIdentEnabled(strictIdentEnabled)
     , _signalProxy(new SignalProxy(SignalProxy::Server, this))

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -28,6 +28,7 @@
 #include <QString>
 #include <QVariant>
 
+#include "backgroundtaskhandler.h"
 #include "corealiasmanager.h"
 #include "corehighlightrulemanager.h"
 #include "coreignorelistmanager.h"
@@ -102,6 +103,7 @@ public:
     inline HighlightRuleManager* highlightRuleManager() { return &_highlightRuleManager; }
     inline CoreTransferManager* transferManager() const { return _transferManager; }
     inline CoreDccConfig* dccConfig() const { return _dccConfig; }
+    inline BackgroundTaskHandler* backgroundTaskHandler() const { return _backgroundTaskHandler; }
 
     //   void attachNetworkConnection(NetworkConnection *conn);
 
@@ -192,6 +194,8 @@ signals:
 
     void disconnectFromCore();
 
+    void bufferRemoved(BufferId);
+
 protected:
     void customEvent(QEvent* event) override;
 
@@ -219,6 +223,8 @@ private:
 
     /// Hook for converting events to the old displayMsg() handlers
     Q_INVOKABLE void processMessageEvent(MessageEvent* event);
+
+    BackgroundTaskHandler* _backgroundTaskHandler;
 
     UserId _user;
 


### PR DESCRIPTION
## In Short

* Adds a background task handler object to each core session
* Moves buffer deletion to that handler

## Impact

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Prevents the core from timing out while deleting a large buffer |
| Risk | ★★☆  _2/3_ | Only changes buffer deletion, which is not critical functionality |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to a few classes |

## Rationale

Currently, while deleting buffers, the core may hang and the IRC connection can time out. With the end of freenode this has become a more pressing matter recently. This PR moves deletion of buffers to a thread per-user to prevent users causing a DoS while simultaneously preventing the core from hanging.