### PR TITLE
[backport 0.14] ci: [mac] Update Qt 5 supported Xcode to v13.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,7 @@ jobs:
       with:
         # Newer Xcode versions may not officially be supported by Qt
         # Check https://doc.qt.io/qt-5/macos.html
-        xcode-version: '12.4.0'
+        xcode-version: '13.x'
 
     - name: Check out source code
       uses: actions/checkout@v2


### PR DESCRIPTION
## In short
* Update Xcode version in CI to fix build
  * Xcode 12.4 is no longer available
  * As of 2022-11-14, [Qt 5 supports up to Xcode 13.x](https://doc.qt.io/qt-5/macos.html )
  * [Matches a similar Xcode version bump made last year](https://github.com/quassel/quassel/pull/590 ), now [with semantic versioning](https://github.com/maxim-lobanov/setup-xcode#readme )!

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes automated macOS builds
Risk | ★☆☆ *1/3* | Updated Xcode version may introduce unexpected changes
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests


*As this is a minor change, I've skipped the usual breakdown analysis.  I don't have a Mac to test with.*