### PR TITLE
Show nick actions when username is right clicked

### DIFF
--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -574,17 +574,87 @@ void SenderChatItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* op
     painter->restore();
 }
 
+bool SenderChatItem::isCursorOverNick(const QPointF& eventPos) {
+    qreal layoutWidth = layout()->minimumWidth();
+    if (layoutWidth > width())
+        return true; // nick is clipped so cursor must be over it
+
+    // compute offset similarly as paint()
+    qreal offset = 0;
+    if (chatScene()->senderCutoffMode() == ChatScene::CutoffLeft)
+        offset = qMin(width() - layoutWidth, (qreal)0);
+    else
+        offset = qMax(layoutWidth - width(), (qreal)0);
+
+    QPointF layoutPos = mapFromLine(eventPos) - QPointF(offset, 0);
+    QTextLine line = layout()->lineAt(0);
+    // check vertical bounds first
+    if (layoutPos.y() >= line.y() && layoutPos.y() < line.y() + line.height()) {
+        // then horizontal bounds
+        if (layoutPos.x() >= line.cursorToX(line.textStart()) && 
+            layoutPos.x() <= line.cursorToX(line.textStart() + line.textLength())
+        )
+            return true;
+    }
+    return false;
+}
+
 void SenderChatItem::handleClick(const QPointF& pos, ChatScene::ClickMode clickMode)
 {
-    if (clickMode == ChatScene::DoubleClick) {
-        BufferInfo curBufInfo = Client::networkModel()->bufferInfo(data(MessageModel::BufferIdRole).value<BufferId>());
-        QString nick = data(MessageModel::EditRole).toString();
+    if (clickMode == ChatScene::SingleClick) {
         // check if the nick is a valid ircUser
-        if (!nick.isEmpty() && Client::network(curBufInfo.networkId())->ircUser(nick))
+        if (_validNickHover) {
+            BufferInfo curBufInfo = Client::networkModel()->bufferInfo(data(MessageModel::BufferIdRole).value<BufferId>());
+            QString nick = data(MessageModel::EditRole).toString();
             Client::bufferModel()->switchToOrStartQuery(curBufInfo.networkId(), nick);
+        }
     }
     else
         ChatItem::handleClick(pos, clickMode);
+}
+
+void SenderChatItem::hoverMoveEvent(QGraphicsSceneHoverEvent* event)
+{
+    QString nick = data(MessageModel::EditRole).toString();
+    bool shouldHover = false;
+    if (!nick.isEmpty()) {
+        BufferInfo curBufInfo = Client::networkModel()->bufferInfo(data(MessageModel::BufferIdRole).value<BufferId>());
+        if (isCursorOverNick(event->pos()) && Client::network(curBufInfo.networkId())->ircUser(nick))
+            shouldHover = true;
+    }
+    if (shouldHover != _validNickHover) {
+        _validNickHover = shouldHover;
+        if (_validNickHover)
+            chatLine()->setCursor(Qt::PointingHandCursor);
+        else
+            chatLine()->unsetCursor();
+        chatLine()->update();
+    }
+    event->accept();
+}
+
+void SenderChatItem::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
+{
+    if (_validNickHover) {
+        _validNickHover = false;
+        chatLine()->unsetCursor();
+        chatLine()->update();
+    }
+    event->accept();
+}
+
+bool SenderChatItem::hasActiveClickable() const
+{
+    return _validNickHover;
+}
+
+std::pair<quint16, quint16> SenderChatItem::activeClickableRange() const
+{
+    if (_validNickHover) {
+        return {0, static_cast<quint16>(data(MessageModel::DisplayRole).toString().length())};
+
+    }
+    return {};
 }
 
 // ************************************************************

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -605,7 +605,7 @@ void SenderChatItem::handleClick(const QPointF& pos, ChatScene::ClickMode clickM
     if (clickMode == ChatScene::SingleClick) {
         if (_validNickHover) {
             if (MainWin *mainWin = QtUi::mainWindow()) {
-                if (auto* inputWidget = mainWin->inputWidget()) {
+                if (InputWidget *inputWidget = mainWin->inputWidget()) {
                     QString nick = data(MessageModel::EditRole).toString();
                     inputWidget->inputLine()->insertPlainText(nick + ": ");
                     inputWidget->inputLine()->moveCursor(QTextCursor::End);
@@ -631,6 +631,7 @@ void SenderChatItem::hoverMoveEvent(QGraphicsSceneHoverEvent* event)
     bool shouldHover = false;
     if (!nick.isEmpty()) {
         BufferInfo curBufInfo = Client::networkModel()->bufferInfo(data(MessageModel::BufferIdRole).value<BufferId>());
+        // now check if irc user is valid
         if (isCursorOverNick(event->pos()) && Client::network(curBufInfo.networkId())->ircUser(nick))
             shouldHover = true;
     }

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -603,10 +603,10 @@ bool SenderChatItem::isCursorOverNick(const QPointF& eventPos) {
 void SenderChatItem::handleClick(const QPointF& pos, ChatScene::ClickMode clickMode)
 {
     if (clickMode == ChatScene::SingleClick) {
-        if (_validNickHover) {
+        if (isValidNickHover()) {
             if (MainWin *mainWin = QtUi::mainWindow()) {
                 if (InputWidget *inputWidget = mainWin->inputWidget()) {
-                    QString nick = data(MessageModel::EditRole).toString();
+                    QString nick = getSenderNick();
                     inputWidget->inputLine()->insertPlainText(nick + ": ");
                     inputWidget->inputLine()->moveCursor(QTextCursor::End);
                     inputWidget->setFocus();
@@ -615,9 +615,9 @@ void SenderChatItem::handleClick(const QPointF& pos, ChatScene::ClickMode clickM
         }
     }
     else if (clickMode == ChatScene::DoubleClick) {
-        if (_validNickHover) {
+        if (isValidNickHover()) {
             BufferInfo curBufInfo = Client::networkModel()->bufferInfo(data(MessageModel::BufferIdRole).value<BufferId>());
-            QString nick = data(MessageModel::EditRole).toString();
+            QString nick = getSenderNick();
             Client::bufferModel()->switchToOrStartQuery(curBufInfo.networkId(), nick);
         }
     }
@@ -627,7 +627,7 @@ void SenderChatItem::handleClick(const QPointF& pos, ChatScene::ClickMode clickM
 
 void SenderChatItem::hoverMoveEvent(QGraphicsSceneHoverEvent* event)
 {
-    QString nick = data(MessageModel::EditRole).toString();
+    QString nick = getSenderNick();
     bool shouldHover = false;
     if (!nick.isEmpty()) {
         BufferInfo curBufInfo = Client::networkModel()->bufferInfo(data(MessageModel::BufferIdRole).value<BufferId>());

--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -19,6 +19,7 @@
  ***************************************************************************/
 
 #include "chatitem.h"
+#include "inputwidget.h"
 
 #include <algorithm>
 #include <iterator>
@@ -602,7 +603,18 @@ bool SenderChatItem::isCursorOverNick(const QPointF& eventPos) {
 void SenderChatItem::handleClick(const QPointF& pos, ChatScene::ClickMode clickMode)
 {
     if (clickMode == ChatScene::SingleClick) {
-        // check if the nick is a valid ircUser
+        if (_validNickHover) {
+            if (MainWin *mainWin = QtUi::mainWindow()) {
+                if (auto* inputWidget = mainWin->inputWidget()) {
+                    QString nick = data(MessageModel::EditRole).toString();
+                    inputWidget->inputLine()->insertPlainText(nick + ": ");
+                    inputWidget->inputLine()->moveCursor(QTextCursor::End);
+                    inputWidget->setFocus();
+                }
+            }
+        }
+    }
+    else if (clickMode == ChatScene::DoubleClick) {
         if (_validNickHover) {
             BufferInfo curBufInfo = Client::networkModel()->bufferInfo(data(MessageModel::BufferIdRole).value<BufferId>());
             QString nick = data(MessageModel::EditRole).toString();

--- a/src/qtui/chatitem.h
+++ b/src/qtui/chatitem.h
@@ -189,6 +189,8 @@ public:
     {}
     inline ChatLineModel::ColumnType column() const override { return ChatLineModel::SenderColumn; }
     void handleClick(const QPointF& pos, ChatScene::ClickMode clickMode) override;
+    bool isValidNickHover() { return _validNickHover; }
+    QString getSenderNick() { return data(MessageModel::EditRole).toString(); }
 
 protected:
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr) override;

--- a/src/qtui/chatitem.h
+++ b/src/qtui/chatitem.h
@@ -193,7 +193,13 @@ public:
 protected:
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr) override;
     inline int type() const override { return ChatScene::SenderChatItemType; }
+    bool isCursorOverNick(const QPointF& eventPos);
     void initLayout(QTextLayout* layout) const override;
+    void hoverMoveEvent(QGraphicsSceneHoverEvent* event) override;
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
+    bool hasActiveClickable() const override;
+    std::pair<quint16, quint16> activeClickableRange() const override;
+    bool _validNickHover = false; // true if cursor is over a valid nick
 };
 
 // ************************************************************

--- a/src/qtui/chatscene.cpp
+++ b/src/qtui/chatscene.cpp
@@ -50,6 +50,8 @@
 #include "mainwin.h"
 #include "markerlineitem.h"
 #include "messagefilter.h"
+#include "nicklistwidget.h"
+#include "nickview.h"
 #include "qtui.h"
 #include "qtuistyle.h"
 #include "webpreviewitem.h"
@@ -781,8 +783,31 @@ void ChatScene::contextMenuEvent(QGraphicsSceneContextMenuEvent* event)
 
     // item-specific options (select link etc)
     ChatItem* item = chatItemAt(pos);
-    if (item)
-        item->addActionsToMenu(&menu, item->mapFromScene(pos));
+    if (item) {
+        bool showItemActions = true;
+        if (auto* senderItem = dynamic_cast<SenderChatItem*>(item)) {
+            // senderItem is a valid pointer
+            MainWin* mainWin = QtUi::mainWindow();
+            if  (mainWin && !isPosOverSelection(pos)) {
+                // get the nick list for the current buffer
+                NickListWidget* nickListWidget = mainWin->findChild<NickListWidget*>();
+                NickView* nickView = nickListWidget->getNickView(singleBufferId());
+                if (nickView && senderItem->isValidNickHover()) {
+                    // if the cursor is over the nickname, search for the nick in the nick list tree
+                    QString nick = senderItem->getSenderNick();
+                    QModelIndex nickIndex = nickView->getIndexFromNick(nick);
+                    if (nickIndex.isValid()) {
+                        // Clear previous actions and add nick-related actions only
+                        showItemActions = false;
+                        menu.clear();
+                        GraphicalUi::contextMenuActionProvider()->addActions(&menu, nickIndex);
+                    }
+                }
+            }
+        }
+        if (showItemActions)
+            item->addActionsToMenu(&menu, item->mapFromScene(pos));
+    }
     else
         // no item -> default scene actions
         GraphicalUi::contextMenuActionProvider()->addActions(&menu, filter(), BufferId());

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -75,6 +75,7 @@ public:
     BufferView* allBuffersView() const;
     BufferView* activeBufferView() const;
 
+    inline InputWidget* inputWidget() const { return _inputWidget; }
     inline BufferWidget* bufferWidget() const { return _bufferWidget; }
     inline SystemTray* systemTray() const { return _systemTray; }
 

--- a/src/qtui/nicklistwidget.h
+++ b/src/qtui/nicklistwidget.h
@@ -40,6 +40,7 @@ class NickListWidget : public AbstractItemView
 
 public:
     NickListWidget(QWidget* parent = nullptr);
+    NickView* getNickView(BufferId bufferId) const { return nickViews.value(bufferId, nullptr); }
 
 public slots:
     void showWidget(bool visible);

--- a/src/uisupport/nickview.cpp
+++ b/src/uisupport/nickview.cpp
@@ -95,6 +95,38 @@ void NickView::setRootIndex(const QModelIndex& index)
         unanimatedExpandAll();
 }
 
+QModelIndex NickView::getIndexFromNick(QString nick)
+{
+    QModelIndexList list;
+    QAbstractItemModel *itemModel = model();
+    if (!itemModel)
+        return QModelIndex();
+    QModelIndex parent = rootIndex();
+    if (!parent.isValid())
+        return QModelIndex();
+    // NickList tree structure is:
+    // Categories (Operators, Voiced, etc)
+    // Each category has multiple nicks
+    for (int row = 0; row < itemModel->rowCount(parent); row++) {
+        QModelIndex categoryIndex = itemModel->index(row, 0, parent);
+        if (!categoryIndex.isValid())
+            continue;
+        for (int nickRow = 0; nickRow < itemModel->rowCount(categoryIndex); nickRow++) {
+            QModelIndex nickIndex = itemModel->index(nickRow, 0, categoryIndex);
+            if (!nickIndex.isValid())
+                continue;
+            QVariant userVariant = nickIndex.data(NetworkModel::IrcUserRole);
+            if (!userVariant.isValid())
+                continue;
+            auto* ircUser = qobject_cast<IrcUser*>(userVariant.value<QObject*>());
+            // if the nick matches, return the index
+            if (ircUser && ircUser->nick() == nick)
+                return nickIndex;
+        }
+    }
+    return QModelIndex();
+}
+
 QModelIndexList NickView::selectedIndexes() const
 {
     QModelIndexList indexList = TreeViewTouch::selectedIndexes();

--- a/src/uisupport/nickview.h
+++ b/src/uisupport/nickview.h
@@ -48,6 +48,7 @@ public slots:
     void init();
     void showContextMenu(const QPoint& pos);
     void startQuery(const QModelIndex& modelIndex);
+    QModelIndex getIndexFromNick(QString nick);
 
 signals:
     void selectionUpdated();


### PR DESCRIPTION
This continues from [#628](https://github.com/quassel/quassel/pull/628) .

If a nick is right clicked in a channel buffer and it is valid, show the same nick options that you would get on right clicking from the nick list view.

This takes O(users) operation in worst case since the nick list tree has to be traversed to find the index for the corresponding nick.

This change only affects channel buffers and not query buffers.