### PR TITLE
[backport 0.14] ci: Fix Craft Windows build by ignoring Python 2

### DIFF
--- a/.craftsettings.ini
+++ b/.craftsettings.ini
@@ -23,6 +23,10 @@ libs/dbus.ignored = True
 libs/llvm-meta.ignored = True
 dev-utils/msys.ignored = True
 dev-utils/perl.ignored = True
+# QtWebEngine currently requires Python 2 to build, but we make use of KDE's
+# prebuilt packages and thus don't need Python 2.  This dependency breaks on
+# GitHub Actions' Windows Server 2022 images.
+dev-utils/python2.ignored = True
 
 [windows-msvc2019_64-cl]
 General/ABI = windows-msvc2019_64-cl


### PR DESCRIPTION
## In short
* Fix Craft Windows build by ignoring Python 2
  * GitHub's [Windows Server 2022 images](https://github.com/actions/virtual-environments/issues/4856 ) removed Python 2
  * Python 2 build-time [dependency introduced by QtWebEngine](https://github.com/KDE/craft-blueprints-kde/blob/f6674971eaa2607e7bd1d0970dc83e73ad7230f3/libs/qt5/qtwebengine/qtwebengine.py#L43 )
  * We rely on KDE's prebuilt QtWebEngine image, so Python 2 is not needed
  * Caught by [the monthly scheduled CI build](https://github.com/quassel/quassel/commit/c51ac776a9b4b9fbc3ff9b0063f44acd566732ea ) before it impacted contributors 🎉

*Many thanks to @TheOneRing on `Libera Chat`/`#quassel` for guiding me!*

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | Fixes Windows builds, makes Windows CI artifacts available
Risk | ★☆☆ *1/3* | Quassel CI depends on KDE's prebuilt of QtWebEngine
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Details

Regarding the QtWebEngine dependency, from what I understand, Quassel IRC already depended on KDE's prebuilt image since QtWebEngine would've taken too long to build from source.  I don't think this is a meaningful risk, but it's worth acknowledging our dependency chain.