### PR TITLE
Fix crash in ~MultiLineEdit() on quit

### DIFF
--- a/src/uisupport/multilineedit.cpp
+++ b/src/uisupport/multilineedit.cpp
@@ -73,6 +73,13 @@ MultiLineEdit::MultiLineEdit(QWidget* parent)
     _mircColorMap["15"] = "#c0c0c0";
 }
 
+MultiLineEdit::~MultiLineEdit()
+{
+#if defined HAVE_SONNET && !defined HAVE_KDE
+    delete _spellCheckDecorator;
+#endif
+}
+
 #if defined HAVE_SONNET && !defined HAVE_KDE
 Sonnet::Highlighter* MultiLineEdit::highlighter() const
 {

--- a/src/uisupport/multilineedit.h
+++ b/src/uisupport/multilineedit.h
@@ -52,6 +52,7 @@ public:
     };
 
     MultiLineEdit(QWidget* parent = nullptr);
+    ~MultiLineEdit() override;
 
     void setCustomFont(const QFont&);  // should be used instead setFont(), so we can set our size correctly
 


### PR DESCRIPTION
Quassel crashed on quit in ~MultiLineEdit() with Sonnet >= v5.102 since https://invent.kde.org/frameworks/sonnet/-/commit/ab31a3e27482539985c666a85aa0b07ac52c5c5f

Thread 1 "quasselclient" received signal SIGSEGV, Segmentation fault. Stacktrace:
QObject::removeEventFilter(QObject*) () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5 Sonnet::SpellCheckDecorator::~SpellCheckDecorator() () at /usr/lib/x86_64-linux-gnu/libKF5SonnetUi.so.5 Sonnet::SpellCheckDecorator::~SpellCheckDecorator() () at /usr/lib/x86_64-linux-gnu/libKF5SonnetUi.so.5 QObjectPrivate::deleteChildren() () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5 QWidget::~QWidget() () at /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5 MultiLineEdit::~MultiLineEdit() (this=0x555555f71550, __in_chrg=<optimized out>) at /run/build/quasselclient/src/uisupport/quassel_uisupport_autogen/EWIEGA46WW/../../multilineedit.h:4

See https://bugs.kde.org/show_bug.cgi?id=464499 for a similar crash in digiKam.

Reported in https://github.com/flathub/org.quassel_irc.QuasselClient/issues/20