### PR TITLE
chatview: add hidpi support to sender column

### DIFF
--- a/src/qtui/chatitem.cpp
+++ b/src/qtui/chatitem.cpp
@@ -544,7 +544,10 @@ void SenderChatItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* op
     if (layoutWidth > width()) {
         // Draw a nice gradient for longer items
         // Qt's text drawing with a gradient brush sucks, so we use compositing instead
-        QPixmap pixmap(layout()->boundingRect().toRect().size());
+        qreal dpr = widget->devicePixelRatioF();
+        auto rect = layout()->boundingRect().toRect().size();
+        QPixmap pixmap(rect.width() * dpr, rect.height() * dpr);
+        pixmap.setDevicePixelRatio(dpr);
         pixmap.fill(Qt::transparent);
 
         QPainter pixPainter(&pixmap);


### PR DESCRIPTION
Now we just use the dpr of the widget for our own pixmap.

<img width="1920" height="1280" alt="image" src="https://github.com/user-attachments/assets/93ba3f1f-8cf2-40cf-b48b-9acbe23eaf65" />
