### PR TITLE
Core/ircparser: Only trim whitespace from the end of the last parameter.

### DIFF
--- a/src/core/ircparser.cpp
+++ b/src/core/ircparser.cpp
@@ -468,8 +468,17 @@ void IrcParser::processNetworkIncoming(NetworkDataEvent* e)
 
         // We want to trim the last param just in case, except for PRIVMSG and NOTICE
         // ... but those happen to be the only ones not using defaultHandling anyway
-        if (!decParams.isEmpty() && decParams.last().endsWith(' '))
-            decParams.append(decParams.takeLast().trimmed());
+        if (!decParams.isEmpty()) {
+            QString& lastParam = decParams.last();
+            if (!lastParam.isEmpty() && lastParam.at(lastParam.size() - 1).isSpace()) {
+                for (int i = lastParam.size() - 1; i != 0; --i) {
+                    if (!lastParam.at(i).isSpace()) {
+                        lastParam.truncate(i + 1);
+                        break;
+                    }
+                }
+            }
+        }
 
         IrcEvent* event;
         if (type == EventManager::IrcEventNumeric)


### PR DESCRIPTION
> QString::trimmed() removes both leading and trailing whitespace, which
> is not the intention here. As QString does not have a ltrim/rtrim
> function, we need to implement the equivalent here to only trim the
> trailing whitespace.

> As QString::trimmed() removed any whitespace for which QChar::isSpace()
> returns true, I have switched the trailing whitespace check to use the
> same function.

I know this is kind of ugly, with a trim function implemented directly
here. I did not see anywhere else that would benefit from a new Quassel
function of rtrim. Totally open to other ideas though.

Set this as draft so I can improve this PR body later when not on mobile.
