### PR TITLE
Broken key exchange fix (Compatability with other clients)

### DIFF
--- a/src/core/cipher.h
+++ b/src/core/cipher.h
@@ -25,12 +25,14 @@ public:
     QByteArray decrypt(QByteArray cipher);
     QByteArray decryptTopic(QByteArray cipher);
     bool encrypt(QByteArray& cipher);
-    QByteArray initKeyExchange();
+    QByteArray initKeyExchange(bool wants_cbc);
     QByteArray parseInitKeyX(QByteArray key);
     bool parseFinishKeyX(QByteArray key);
     bool setKey(QByteArray key);
     QByteArray key() { return m_key; }
     bool setType(const QString& type);
+    bool wewantCbc() { return m_wantscbc; }
+    bool peerwantsCbc() { return m_peerwantscbc; }
     QString type() { return m_type; }
     static bool neededFeaturesAvailable();
     inline bool usesCBC() { return m_cbc; }
@@ -47,6 +49,8 @@ private:
     QCA::DHPrivateKey m_tempKey;
     QCA::BigInteger m_primeNum;
     QString m_type;
+    bool m_wantscbc;
+    bool m_peerwantscbc;
     bool m_cbc;
 };
 

--- a/src/qtui/topicwidget.cpp
+++ b/src/qtui/topicwidget.cpp
@@ -264,10 +264,15 @@ QString TopicWidget::sanitizeTopic(const QString& topic)
     // But the use of "plain text" functionality from Qt replaces
     // some unicode characters with a new line, which then triggers
     // a stack overflow later
+
     QString result(topic);
-    result.replace(QChar::CarriageReturn, " ");
-    result.replace(QChar::ParagraphSeparator, " ");
-    result.replace(QChar::LineSeparator, " ");
+    for(int i = 0; i< result.length(); i++) {
+        QChar a = result.at(i);
+        if (a.isPrint())
+            continue;
+        else
+            result[i] = QChar('?');
+    }
 
     return result;
 }


### PR DESCRIPTION
Hello,

this fixes a bunch of crap in the crypto key exchange department. I tested it using other clients (mirccryption), irssi (falsovski irssi-fish) with the monolithic build.

basically fixes https://bugs.quassel-irc.org/issues/1857

simultaneously fixes a rare bug i encountered:   when channel and topic were set with a different key. decryption of topic will then lead to random garbage bytes. Some which will still trigger the stack overflow despite the previous fixes.

also seems to cover integrates/resolve these features pull reqs:
mcps * cbc trigger decryption: https://github.com/quassel/quassel/pull/620
crash on broken topic: https://github.com/quassel/quassel/pull/612

best regards