### PR TITLE
data/scripts/mpris: update to use current MPRIS D-Bus interface

### DIFF
--- a/data/scripts/mpris
+++ b/data/scripts/mpris
@@ -23,21 +23,21 @@
 # Simple script to read metadata from mpris compatible mediaplayers via dbus.
 #
 # Run it like this:
-# mpris amarok
+# mpris strawberry
 #
 # The script fills all fields exported by the player's dbusinterface.
-# They are defined here: http://wiki.xmms2.xmms.se/wiki/MPRIS_Metadata
+# They are defined here: https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/#fields
 #
 # To see which fields are actually available from your player,
 # call something like this from a terminal:
 #
-# qdbus org.mpris.amarok /Player GetMetadata
+# qdbus org.mpris.MediaPlayer2.strawberry /org/mpris/MediaPlayer2 Metadata
 # or
-# qdbus org.mpris.vlc /Player GetMetadata
+# qdbus org.mpris.MediaPlayer2.mpv /org/mpris/MediaPlayer2 Metadata
 # etc.
-# 
+#
 # Every field is available in the data hash 'd' via
-# $d{"NAME_OF_FIELD"}
+# $d{"NAME_OF_FIELD"} (without the 'xesam:' prefix)
 # To edit the output just change the marked line accordingly.
 
 use strict;
@@ -48,11 +48,11 @@ if($#ARGV < 0) {
  exit 1;
 }
 
-die "Please don't use any special characters in playername." if($ARGV[0] =~ /[^\w\d_-]/);
+die "Please don't use any special characters in playername." if($ARGV[0] =~ /[^\.\w\d_-]/);
 
-open(IN,"qdbus org.mpris.".$ARGV[0]." /Player GetMetadata|") or die "Couldn't get dbus result.";
+open(IN,"qdbus org.mpris.MediaPlayer2.".$ARGV[0]." /org/mpris/MediaPlayer2 Metadata|") or die "Couldn't get dbus result.";
 while(<IN>) {
-	$d{$1} = $2 if(/^([^:]+):\s+([^\n]+)/);
+	$d{$1} = $2 if(/^xesam:([^:]+):\s+([^\n]+)/);
 }
 close IN;
 


### PR DESCRIPTION
- Update documentation
- Allow for `.` in the name of the player name
- Strip `xesam:` from the result