### PR TITLE
[WIP] Expand URL clickability

### DIFF
--- a/src/uisupport/clickable.cpp
+++ b/src/uisupport/clickable.cpp
@@ -53,7 +53,7 @@ void Clickable::activate(NetworkId networkId, const QString& text) const
 ClickableList ClickableList::fromString(const QString& str)
 {
     // For matching URLs
-    static QString scheme(R"((?:(?:mailto:|(?:[+.-]?\w)+://)|www(?=\.\S+\.)))");
+    static QString scheme(R"((?:(?:mailto:|tel:|geo:|news:|urn:|(?:[+.-]?\w)+://)|www(?=\.\S+\.)))");
     static QString authority(R"((?:(?:[,.;@:]?[-\w]+)+\.?|\[[0-9a-f:.]+\])(?::\d+)?)");
     static QString urlChars("(?:[,.;:]*[\\w~@/?&=+$()!%#*-])");
     static QString urlEnd("(?:>|[,.;:\"]*\\s|\\b|$)");  // NOLINT(modernize-raw-string-literal)


### PR DESCRIPTION
This PR is currently a work in progress.

This is a temporary fix to enable the automatic linking of the following URI schemes:

* `tel:`
* `geo:`
* `news:`
* `urn:`

These were all requested in either [Issue 1414](https://bugs.quassel-irc.org/issues/1414) or [Issue 1761](https://bugs.quassel-irc.org/issues/1761). Another requested URL scheme was `magnet:` but without some serious overhauling to the regex for detecting URLs, this will not be as trivial of an addition.

In terms of impact, this shouldn't affect much, as `mailto:` and `http(s):` links still work fine, naked `www.foobar.com` URLs are still detected, etc.