### PR TITLE
Added client-side support for implicit TLS connections

### DIFF
--- a/src/client/clientauthhandler.cpp
+++ b/src/client/clientauthhandler.cpp
@@ -73,7 +73,7 @@ void ClientAuthHandler::connectToCore()
     setSocket(socket);
     connect(socket, &QAbstractSocket::stateChanged, this, &ClientAuthHandler::onSocketStateChanged);
     if (Quassel::isOptionSet("implicit-tls")) {
-        connect(socket, &QAbstractSocket::connected, this, &ClientAuthHandler::onImplicitTLSSocketConnected);
+        connect(socket, &QAbstractSocket::connected, this, &ClientAuthHandler::onImplicitTlsSocketConnected);
     } else {
         connect(socket, &QIODevice::readyRead, this, &ClientAuthHandler::onReadyRead);
         connect(socket, &QAbstractSocket::connected, this, &ClientAuthHandler::onSocketConnected);
@@ -147,7 +147,7 @@ void ClientAuthHandler::onSocketDisconnected()
     AuthHandler::onSocketDisconnected();
 }
 
-void ClientAuthHandler::onImplicitTLSSocketConnected()
+void ClientAuthHandler::onImplicitTlsSocketConnected()
 {
     if (_peer) {
         qWarning() << Q_FUNC_INFO << "Peer already exists!";
@@ -181,7 +181,7 @@ void ClientAuthHandler::onImplicitTlsSocketEncrypted()
         // Cert is valid, so we don't want to store it as known
         // That way, a warning will appear in case it becomes invalid at some point
         CoreAccountSettings s;
-        s.setAccountValue("SSLCert", QString());
+        s.setAccountValue("SslCert", QString());
         s.setAccountValue("SslCertDigestVersion", QVariant(QVariant::Int));
     }
 
@@ -494,7 +494,7 @@ void ClientAuthHandler::onSslSocketEncrypted()
         // Cert is valid, so we don't want to store it as known
         // That way, a warning will appear in case it becomes invalid at some point
         CoreAccountSettings s;
-        s.setAccountValue("SSLCert", QString());
+        s.setAccountValue("SslCert", QString());
         s.setAccountValue("SslCertDigestVersion", QVariant(QVariant::Int));
     }
 

--- a/src/client/clientauthhandler.h
+++ b/src/client/clientauthhandler.h
@@ -94,7 +94,7 @@ private slots:
     void onSocketStateChanged(QAbstractSocket::SocketState state);
     void onSocketError(QAbstractSocket::SocketError) override;
     void onSocketDisconnected() override;
-    void onImplicitTLSSocketConnected();
+    void onImplicitTlsSocketConnected();
     void onImplicitTlsSocketEncrypted();
     void onReadyRead();
 

--- a/src/client/clientauthhandler.h
+++ b/src/client/clientauthhandler.h
@@ -94,6 +94,8 @@ private slots:
     void onSocketStateChanged(QAbstractSocket::SocketState state);
     void onSocketError(QAbstractSocket::SocketError) override;
     void onSocketDisconnected() override;
+    void onImplicitTLSSocketConnected();
+    void onImplicitTlsSocketEncrypted();
     void onReadyRead();
 
     void onSslSocketEncrypted();
@@ -111,5 +113,6 @@ private:
     CoreAccount _account;
     bool _probing;
     bool _legacy;
+    bool _tls;
     quint8 _connectionFeatures;
 };

--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -337,6 +337,7 @@ void Quassel::setupCliParser()
             {"qss", tr("Load a custom application stylesheet."), tr("file.qss")},
             {"hidewindow", tr("Start the client minimized to the system tray.")},
             {"account", tr("Account id to connect to on startup."), tr("account"), "0"},
+            {"implicit-tls", tr("Force implicit TLS connection when connecting to the core")},
         };
     }
 

--- a/src/common/quassel.cpp
+++ b/src/common/quassel.cpp
@@ -367,6 +367,9 @@ void Quassel::setupCliParser()
             {"require-ssl", tr("Require SSL for remote (non-loopback) client connections.")},
             {"ssl-cert", tr("Specify the path to the SSL certificate."), tr("path"), "configdir/quasselCert.pem"},
             {"ssl-key", tr("Specify the path to the SSL key."), tr("path"), "ssl-cert-path"},
+            {"require-tls", tr("Require TLS for remote (non-loopback) client connections.")},
+            {"tls-cert", tr("Specify the path to the TLS certificate."), tr("path"), "configdir/quasselCert.pem"},
+            {"tls-key", tr("Specify the path to the SSL key."), tr("path"), "ssl-cert-path"},
             {"metrics-daemon", tr("Enable metrics API.")},
             {"metrics-port", tr("The port quasselcore will listen at for metrics requests. Only meaningful with --metrics-daemon."), tr("port"), "9558"},
             {"metrics-listen", tr("The address(es) quasselcore will listen on for metrics requests. Same format as --listen."), tr("<address>[,...]"), "::1,127.0.0.1"}

