### PR TITLE
[PR-586] Allow setting outgoing IP per user

### DIFF
--- a/src/core/SQL/PostgreSQL/select_outgoing_ip.sql
+++ b/src/core/SQL/PostgreSQL/select_outgoing_ip.sql
@@ -1,0 +1,3 @@
+SELECT outgoing_ip
+FROM quasseluser
+WHERE userid = :userid

--- a/src/core/SQL/PostgreSQL/setup_000_quasseluser.sql
+++ b/src/core/SQL/PostgreSQL/setup_000_quasseluser.sql
@@ -3,5 +3,6 @@ CREATE TABLE quasseluser (
        username TEXT UNIQUE NOT NULL,
        password TEXT NOT NULL,
        hashversion integer NOT NULL DEFAULT 0,
-       authenticator TEXT NOT NULL DEFAULT 'Database'
+       authenticator TEXT NOT NULL DEFAULT 'Database',
+       outgoing_ip TEXT NOT NULL DEFAULT ''
 )

--- a/src/core/SQL/PostgreSQL/version/32/upgrade_000_alter_quasseluser_add_outgoing_ip.sql
+++ b/src/core/SQL/PostgreSQL/version/32/upgrade_000_alter_quasseluser_add_outgoing_ip.sql
@@ -1,0 +1,1 @@
+ALTER TABLE quasseluser ADD COLUMN outgoing_ip TEXT NOT NULL DEFAULT ''

--- a/src/core/SQL/SQLite/select_outgoing_ip.sql
+++ b/src/core/SQL/SQLite/select_outgoing_ip.sql
@@ -1,0 +1,3 @@
+SELECT outgoing_ip
+FROM quasseluser
+WHERE userid = :userid

--- a/src/core/SQL/SQLite/setup_000_quasseluser.sql
+++ b/src/core/SQL/SQLite/setup_000_quasseluser.sql
@@ -3,5 +3,6 @@ CREATE TABLE quasseluser (
        username TEXT UNIQUE NOT NULL,
        password TEXT NOT NULL,
        hashversion INTEGER NOT NULL DEFAULT 0,
-       authenticator TEXT NOT NULL DEFAULT "Database"
+       authenticator TEXT NOT NULL DEFAULT "Database",
+       outgoing_ip TEXT NOT NULL DEFAULT ""
 )

--- a/src/core/SQL/SQLite/version/33/upgrade_000_alter_quasseluser_add_outgoing_ip.sql
+++ b/src/core/SQL/SQLite/version/33/upgrade_000_alter_quasseluser_add_outgoing_ip.sql
@@ -1,0 +1,1 @@
+ALTER TABLE quasseluser ADD COLUMN outgoing_ip TEXT NOT NULL DEFAULT ""

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -678,6 +678,7 @@ public:
     inline OidentdConfigGenerator* oidentdConfigGenerator() const { return _oidentdConfigGenerator; }
     inline IdentServer* identServer() const { return _identServer; }
     inline MetricsServer* metricsServer() const { return _metricsServer; }
+    inline QHostAddress getUserOutgoingIp(UserId userId) const { return _storage->getUserOutgoingIp(userId); }
 
     static const int AddClientEventId;
 

--- a/src/core/corenetwork.cpp
+++ b/src/core/corenetwork.cpp
@@ -268,6 +268,18 @@ void CoreNetwork::connectToIrc(bool reconnecting)
         // hostname of the server. Qt's DNS cache also isn't used by the proxy so we don't need to refresh the entry.
         QHostInfo::fromName(server.host);
     }
