### PR TITLE
common: Fix translation loading, use all paths

### DIFF
--- a/src/common/quassel.h
+++ b/src/common/quassel.h
@@ -182,7 +182,7 @@ public:
      */
     static QString findDataFilePath(const QString& filename);
 
-    static QString translationDirPath();
+    static QStringList translationDirPaths();
 
     //! Returns a list of directories we look for scripts in
     /** We look for a subdirectory named "scripts" in the configdir and in all datadir paths.
@@ -253,7 +253,7 @@ private:
     QString _coreDumpFileName;
     QString _configDirPath;
     QStringList _dataDirPaths;
-    QString _translationDirPath;
+    QStringList _translationDirPaths;
 
     QCommandLineParser _cliParser;
 

--- a/src/qtui/settingspages/appearancesettingspage.cpp
+++ b/src/qtui/settingspages/appearancesettingspage.cpp
@@ -85,10 +85,21 @@ void AppearanceSettingsPage::initStyleComboBox()
 
 void AppearanceSettingsPage::initLanguageComboBox()
 {
-    QDir i18nDir(Quassel::translationDirPath(), "*.qm");
+    // Fetch all translation files across all translation paths
+    QStringList translationFiles;
+    for (auto dir : Quassel::translationDirPaths()) {
+        QDir i18nDir(dir, "*.qm");
+        translationFiles.append(i18nDir.entryList());
+    }
+
+    if (translationFiles.isEmpty()) {
+        qWarning() << "Could not find any translation files inside translation paths:"
+                   << Quassel::translationDirPaths();
+        return;
+    }
 
     QRegExp rx("(qt_)?([a-zA-Z_]+)\\.qm");
-    foreach (QString translationFile, i18nDir.entryList()) {
+    foreach (QString translationFile, translationFiles) {
         if (!rx.exactMatch(translationFile))
             continue;
         if (!rx.cap(1).isEmpty())


### PR DESCRIPTION
## In short
* Fix `QTranslator` loading Qt translations on Linux
  * Specify [directory as `directory` in `load()`, not as `prefix`](https://doc.qt.io/qt-5/qtranslator.html#load-1 )
  * Fixes loading Qt (not Quassel) translations on Ubuntu 20.04 LTS
* Load translations from all available translation data directories
  * Fixes failure to load translations on Windows due to Qt translation install path
  * Always includes internal resource when present (`:/i18n/`)

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★★ *3/3* | Fixes missing translations on Windows
Risk | ★★☆ *2/3* | Modifies translation search/load code, macOS untested
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Details

As of 0.14.0, the Windows installer for Quassel places the Qt translations into `C:\Program Files\Quassel IRC\translations` folder, while Quassel's own translations are bundled internally in `:/i18n/`.

Before this change, Quassel would only try to load translations from one possible data path, missing the bundled translations in `:/i18n/`.

After this change, Quassel tries to load translations from all available data paths, including the bundled translations when present.

## Testing

### Steps

1.  Build and install Quassel
    * On Windows, download the `Windows.zip` artifact from GitHub Actions
2.  Open the configuration window
    * Go to `Settings` → `Configure Quassel…`
    * Or, press <kbd>F7</kbd>
3.  Expand the `Language:` drop-down, check that expected languages are present
4.  Select a different language, apply
5.  Restart Quassel
6.  Check if the language applied successfully

### Before
#### Linux

Qt translations fail to load according to the `false` return status of `qtTranslator->load(…)` with `QLibraryInfo::location(QLibraryInfo::TranslationsPath)`.

#### Windows

All translations fail to load.

The `Language:` setting in the configuration window displays `<Untranslated>`, `<System Default>`, and `C` as the only options.

![Screenshot of the Quassel IRC client window in English showing the "Configure Quassel..." window with the "Language" dropdown expanded revealing a lack of translations.](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-qt-win-trans/Screenshot%20-%20Quassel%20IRC%20before%20fix%20stuck%20in%20English.png#v1)

### After
#### Linux

Qt translations successfully load according to the `true` return status of `qtTranslator->load(…)` with `QLibraryInfo::location(QLibraryInfo::TranslationsPath)`.

*NOTE: For unknown reasons, even when Qt claims the translation loaded successfully, system strings (e.g. the `Cancel` button) does not get translated.  Quassel's strings change successfully.  This is not a regression as the same issue happens on the `master` branch.*

#### Windows

Translations load and apply to both Quassel's strings and Qt's system strings (e.g. the `Cancel` button).

The `Language:` setting in the configuration window displays all the expected language options.

The `Debug Log` window now prints the following debug message:
```
Translation paths: "C:/Program Files/Quassel IRC\translations/", ":/i18n/", with Qt fallback: "C:/Program Files/Quassel IRC/translations"
```

![Screenshot of the Quassel IRC client window in German showing the "Configure Quassel..." window with the "Language" dropdown expanded, showing a full list of translations as expected.](https://zorro.casa/sync/Hosting/Utilities/Quassel/Development/pr/fix-qt-win-trans/Screenshot%20-%20Quassel%20IRC%20after%20fix%20in%20German.png#v1)
