### PR TITLE
ci: Schedule monthly build to catch regressions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,16 @@
 # and attaching Windows and macOS builds, as well as the source archive.
 name: Quassel CI
 
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run at 13:37 on the 14th of every month (odd time to reduce load)
+    - cron: '37 13 14 * *'
+
+# Can't use simpler definition of [ push, pull_request, schedule ]
+# See https://www.jeffgeerling.com/blog/2020/running-github-actions-workflow-on-schedule-and-other-events
 
 defaults:
   run:


### PR DESCRIPTION
## In short
* [Schedule a monthly CI build](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#scheduled-events ) to catch regressions in build system
  * Helps during periods of low commit activity
  * Would have (eventually) [caught the recent macOS CI failure](https://github.com/quassel/quassel/commit/7064a9e9b8aec31aca5ac88b4a5190a50dfc84c7 )
  * Scheduled for [off-peak hour `13:37` on 14th](https://crontab.guru/#37_13_14_*_*) to help reduce load
  * Keeps Quassel CI download artifacts available ([avoids expiration](https://github.com/actions/upload-artifact#retention-period))

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Keeps artifacts available, makes CI failures detectable via badge and email
Risk | ★☆☆ *1/3* | Slightly increases load on GitHub CI - one extra build per month
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Rationale
Quassel development might have times of rest, but the build system Quassel uses continues to change regardless.  Scheduling a monthly rebuild helps with detecting any CI problems before it negatively impacts contributors or the process of getting a Quassel release out the door.

GitHub Artifacts also [expire after 3 months by default](https://github.com/actions/upload-artifact#retention-period), so this helps ensure that Windows and macOS nightly builds remain available.

If desired, builds could be configured to run more frequently, e.g. every other week.

### Quassel Linux container images
**NOTE:** This does **not** automatically update [the Quassel Docker Hub images](https://github.com/quassel/quassel-build-env)!  That needs handled on the Docker Hub side!