+    QHostAddress outgoingIp = coreSession()->outgoingIp();
+    if (!outgoingIp.isNull()) {
+        qDebug() << "Setting outgoing ip for user " << coreSession()->user()
+                 << "to ip" << outgoingIp;
+        if (!socket.bind(outgoingIp)) {
+            qWarning() << "Binding socket for user "<< coreSession()->user()
+                       << "to ip" << outgoingIp
+                       << "failed";
+            disconnectFromIrc(false, {}, false);
+            return;
+        }
+    }
     if (server.useSsl) {
         CoreIdentity* identity = identityPtr();
         if (identity) {

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -80,6 +80,7 @@ CoreSession::CoreSession(UserId uid, bool restoreState, bool strictIdentEnabled,
     , _ignoreListManager(this)
     , _highlightRuleManager(this)
     , _metricsServer(Core::instance()->metricsServer())
+    , _outgoingIp(Core::instance()->getUserOutgoingIp(uid))
 {
     SignalProxy* p = signalProxy();
     p->setHeartBeatInterval(30);

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -68,6 +68,7 @@ public:
 
     std::vector<BufferInfo> buffers() const;
     inline UserId user() const { return _user; }
+    QHostAddress outgoingIp() const { return _outgoingIp; }
     CoreNetwork* network(NetworkId) const;
     CoreIdentity* identity(IdentityId) const;
 
@@ -273,6 +274,7 @@ private:
     CoreIgnoreListManager _ignoreListManager;
     CoreHighlightRuleManager _highlightRuleManager;
     MetricsServer* _metricsServer{nullptr};
+    QHostAddress _outgoingIp;
 };
 
 struct NetworkInternalMessage

--- a/src/core/postgresqlstorage.cpp
+++ b/src/core/postgresqlstorage.cpp
@@ -355,6 +355,24 @@ QString PostgreSqlStorage::getUserAuthenticator(const UserId userid)
     }
 }
 
+QHostAddress PostgreSqlStorage::getUserOutgoingIp(const UserId userId)
+{
+    QSqlQuery query(logDb());
+    query.prepare(queryString("select_outgoing_ip"));
+    query.bindValue(":userid", userId.toInt());
+    safeExec(query);
+    watchQuery(query);
+
+    if (query.first()) {
+        QString hostAddressString = query.value(0).toString();
+        if (!hostAddressString.isEmpty()) {
+            return QHostAddress(hostAddressString);
+        }
+    }
+
+    return QHostAddress();
+}
+
 UserId PostgreSqlStorage::internalUser()
 {
     QSqlQuery query(logDb());

--- a/src/core/postgresqlstorage.h
+++ b/src/core/postgresqlstorage.h
@@ -51,6 +51,7 @@ public:
     UserId validateUser(const QString& user, const QString& password) override;
     UserId getUserId(const QString& username) override;
     QString getUserAuthenticator(const UserId userid) override;
+    QHostAddress getUserOutgoingIp(UserId userId) override;
     UserId internalUser() override;
     void delUser(UserId user) override;
     void setUserSetting(UserId userId, const QString& settingName, const QVariant& data) override;

--- a/src/core/sqlitestorage.cpp
+++ b/src/core/sqlitestorage.cpp
@@ -319,6 +319,30 @@ QString SqliteStorage::getUserAuthenticator(const UserId userid)
     return authenticator;
 }
 
+QHostAddress SqliteStorage::getUserOutgoingIp(UserId userId)
+{
+    QHostAddress hostAddress{};
+
+    {
+        QSqlQuery query(logDb());
+        query.prepare(queryString("select_outgoing_ip"));
+        query.bindValue(":userid", userId.toInt());
+
+        lockForRead();
+        safeExec(query);
+
+        if (query.first()) {
+            QString hostAddressString = query.value(0).toString();
+            if (!hostAddressString.isEmpty()) {
+                hostAddress = QHostAddress(hostAddressString);
+            }
+        }
+    }
+    unlock();
+
+    return hostAddress;
+}
+
 UserId SqliteStorage::internalUser()
 {
     UserId userId;

--- a/src/core/sqlitestorage.h
+++ b/src/core/sqlitestorage.h
@@ -55,6 +55,7 @@ public:
     UserId validateUser(const QString& user, const QString& password) override;
     UserId getUserId(const QString& username) override;
     QString getUserAuthenticator(const UserId userid) override;
+    QHostAddress getUserOutgoingIp(UserId userId) override;
     UserId internalUser() override;
     void delUser(UserId user) override;
     void setUserSetting(UserId userId, const QString& settingName, const QVariant& data) override;

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -155,6 +155,12 @@ public:
      */
     virtual QString getUserAuthenticator(const UserId userid) = 0;
 
+    //! Get the outgoing IP address to be used for a given user.
+    /** \param userId The users Id
+     *  \return The host address to use for this user, if existing
+     */
+    virtual QHostAddress getUserOutgoingIp(UserId userId) = 0;
+
     //! Determine the UserId of the internal user
     /** \return A valid UserId if the password matches the username; 0 else
      */


### PR DESCRIPTION
## In Short

* Adds a database column to the quasseluser table for per-user outgoing IPs
* Binds to that IP when creating new outgoing sockets

## Impact

| Criteria | Rank | Reason |
| - | - | - |
| Impact | ★☆☆  _1/3_ | Allows separating outgoing users by IP, useful as IPv6 identd alternative |
| Risk | ★★★  _3/3_ | Changes network socket creation, might cause IRC connectivity to fail |
| Intrusiveness | ★☆☆  _1/3_ | Changes localized to a few classes |

## Rationale

Currently, Quassel supports identd for per-user ident to allow owners of larger quassel cores to avoid a ban of one user affecting the others. Many networks have stopped supporting this, though, instead opting to move to IPv6 based alternatives.

With this change, the operator of a Quassel Core can set an IPv6 for each individual user, which will be used for outgoing IRC connections, allowing bans against one user to avoid affecting other users.