### PR TITLE
Allow basic setup to be disabled via environment variable

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -183,8 +183,13 @@ void Core::init()
             if (writeError) {
                 throw ExitException{EXIT_FAILURE, tr("Cannot write quasselcore configuration; probably a permission problem.")};
             }
-
+            
             qInfo() << "Core is currently not configured! Please connect with a Quassel Client for basic setup.";
+            
+            QString disable_basic_setup = environment.value("DISABLE_BASIC_SETUP");
+            if (disable_basic_setup == "true") {
+                throw ExitException{EXIT_FAILURE, tr("Unable to enter basic setup as it has been disabled. Exiting...")};
+            }
         }
     }
 


### PR DESCRIPTION
Hello.

I'm wanted to propose a feature to quassel.

Sometimes it happens that quassel can lose connection to the database instance.
And by default if it restarts, it can get into the basic setup, even if that is something that won't be necessary as the database can come back shortly after.

It's also a good security feature as this ensures it can't ever enter it unexpectedly, this is useful for automated environments like Docker.

As to not break previous behaviour this has to be enabled manually by setting the DISABLE_BASIC_SETUP  environment variable to true.

Let me know what you think, and if i should also try to get support for this in the config file.
I think for most users wanting to disable basic setup this should be enough however.

I thank you all for your time developing Quassel.

