### PR TITLE
Add formatting for RPL_HELPSTART/RPL_HELPTXT/RPL_ENDOFHELP

### DIFF
--- a/src/core/eventstringifier.cpp
+++ b/src/core/eventstringifier.cpp
@@ -783,6 +783,33 @@ void EventStringifier::processIrcEvent437(IrcEvent* e)
     displayMsg(e, Message::Error, tr("Nick/channel is temporarily unavailable: %1").arg(e->params()[0]));
 }
 
+/* RPL_HELPSTART */
+void EventStringifier::processIrcEvent704(IrcEvent* e)
+{
+    if (!checkParamCount(e, 2))
+        return;
+
+    displayMsg(e, Message::Error, tr("[Help] %1").arg(e->params()[1]));
+}
+
+/* RPL_HELPTXT */
+void EventStringifier::processIrcEvent705(IrcEvent* e)
+{
+    if (!checkParamCount(e, 2))
+        return;
+
+    displayMsg(e, Message::Error, tr("[Help] %1").arg(e->params()[1]));
+}
+
+/* RPL_ENDOFHELP */
+void EventStringifier::processIrcEvent706(IrcEvent* e)
+{
+    if (!checkParamCount(e, 2))
+        return;
+
+    displayMsg(e, Message::Error, tr("[Help] %1").arg(e->params()[1]));
+}
+
 // template
 /*
 

--- a/src/core/eventstringifier.h
+++ b/src/core/eventstringifier.h
@@ -94,6 +94,9 @@ public:
     Q_INVOKABLE void processIrcEvent432(IrcEvent* event);  // ERR_ERRONEUSNICKNAME
     Q_INVOKABLE void processIrcEvent433(IrcEvent* event);  // ERR_NICKNAMEINUSE
     Q_INVOKABLE void processIrcEvent437(IrcEvent* event);  // ERR_UNAVAILRESOURCE
+    Q_INVOKABLE void processIrcEvent704(IrcEvent* event);  // RPL_HELPSTART
+    Q_INVOKABLE void processIrcEvent705(IrcEvent* event);  // RPL_HELPTXT
+    Q_INVOKABLE void processIrcEvent706(IrcEvent* event);  // RPL_ENDOFHELP
 
     // Q_INVOKABLE void processIrcEvent(IrcEvent *event);
 


### PR DESCRIPTION
For example with the reply to `/help mode` on InspIRCd:

Before:

![screenshot-2022-04-02_13-59-15](https://user-images.githubusercontent.com/406946/161382158-7458b054-818e-4f16-b84a-fb9232f87877.png)

After:

![screenshot-2022-04-02_13-59-01](https://user-images.githubusercontent.com/406946/161382161-8152bbd5-f35d-4484-9eb1-1be97828d3b9.png)
