### PR TITLE
ci: [mac] Update Xcode version to Qt 5 supported

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,8 @@ jobs:
       uses: maxim-lobanov/setup-xcode@v1
       with:
         # Newer Xcode versions may not officially be supported by Qt
-        xcode-version: '10.3'
+        # Check https://doc.qt.io/qt-5/macos.html
+        xcode-version: '12.4.0'
 
     - name: Check out source code
       uses: actions/checkout@v2


### PR DESCRIPTION
## In short
* Update Xcode version in CI to fix build
  * Xcode 10.3 is no longer available
  * As of 2021-10-14, [Qt 5 supports up to Xcode 12.5.1](https://doc.qt.io/qt-5/macos.html )

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes automated macOS builds
Risk | ★☆☆ *1/3* | Updated Xcode version may introduce unexpected changes
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests


*As this is a minor change, I've skipped the usual breakdown analysis.  I don't have a Mac to test with.*