--- a/src/core/sslserver.cpp
+++ b/src/core/sslserver.cpp
@@ -36,6 +36,9 @@ SslServer::SslServer(QObject* parent)
     if (Quassel::isOptionSet("ssl-cert")) {
         _sslCertPath = Quassel::optionValue("ssl-cert");
     }
+    else if (Quassel::isOptionSet("tls-cert")) {
+        _sslCertPath = Quassel::optionValue("tls-cert");
+    }
     else {
         _sslCertPath = Quassel::configDirPath() + "quasselCert.pem";
     }
@@ -43,23 +46,26 @@ SslServer::SslServer(QObject* parent)
     if (Quassel::isOptionSet("ssl-key")) {
         _sslKeyPath = Quassel::optionValue("ssl-key");
     }
+    else if (Quassel::isOptionSet("tls-key")) {
+        _sslKeyPath = Quassel::optionValue("tls-key");
+    }
     else {
         _sslKeyPath = _sslCertPath;
     }
 
     // Initialize the certificates for first-time usage
     if (!loadCerts()) {
-        // If the core is unable to load a certificate, and "--require-ssl" is specified,
+        // If the core is unable to load a certificate, and "--require-ssl"/"--require-tls" is specified,
         // do not proceed, throw an exception and quit. This prevents the core from falling
         // back to a plaintext-only core when they should be expecting SSL/TLS only.
-        if (Quassel::isOptionSet("require-ssl")) {
-            throw ExitException{EXIT_FAILURE, tr("--require-ssl is set, but no SSL certificate is available. Exiting.\n"
-                                                 "Please see https://quassel-irc.org/faq/cert to learn how to enable SSL support.")};
+        if (Quassel::isOptionSet("require-ssl") || Quassel::isOptionSet("require-tls")) {
+            throw ExitException{EXIT_FAILURE, tr("--require-ssl/--require-tls is set, but no SSL/TLS certificate is available. Exiting.\n"
+                                                 "Please see https://quassel-irc.org/faq/cert to learn how to enable SSL/TLS support.")};
         }
         if (!sslWarningShown) {
             qWarning() << "SslServer: Unable to set certificate file\n"
-                       << "          Quassel Core will still work, but cannot provide SSL for client connections.\n"
-                       << "          Please see https://quassel-irc.org/faq/cert to learn how to enable SSL support.";
+                       << "          Quassel Core will still work, but cannot provide SSL/TLS for client connections.\n"
+                       << "          Please see https://quassel-irc.org/faq/cert to learn how to enable SSL/TLS support.";
             sslWarningShown = true;
         }
     }
@@ -101,13 +107,13 @@ bool SslServer::reloadCerts()
         // error if something goes wrong, in order to simplify checking if it's working.
         if (isCertValid()) {
             qWarning() << "SslServer: Unable to reload certificate file, reverting\n"
-                       << "          Quassel Core will use the previous key to provide SSL for client connections.\n"
-                       << "          Please see https://quassel-irc.org/faq/cert to learn how to enable SSL support.";
+                       << "          Quassel Core will use the previous key to provide SSL/TLS for client connections.\n"
+                       << "          Please see https://quassel-irc.org/faq/cert to learn how to enable SSL/TLS support.";
         }
         else {
             qWarning() << "SslServer: Unable to reload certificate file\n"
-                       << "          Quassel Core will still work, but cannot provide SSL for client connections.\n"
-                       << "          Please see https://quassel-irc.org/faq/cert to learn how to enable SSL support.";
+                       << "          Quassel Core will still work, but cannot provide SSL/TLS for client connections.\n"
+                       << "          Please see https://quassel-irc.org/faq/cert to learn how to enable SSL/TLS support.";
         }
         return false;
     }


### PR DESCRIPTION
This PR adds client-side support for implicit TLS connections. It's intentionally very minimal, no large refactors, in order to make merging and feedback easier.

This is intended to work with proxies that terminate TLS before the application. From the operational side it significantly simplifies certificate management. Implicit TLS connections also reduce potential privacy leaks and prevent any potential (downgrade) attacks during Quassel protocol negotiation.

In terms of future improvements, I am thinking about implementing the Proxy Protocol (v2) for accurate logging. I would also like to enforce TLSv1.3 minimum on implicit TLS connections, if there are no objections. In general it would be nice to switch to "TLS" as the term used in user-facing strings and also code, instead of "SSL" which is obsolete for more than a decade now.