### PR TITLE
fix client execwrapper not using full path to script

### DIFF
--- a/src/client/execwrapper.cpp
+++ b/src/client/execwrapper.cpp
@@ -73,7 +73,7 @@ void ExecWrapper::start(const BufferInfo& info, const QString& command)
             if (!QFile::exists(fileName))
                 continue;
             _process.setWorkingDirectory(scriptDir);
-            _process.start(_scriptName, params);
+            _process.start(fileName, params);
             return;
         }
         emit error(tr("Could not find script \"%1\"").arg(_scriptName));


### PR DESCRIPTION
The clients execwrapper was using the scriptName instead of the full path fileName to execute scripts leading to scripts only being found and executed if the script directory was also in $PATH or a executable with the same name as the script was in $PATH.

This could also lead to confusion as it executes whatever is in $PATH instead of the actual script in quassels directories.