### PR TITLE
[backport 0.14] client: Fix AsNeededBacklog hang with old cores

### DIFF
--- a/src/client/backlogrequester.cpp
+++ b/src/client/backlogrequester.cpp
@@ -136,7 +136,7 @@ void PerBufferUnreadBacklogRequester::requestBacklog(const BufferIdList& bufferI
 //  AS NEEDED BACKLOG REQUESTER
 // ========================================
 AsNeededBacklogRequester::AsNeededBacklogRequester(ClientBacklogManager* backlogManager)
-    : BacklogRequester(false, BacklogRequester::AsNeeded, backlogManager)
+    : BacklogRequester(true, BacklogRequester::AsNeeded, backlogManager)
 {
     BacklogSettings backlogSettings;
     _legacyBacklogCount = backlogSettings.asNeededLegacyBacklogAmount();


### PR DESCRIPTION
## In short
* Fix default `Only fetch when needed` hang with pre-0.13 cores
  * Fixes backlog fetch taking 3× time compared to 0.13 client
  * Impacts clients with Ubuntu 18.04 server (Quassel core 0.12.4)

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes backlog fetch regression with cores 0.12.5 and older
Risk | ★☆☆ *1/3* | Mimics well-tested fixed backlog fetch method
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Details

For whatever reason, if the client doesn't call `updateProgress(...);` after initial backlog request, it hangs.

To fix this, `AsNeededBacklogRequester` has been changed to set `buffering`/`isBuffering()` to `true` on initialization, [which causes the client to call `updateProgress()`](https://github.com/quassel/quassel/blob/0.14/src/client/clientbacklogmanager.cpp#L116-L118 ).

Why does the disabled `GlobalUnreadBacklogRequester` need to set `buffering` to `false` initially?  Why does this cause the client to hang?  Should `buffering` always be initialized to `true`..?

This should be investigated further in the future.

## Testing

### Steps

1.  Set up pre-0.13 Quassel core
    * One option: install Ubuntu 18.04 LTS in a VM, then `sudo apt install quassel-core`
2.  Restore an SQLite (or PostgreSQL?) database with many buffers
    * Tested with 156 buffers
3.  Connect 0.14 client, do initial setup to use the restored database
4.  Set client to `Fetch only when needed` backlog fetching mode
5.  Time how long connecting takes
6.  Apply this patch
7.  Rebuild, time how long connecting takes

#### Test case

* 167 MB SQLite database from 2014 with 156 buffers
* `0.12.4` core (Ubuntu 18.04)
* `0.14-git` client (Kubuntu 20.04)

### Before
* Average 9 seconds to finish backlog fetch

### After
* Average 2 seconds to finish backlog fetch
