### PR TITLE
Allow updating an ISUPPORT token.

### DIFF
--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -789,7 +789,7 @@ void Network::setUnlimitedMessageRate(bool unlimitedRate)
 
 void Network::addSupport(const QString& param, const QString& value)
 {
-    if (!_supports.contains(param)) {
+    if (!_supports.contains(param) || _supports[param] != value) {
         _supports[param] = value;
         SYNC(ARG(param), ARG(value))
     }


### PR DESCRIPTION
## In Brief

- Update internal `support` (or `ISUPPORT`) tokens for a network when they change.

## Impact
| Criteria           | Rank         | Reason                                                                                                                 |
| ----------------- | -------------- | --------------------------------------------------------------------------------------------------------- |
| Impact            | ★☆☆ 1/3 | Keeps the core and client up-to-date with the necessary network configuration. |
| Risk                | ★★☆ 2/3 | May lead to unintended weirdness in handling of some changed tokens.            |
| Intrusiveness | ★☆☆ 1/3  | One line change; doesn't appear to interfere with other PRs.                              |

## Rationale
Currently, if a network changes their configuration in such a way that one or more of their ISUPPORT tokens changes, the core must be restarted in order for it to see these updated tokens. Obviously this is a non-ideal way to handle a change in one network. Allowing the core to update its internal state when a change occurs removes the need for a restart. That said, not all IRCds will send an updated ISUPPORT message for all changes, or at all. A manual `/VERSION` or reconnect may still be required. This is still better than a core restart.
#### Recent example case:
Freenode recently did a big switch of IRCd and services software, resulting in at least a few changes to the ISUPPORT tokens. Two of the notable token changes were `PREFIX` and `STATUSMSG`, as they added two prefixes (also added to statusmsg). The more common prefix of these two being `halfop (h | %)`. After disconnecting from 'old freenode' and connecting to 'new freenode', I noticed this change in the ISUPPORT message and kept an eye on channels for the use of them. Joining a channel with halfops in it or running `/names` on an existing channel would show halfops in the nick list as `%nick` under User(s) instead of `nick` under Half-Op(s). Un-tested/noticed, this likely would have messed up status message matching as well, since `%` would not have been known as a character to match. A core restart was required in order to clear/update the internal state.

## Testing
Using the above example as a before test case, I ran a test with my InspIRCd v3 testnet. I removed halfop from the configuration, connected Quassel and joined a channel, and re-added halfop to the configuration. This still resulted in the possibility of seeing a halfop as `%nick` in the User(s) section before a manual `/version` or reconnect is done. Running `/version` and then updating the channel with `/names` placed the user in the correct Half-Op(s) section, leaving behind a `%nick` in the User(s) section yet. This is not surprising as the core still thought of them as separate users with the prefix character change. The same can happen in the before case with a halfop being de-halfop'ed and so forth. A reconnect to the network cleared everything up.