### PR TITLE
Add functionality to hover over nick to see if they are still connected.

### DIFF
--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -574,17 +574,87 @@ void SenderChatItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* op
     painter->restore();
 }
 
+bool SenderChatItem::isCursorOverNick(const QPointF& eventPos) {
+    qreal layoutWidth = layout()->minimumWidth();
+    if (layoutWidth > width())
+        return true; // nick is clipped so cursor must be over it
+
+    // compute offset similarly as paint()
+    qreal offset = 0;
+    if (chatScene()->senderCutoffMode() == ChatScene::CutoffLeft)
+        offset = qMin(width() - layoutWidth, (qreal)0);
+    else
+        offset = qMax(layoutWidth - width(), (qreal)0);
+
+    QPointF layoutPos = mapFromLine(eventPos) - QPointF(offset, 0);
+    QTextLine line = layout()->lineAt(0);
+    // check vertical bounds first
+    if (layoutPos.y() >= line.y() && layoutPos.y() < line.y() + line.height()) {
+        // then horizontal bounds
+        if (layoutPos.x() >= line.cursorToX(line.textStart()) && 
+            layoutPos.x() <= line.cursorToX(line.textStart() + line.textLength())
+        )
+            return true;
+    }
+    return false;
+}
+
 void SenderChatItem::handleClick(const QPointF& pos, ChatScene::ClickMode clickMode)
 {
-    if (clickMode == ChatScene::DoubleClick) {
-        BufferInfo curBufInfo = Client::networkModel()->bufferInfo(data(MessageModel::BufferIdRole).value<BufferId>());
-        QString nick = data(MessageModel::EditRole).toString();
+    if (clickMode == ChatScene::SingleClick) {
         // check if the nick is a valid ircUser
-        if (!nick.isEmpty() && Client::network(curBufInfo.networkId())->ircUser(nick))
+        if (_validNickHover) {
+            BufferInfo curBufInfo = Client::networkModel()->bufferInfo(data(MessageModel::BufferIdRole).value<BufferId>());
+            QString nick = data(MessageModel::EditRole).toString();
             Client::bufferModel()->switchToOrStartQuery(curBufInfo.networkId(), nick);
+        }
     }
     else
         ChatItem::handleClick(pos, clickMode);
+}
+
+void SenderChatItem::hoverMoveEvent(QGraphicsSceneHoverEvent* event)
+{
+    QString nick = data(MessageModel::EditRole).toString();
+    bool shouldHover = false;
+    if (!nick.isEmpty()) {
+        BufferInfo curBufInfo = Client::networkModel()->bufferInfo(data(MessageModel::BufferIdRole).value<BufferId>());
+        if (isCursorOverNick(event->pos()) && Client::network(curBufInfo.networkId())->ircUser(nick))
+            shouldHover = true;
+    }
+    if (shouldHover != _validNickHover) {
+        _validNickHover = shouldHover;
+        if (_validNickHover)
+            chatLine()->setCursor(Qt::PointingHandCursor);
+        else
+            chatLine()->unsetCursor();
+        chatLine()->update();
+    }
+    event->accept();
+}
+
+void SenderChatItem::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
+{
+    if (_validNickHover) {
+        _validNickHover = false;
+        chatLine()->unsetCursor();
+        chatLine()->update();
+    }
+    event->accept();
+}
+
+bool SenderChatItem::hasActiveClickable() const
+{
+    return _validNickHover;
+}
+
+std::pair<quint16, quint16> SenderChatItem::activeClickableRange() const
+{
+    if (_validNickHover) {
+        return {0, static_cast<quint16>(data(MessageModel::DisplayRole).toString().length())};
+
+    }
+    return {};
 }
 
 // ************************************************************

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -605,7 +605,7 @@ void SenderChatItem::handleClick(const QPointF& pos, ChatScene::ClickMode clickM
     if (clickMode == ChatScene::SingleClick) {
         if (_validNickHover) {
             if (MainWin *mainWin = QtUi::mainWindow()) {
-                if (auto* inputWidget = mainWin->inputWidget()) {
+                if (InputWidget *inputWidget = mainWin->inputWidget()) {
                     QString nick = data(MessageModel::EditRole).toString();
                     inputWidget->inputLine()->insertPlainText(nick + ": ");
                     inputWidget->inputLine()->moveCursor(QTextCursor::End);
@@ -631,6 +631,7 @@ void SenderChatItem::hoverMoveEvent(QGraphicsSceneHoverEvent* event)
     bool shouldHover = false;
     if (!nick.isEmpty()) {
         BufferInfo curBufInfo = Client::networkModel()->bufferInfo(data(MessageModel::BufferIdRole).value<BufferId>());
+        // now check if irc user is valid
         if (isCursorOverNick(event->pos()) && Client::network(curBufInfo.networkId())->ircUser(nick))
             shouldHover = true;
     }

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -19,6 +19,7 @@
  ***************************************************************************/
 
 #include "chatitem.h"
+#include "inputwidget.h"
 
 #include <algorithm>
 #include <iterator>
@@ -602,7 +603,18 @@ bool SenderChatItem::isCursorOverNick(const QPointF& eventPos) {
 void SenderChatItem::handleClick(const QPointF& pos, ChatScene::ClickMode clickMode)
 {
     if (clickMode == ChatScene::SingleClick) {
-        // check if the nick is a valid ircUser
+        if (_validNickHover) {
+            if (MainWin *mainWin = QtUi::mainWindow()) {
+                if (auto* inputWidget = mainWin->inputWidget()) {
+                    QString nick = data(MessageModel::EditRole).toString();
+                    inputWidget->inputLine()->insertPlainText(nick + ": ");
+                    inputWidget->inputLine()->moveCursor(QTextCursor::End);
+                    inputWidget->setFocus();
+                }
+            }
+        }
+    }
+    else if (clickMode == ChatScene::DoubleClick) {
         if (_validNickHover) {
             BufferInfo curBufInfo = Client::networkModel()->bufferInfo(data(MessageModel::BufferIdRole).value<BufferId>());
             QString nick = data(MessageModel::EditRole).toString();

--- a/src/qtui/chatitem.h
+++ b/src/qtui/chatitem.h
@@ -193,7 +193,13 @@ public:
 protected:
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr) override;
     inline int type() const override { return ChatScene::SenderChatItemType; }
+    bool isCursorOverNick(const QPointF& eventPos);
     void initLayout(QTextLayout* layout) const override;
+    void hoverMoveEvent(QGraphicsSceneHoverEvent* event) override;
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
+    bool hasActiveClickable() const override;
+    std::pair<quint16, quint16> activeClickableRange() const override;
+    bool _validNickHover = false; // true if cursor is over a valid nick
 };
 
 // ************************************************************

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -75,6 +75,7 @@ public:
     BufferView* allBuffersView() const;
     BufferView* activeBufferView() const;
 
+    inline InputWidget* inputWidget() const { return _inputWidget; }
     inline BufferWidget* bufferWidget() const { return _bufferWidget; }
     inline SystemTray* systemTray() const { return _systemTray; }
 


### PR DESCRIPTION
In SenderChatView, on hover, check if the cursor is on the nickname. 
If the nick is a valid user who is still connected to the channel, show a clickable pointer.

On single click, the user's nick is added to the input box to mention them.
The flow on double click is the same as before - it opens the query buffer. But now, this only happens if the cursor is actually over the nickname instead of anywhere on the SenderChatView.

tl;dr: these changes help check quickly if the user is still in the channel or not by hovering over their name before replying.