### PR TITLE
uisupport: fix application name for .desktop shell integration

### DIFF
--- a/src/uisupport/aboutdata.cpp
+++ b/src/uisupport/aboutdata.cpp
@@ -114,13 +114,14 @@ AboutData& AboutData::addCredits(std::initializer_list<AboutPerson> credits)
 
 KAboutData AboutData::kAboutData() const
 {
-    KAboutData aboutData(Quassel::buildInfo().applicationName, tr("Quassel IRC"), Quassel::buildInfo().plainVersionString);
+    KAboutData aboutData(Quassel::buildInfo().clientApplicationName, tr("Quassel IRC"), Quassel::buildInfo().plainVersionString);
     aboutData.addLicense(KAboutLicense::GPL_V2);
     aboutData.addLicense(KAboutLicense::GPL_V3);
     aboutData.setShortDescription(tr("A modern, distributed IRC client"));
     aboutData.setProgramLogo(QVariant::fromValue(QImage(":/pics/quassel-logo.png")));
     aboutData.setBugAddress("https://bugs.quassel-irc.org/projects/quassel-irc/issues/new");
     aboutData.setOrganizationDomain(Quassel::buildInfo().organizationDomain.toUtf8());
+    aboutData.setDesktopFileName(Quassel::buildInfo().clientApplicationName);
 
     for (const auto& person : authors()) {
         aboutData.addAuthor(person.prettyName(), person.task(), person.emailAddress());


### PR DESCRIPTION
When building for KDE (cmake -DUSE_KDE=1), the KAboutData constructor as invoked by uisupport causes the resulting application name to be "org.kde.quassel".

At least on GNOME, this "org.kde.quassel" doesn't match the corresponding "quasselclient.desktop" file, which means the app doesn't get a pretty name/icon in the app launcher, which looks pretty ugly:

![1-bad](https://user-images.githubusercontent.com/2263268/232772887-20cb7417-0fcb-4531-bd5d-7ecc0661b7b8.png)

The solution is to call [KAboutData::setDesktopFileName()](https://api.kde.org/frameworks/kcoreaddons/html/classKAboutData.html) with the desired name. This means the corresponding .desktop is matched, and you get a pretty name/icon:

![2-good](https://user-images.githubusercontent.com/2263268/232773076-55aa97d3-e529-4ee2-9460-2ccab4d67dcf.png)

This issue doesn't occur when building with USE_KDE=0 for two reasons:

1. Because QtUiApplication already calls QGuiApplication::setDesktopFileName() with the correct value (which is, unfortunately, ignored when USE_KDE=1); and
2. Even if desktopFileName were to be unset, the binary name "quasselclient" would be used instead, which correctly matches "quasselclient.desktop".

For these reasons, we only need to fix the KAboutData settings.

An alternative workaround would be to set this flag in the quasselclient.desktop file:

    StartupWMClass=org.kde.quassel

But I would say this is worse because the "org.kde" doesn't make sense, since this is not a KDE project, and because the WM_CLASS would differ depending on the value of USE_KDE=<0|1>.